### PR TITLE
Data cleanup after tests execution

### DIFF
--- a/test/non-functional/auth/anonymous.it-spec.ts
+++ b/test/non-functional/auth/anonymous.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import { mutationNoAuth } from '../../utils/graphql.request';
@@ -5,7 +11,14 @@ import { mutationNoAuth } from '../../utils/graphql.request';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
 let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -37,161 +50,183 @@ beforeAll(async done => {
     projectId: DataModel.projectId,
   });
 
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
-describe.skip('', () => {
-describe('GlobalRegistered - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
-  });
+afterAll(async done => {
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+
+  done();
 });
+describe.skip('Anonymous - authorization test suite', () => {
+  describe('Anonymous - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
 
-describe('GlobalRegistered - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
-
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
+  describe('Anonymous - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
+  describe('Anonymous - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
+  describe('Anonymous - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutationNoAuth(
-      getMutation(operation),
-      getVariables(operation)
-    );
+  describe('Anonymous - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
+
+  describe('Anonymous - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutationNoAuth(
+        getMutation(operation),
+        getVariables(operation)
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
+  });
 });

--- a/test/non-functional/auth/challenge-admin.it-spec.ts
+++ b/test/non-functional/auth/challenge-admin.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,8 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
-let ecoverseId: string;
+let projectId: string;
+let opportunityId: string;
 let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -48,177 +60,195 @@ beforeAll(async done => {
     projectId: DataModel.projectId,
   });
 
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   let tests = await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'ChallengeAdmin',
     challengeId
   );
-  console.log(tests.body);
+
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
 
-describe.skip('', () => {
-describe('ChallengeAdmin - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+describe.skip('ChallengeAdmin - authorization test suite', () => {
+  describe('ChallengeAdmin - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeAdmin - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeAdmin - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeAdmin - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeAdmin - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeAdmin - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeAdmin - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeAdmin - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeAdmin - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeAdmin - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeAdmin - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/challenge-member.it-spec.ts
+++ b/test/non-functional/auth/challenge-member.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,7 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
 let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -47,177 +60,194 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
 
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   let tests = await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'ChallengeMember',
     challengeId
   );
-  console.log(tests.body);
-});
-describe.skip('', () => {
-describe('ChallengeMember - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe.skip('ChallengeMember - authorization test suite', () => {
+  describe('ChallengeMember - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeMember - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeMember - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeMember - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeMember - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeMember - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeMember - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeMember - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeMember - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('ChallengeMember - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('ChallengeMember - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/ecoverse-admin.it-spec.ts
+++ b/test/non-functional/auth/ecoverse-admin.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,7 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
 let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -47,18 +60,36 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   let tests = await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'EcoverseAdmin',
     ecoverseId
   );
   console.log(tests.body);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
-describe.skip('', () => {
+describe('EcoverseAdmin - authorization test suite', () => {
 describe('EcoverseAdmin - Create Mutation', () => {
   test.each`
     operation                      | expected

--- a/test/non-functional/auth/ecoverse-host.it-spec.ts
+++ b/test/non-functional/auth/ecoverse-host.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,8 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
-let organisationId: string;
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
 let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -48,176 +60,194 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   let tests = await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'EcoverseHost',
     organisationId
   );
-  console.log(tests.body);
-});
-describe.skip('', () => {
-describe('EcoverseHost - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe.skip('EcoverseHost - authorization test suite', () => {
+  describe('EcoverseHost - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseHost - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseHost - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseHost - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseHost - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseHost - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseHost - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseHost - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseHost - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseHost - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseHost - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/ecoverse-member.it-spec.ts
+++ b/test/non-functional/auth/ecoverse-member.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,7 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
 let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -47,176 +60,193 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
 
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'EcoverseMember',
     ecoverseId
   );
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
-describe.skip('', () => {
-describe('EcoverseMember - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+describe.skip('EcoverseMember - authorization test suite', () => {
+  describe('EcoverseMember - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseMember - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseMember - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseMember - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseMember - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseMember - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseMember - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseMember - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseMember - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('EcoverseMember - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('EcoverseMember - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/global-admin-community.it-spec.ts
+++ b/test/non-functional/auth/global-admin-community.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,7 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
 let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -45,174 +58,192 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'GlobalAdminCommunity'
   );
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
-describe.skip('', () => {
-describe('GlobalAdminCommunity - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+describe.skip('GlobalAdminCommunity - authorization test suite', () => {
+  describe('GlobalAdminCommunity - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalAdminCommunity - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalAdminCommunity - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalAdminCommunity - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalAdminCommunity - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalAdminCommunity - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalAdminCommunity - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalAdminCommunity - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalAdminCommunity - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalAdminCommunity - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalAdminCommunity - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/global-admin.it-spec.ts
+++ b/test/non-functional/auth/global-admin.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import { mutation } from '../../utils/graphql.request';
@@ -6,6 +12,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -35,165 +49,187 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
-describe.skip('', () => {
-describe('Global Admin - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
-  });
+afterAll(async done => {
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
 
-describe('Global Admin - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
+describe.skip('GlobalAdmin - authorization test suite', () => {
+  describe('Global Admin - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('Global Admin - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
+  describe('Global Admin - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('Global Admin - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
+  describe('Global Admin - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('Global Admin - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
+  describe('Global Admin - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('Global Admin - Delete Mutation', () => {
-  test.each`
-    operation                  | expected
-    ${'deleteActor'}           | ${notAuthorizedCode}
-    ${'deleteActorGroup'}      | ${notAuthorizedCode}
-    ${'deleteUserGroup'}       | ${notAuthorizedCode}
-    ${'deleteUserApplication'} | ${notAuthorizedCode}
-    ${'deleteUser'}            | ${notAuthorizedCode}
-    ${'deleteRelation'}        | ${notAuthorizedCode}
-    ${'deleteReference'}       | ${notAuthorizedCode}
-    ${'deleteProject'}         | ${notAuthorizedCode}
-    ${'deleteAspect'}          | ${notAuthorizedCode}
-    ${'deleteOpportunity'}     | ${notAuthorizedCode}
-    ${'deleteChallenge'}       | ${notAuthorizedCode}
-    ${'deleteEcoverse'}        | ${notAuthorizedCode}
-    ${'deleteOrganisation'}    | ${notAuthorizedCode}
-  `('global admin: $operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.GLOBAL_ADMIN
-    );
+  describe('Global Admin - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
+
+  describe('Global Admin - Delete Mutation', () => {
+    test.each`
+      operation                  | expected
+      ${'deleteActor'}           | ${notAuthorizedCode}
+      ${'deleteActorGroup'}      | ${notAuthorizedCode}
+      ${'deleteUserGroup'}       | ${notAuthorizedCode}
+      ${'deleteUserApplication'} | ${notAuthorizedCode}
+      ${'deleteUser'}            | ${notAuthorizedCode}
+      ${'deleteRelation'}        | ${notAuthorizedCode}
+      ${'deleteReference'}       | ${notAuthorizedCode}
+      ${'deleteProject'}         | ${notAuthorizedCode}
+      ${'deleteAspect'}          | ${notAuthorizedCode}
+      ${'deleteOpportunity'}     | ${notAuthorizedCode}
+      ${'deleteChallenge'}       | ${notAuthorizedCode}
+      ${'deleteEcoverse'}        | ${notAuthorizedCode}
+      ${'deleteOrganisation'}    | ${notAuthorizedCode}
+    `('global admin: $operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.GLOBAL_ADMIN
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
+  });
 });

--- a/test/non-functional/auth/global-registered.it-spec.ts
+++ b/test/non-functional/auth/global-registered.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import { grantCredentialsMutation } from '@test/utils/mutations/authorization-mutation';
@@ -7,6 +13,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -38,170 +52,188 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
 
   done();
 });
 
-afterAll(async () => {});
-describe.skip('', () => {
-describe('GlobalRegistered - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
-
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
-  });
+afterAll(async done => {
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
 });
+describe('GlobalRegistered - authorization test suite', () => {
+  describe('GlobalRegistered - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-describe('GlobalRegistered - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
-
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalRegistered - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalRegistered - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalRegistered - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('GlobalRegistered - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('GlobalRegistered - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
+
+  describe('GlobalRegistered - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
+  });
 });

--- a/test/non-functional/auth/opportunity-member.it-spec.ts
+++ b/test/non-functional/auth/opportunity-member.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,15 +16,19 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
-let ecoverseId: string;
-let challengeId: string;
+let projectId: string;
 let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
 beforeAll(async done => {
   let DataModel = await dataGenerator();
-  opportunityId = DataModel.opportunityId;
 
   await grantCredentialsMutation(
     'non.ecoverse@alkem.io',
@@ -49,175 +59,194 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'OpportunityMember',
     opportunityId
   );
-});
-describe.skip('', () => {
-describe('OpportunityMember - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe.skip('OpportunityMember - authorization test suite', () => {
+  describe('OpportunityMember - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OpportunityMember - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OpportunityMember - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OpportunityMember - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OpportunityMember - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OpportunityMember - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OpportunityMember - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OpportunityMember - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OpportunityMember - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OpportunityMember - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OpportunityMember - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/organisation-admin.it-spec.ts
+++ b/test/non-functional/auth/organisation-admin.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,13 +16,19 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
 let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
 beforeAll(async done => {
   let DataModel = await dataGenerator();
-  organisationId = DataModel.organisationId;
 
   await grantCredentialsMutation(
     'non.ecoverse@alkem.io',
@@ -47,175 +59,194 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'OrganisationAdmin',
     organisationId
   );
-});
-describe.skip('', () => {
-describe('OrganisationAdmin - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe('OrganisationAdmin - authorization test suite', () => {
+  describe('OrganisationAdmin - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationAdmin - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationAdmin - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationAdmin - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationAdmin - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationAdmin - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationAdmin - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationAdmin - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationAdmin - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationAdmin - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationAdmin - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/organisation-member.it-spec.ts
+++ b/test/non-functional/auth/organisation-member.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,7 +16,14 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
 let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 
 let getVariables: (operationName: string) => string;
 
@@ -47,179 +60,197 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
 
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'OrganisationMember',
     organisationId
   );
-});
-describe.skip('', () => {
-describe('OrganisationMember - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe('OrganisationMember - authorization test suite', () => {
+  describe('OrganisationMember - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationMember - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationMember - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationMember - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationMember - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationMember - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationMember - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    // console.log(response.body);
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      // console.log(response.body);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationMember - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationMember - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    // console.log(response.body);
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      // console.log(response.body);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('OrganisationMember - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('OrganisationMember - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    // console.log(response.body);
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      // console.log(response.body);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/non-functional/auth/user-group-member.it-spec.ts
+++ b/test/non-functional/auth/user-group-member.it-spec.ts
@@ -1,3 +1,9 @@
+import { removeChallangeMutation } from '@test/functional-api/integration/challenge/challenge.request.params';
+import { removeEcoverseMutation } from '@test/functional-api/integration/ecoverse/ecoverse.request.params';
+import { removeOpportunityMutation } from '@test/functional-api/integration/opportunity/opportunity.request.params';
+import { deleteOrganisationMutation } from '@test/functional-api/integration/organisation/organisation.request.params';
+import { removeProjectMutation } from '@test/functional-api/integration/project/project.request.params';
+import { removeUserMutation } from '@test/functional-api/user-management/user.request.params';
 import { dataGenerator } from '@test/utils/data-generator';
 import { createVariablesGetter, getMutation } from '@test/utils/getters';
 import {
@@ -10,13 +16,20 @@ import { TestUser } from '../../utils/token.helper';
 const notAuthorizedCode = '"code":"UNAUTHENTICATED"';
 const forbiddenCode = '"code":"FORBIDDEN"';
 const userNotRegistered = 'USER_NOT_REGISTERED';
+let projectId: string;
+let opportunityId: string;
+let challengeId: string;
+let ecoverseId: string;
+let organisationIdDel: string;
+let organisationId: string;
+let userIdTwo: string;
+let userId: string;
 let ecoverseGroupyId: string;
 
 let getVariables: (operationName: string) => string;
 
 beforeAll(async done => {
   let DataModel = await dataGenerator();
-  ecoverseGroupyId = DataModel.ecoverseGroupyId;
 
   await grantCredentialsMutation(
     'non.ecoverse@alkem.io',
@@ -47,176 +60,195 @@ beforeAll(async done => {
     referenceId: DataModel.referenceId,
     projectId: DataModel.projectId,
   });
+  projectId = DataModel.projectId;
+  opportunityId = DataModel.opportunityId;
+  challengeId = DataModel.challengeId;
+  ecoverseId = DataModel.ecoverseId;
+  organisationIdDel = DataModel.organisationIdDel;
+  organisationId = DataModel.organisationId;
+  userIdTwo = DataModel.userIdTwo;
+  userId = DataModel.userId;
+  ecoverseGroupyId = DataModel.ecoverseGroupyId;
 
   done();
 });
 
-afterAll(async () => {
+afterAll(async done => {
   await revokeCredentialsMutation(
     'non.ecoverse@alkem.io',
     'UserGroupMember',
     ecoverseGroupyId
   );
-});
-describe.skip('', () => {
-describe('UserGroupMember - Create Mutation', () => {
-  test.each`
-    operation                      | expected
-    ${'createUser'}                | ${notAuthorizedCode}
-    ${'createOrganisation'}        | ${notAuthorizedCode}
-    ${'createEcoverse'}            | ${notAuthorizedCode}
-    ${'createChallenge'}           | ${notAuthorizedCode}
-    ${'createChildChallenge'}      | ${notAuthorizedCode}
-    ${'createOpportunity'}         | ${notAuthorizedCode}
-    ${'createProject'}             | ${notAuthorizedCode}
-    ${'createAspect'}              | ${notAuthorizedCode}
-    ${'createActorGroup'}          | ${notAuthorizedCode}
-    ${'createActor'}               | ${notAuthorizedCode}
-    ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
-    ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
-    ${'createReferenceOnContext'}  | ${notAuthorizedCode}
-    ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
-    ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
-    ${'createRelation'}            | ${notAuthorizedCode}
-    ${'createApplication'}         | ${notAuthorizedCode}
-    ${'createApplicationSelfUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+  await removeProjectMutation(projectId);
+  await removeOpportunityMutation(opportunityId);
+  await removeChallangeMutation(challengeId);
+  await removeEcoverseMutation(ecoverseId);
+  await deleteOrganisationMutation(organisationIdDel);
+  await deleteOrganisationMutation(organisationId);
+  await removeUserMutation(userIdTwo);
+  await removeUserMutation(userId);
+  done();
+});
+describe.skip('UserGroupMember - authorization test suite', () => {
+  describe('UserGroupMember - Create Mutation', () => {
+    test.each`
+      operation                      | expected
+      ${'createUser'}                | ${notAuthorizedCode}
+      ${'createOrganisation'}        | ${notAuthorizedCode}
+      ${'createEcoverse'}            | ${notAuthorizedCode}
+      ${'createChallenge'}           | ${notAuthorizedCode}
+      ${'createChildChallenge'}      | ${notAuthorizedCode}
+      ${'createOpportunity'}         | ${notAuthorizedCode}
+      ${'createProject'}             | ${notAuthorizedCode}
+      ${'createAspect'}              | ${notAuthorizedCode}
+      ${'createActorGroup'}          | ${notAuthorizedCode}
+      ${'createActor'}               | ${notAuthorizedCode}
+      ${'createGroupOnOrganisation'} | ${notAuthorizedCode}
+      ${'createGroupOnCommunity'}    | ${notAuthorizedCode}
+      ${'createReferenceOnContext'}  | ${notAuthorizedCode}
+      ${'createReferenceOnProfile'}  | ${notAuthorizedCode}
+      ${'createTagsetOnProfile'}     | ${notAuthorizedCode}
+      ${'createRelation'}            | ${notAuthorizedCode}
+      ${'createApplication'}         | ${notAuthorizedCode}
+      ${'createApplicationSelfUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
+
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('UserGroupMember - Update Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'updateActor'}        | ${notAuthorizedCode}
-    ${'updateAspect'}       | ${notAuthorizedCode}
-    ${'updateChallenge'}    | ${notAuthorizedCode}
-    ${'updateOpportunity'}  | ${notAuthorizedCode}
-    ${'updateEcoverse'}     | ${notAuthorizedCode}
-    ${'updateOrganisation'} | ${notAuthorizedCode}
-    ${'updateProfile'}      | ${notAuthorizedCode}
-    ${'updateProject'}      | ${notAuthorizedCode}
-    ${'updateUser'}         | ${notAuthorizedCode}
-    ${'updateUserSelf'}     | ${notAuthorizedCode}
-    ${'updateUserGroup'}    | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('UserGroupMember - Update Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'updateActor'}        | ${notAuthorizedCode}
+      ${'updateAspect'}       | ${notAuthorizedCode}
+      ${'updateChallenge'}    | ${notAuthorizedCode}
+      ${'updateOpportunity'}  | ${notAuthorizedCode}
+      ${'updateEcoverse'}     | ${notAuthorizedCode}
+      ${'updateOrganisation'} | ${notAuthorizedCode}
+      ${'updateProfile'}      | ${notAuthorizedCode}
+      ${'updateProject'}      | ${notAuthorizedCode}
+      ${'updateUser'}         | ${notAuthorizedCode}
+      ${'updateUserSelf'}     | ${notAuthorizedCode}
+      ${'updateUserGroup'}    | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('UserGroupMember - Assign / Remove Mutation', () => {
-  test.each`
-    operation                    | expected
-    ${'assignUserToCommunity'}   | ${notAuthorizedCode}
-    ${'removeUserFromCommunity'} | ${notAuthorizedCode}
-    ${'assignUserToGroup'}       | ${notAuthorizedCode}
-    ${'removeUserFromGroup'}     | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('UserGroupMember - Assign / Remove Mutation', () => {
+    test.each`
+      operation                    | expected
+      ${'assignUserToCommunity'}   | ${notAuthorizedCode}
+      ${'removeUserFromCommunity'} | ${notAuthorizedCode}
+      ${'assignUserToGroup'}       | ${notAuthorizedCode}
+      ${'removeUserFromGroup'}     | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('UserGroupMember - Event Mutation', () => {
-  test.each`
-    operation               | expected
-    ${'eventOnChallenge'}   | ${notAuthorizedCode}
-    ${'eventOnOpportunity'} | ${notAuthorizedCode}
-    ${'eventOnProject'}     | ${notAuthorizedCode}
-    ${'eventOnApplication'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('UserGroupMember - Event Mutation', () => {
+    test.each`
+      operation               | expected
+      ${'eventOnChallenge'}   | ${notAuthorizedCode}
+      ${'eventOnOpportunity'} | ${notAuthorizedCode}
+      ${'eventOnProject'}     | ${notAuthorizedCode}
+      ${'eventOnApplication'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('UserGroupMember - Grant/Revoke Mutation', () => {
-  test.each`
-    operation                     | expected
-    ${'grantCredentialToUser'}    | ${notAuthorizedCode}
-    ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('UserGroupMember - Grant/Revoke Mutation', () => {
+    test.each`
+      operation                     | expected
+      ${'grantCredentialToUser'}    | ${notAuthorizedCode}
+      ${'revokeCredentialFromUser'} | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 
-describe('UserGroupMember - Delete Mutation', () => {
-  test.each`
-    operation                             | expected
-    ${'deleteActor'}                      | ${notAuthorizedCode}
-    ${'deleteActorGroup'}                 | ${notAuthorizedCode}
-    ${'deleteUserGroup'}                  | ${notAuthorizedCode}
-    ${'deleteUserApplication'}            | ${notAuthorizedCode}
-    ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
-    ${'deleteUser'}                       | ${notAuthorizedCode}
-    ${'deleteRelation'}                   | ${notAuthorizedCode}
-    ${'deleteReference'}                  | ${notAuthorizedCode}
-    ${'deleteProject'}                    | ${notAuthorizedCode}
-    ${'deleteAspect'}                     | ${notAuthorizedCode}
-    ${'deleteOpportunity'}                | ${notAuthorizedCode}
-    ${'deleteChallenge'}                  | ${notAuthorizedCode}
-    ${'deleteEcoverse'}                   | ${notAuthorizedCode}
-    ${'deleteOrganisation'}               | ${notAuthorizedCode}
-  `('$operation', async ({ operation, expected }) => {
-    const response = await mutation(
-      getMutation(operation),
-      getVariables(operation),
-      TestUser.NON_ECOVERSE_MEMBER
-    );
+  describe('UserGroupMember - Delete Mutation', () => {
+    test.each`
+      operation                             | expected
+      ${'deleteActor'}                      | ${notAuthorizedCode}
+      ${'deleteActorGroup'}                 | ${notAuthorizedCode}
+      ${'deleteUserGroup'}                  | ${notAuthorizedCode}
+      ${'deleteUserApplication'}            | ${notAuthorizedCode}
+      ${'deleteUserApplicationAnotherUser'} | ${notAuthorizedCode}
+      ${'deleteUser'}                       | ${notAuthorizedCode}
+      ${'deleteRelation'}                   | ${notAuthorizedCode}
+      ${'deleteReference'}                  | ${notAuthorizedCode}
+      ${'deleteProject'}                    | ${notAuthorizedCode}
+      ${'deleteAspect'}                     | ${notAuthorizedCode}
+      ${'deleteOpportunity'}                | ${notAuthorizedCode}
+      ${'deleteChallenge'}                  | ${notAuthorizedCode}
+      ${'deleteEcoverse'}                   | ${notAuthorizedCode}
+      ${'deleteOrganisation'}               | ${notAuthorizedCode}
+    `('$operation', async ({ operation, expected }) => {
+      const response = await mutation(
+        getMutation(operation),
+        getVariables(operation),
+        TestUser.NON_ECOVERSE_MEMBER
+      );
 
-    const responseData = JSON.stringify(response.body).replace('\\', '');
-    expect(response.status).toBe(200);
-    expect(responseData).not.toContain(expected);
-    expect(responseData).not.toContain(forbiddenCode);
-    expect(responseData).not.toContain(userNotRegistered);
+      const responseData = JSON.stringify(response.body).replace('\\', '');
+      expect(response.status).toBe(200);
+      expect(responseData).not.toContain(expected);
+      expect(responseData).not.toContain(forbiddenCode);
+      expect(responseData).not.toContain(userNotRegistered);
+    });
   });
-});
 });

--- a/test/utils/data-generator.ts
+++ b/test/utils/data-generator.ts
@@ -47,14 +47,14 @@ export const dataGenerator = async () => {
     'orgToDelName',
     `orgdel${uniqueId}`
   );
-  console.log(responseOrgDel.body);
+
   const organisationIdDel = responseOrgDel.body.data.createOrganisation.id;
 
   const responseOrg = await createOrganisationMutation(
     organisationName,
     hostNameId + 'test'
   );
-  console.log(responseOrg.body);
+
   const organisationId = responseOrg.body.data.createOrganisation.id;
 
   const responseEco = await createEcoverseMutation(


### PR DESCRIPTION
### Describe the background of your pull request

Data cleanup after tests execution.

Issue is dependent on the following requirements:
- Additional mechanism for db restore must be applied in order, to fully clean the leftovers from the tests in authorization suite.
- Authorization tests must be executed as part of separate build

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [x] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
