### PR TITLE
Nightly config with single report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,7 @@ before_install:
 install:
   - npm install
 script:
-  - npm run test:organization
-  - npm run test:preferences
-  - npm run test:roleset
-  - npm run test:contributormanagement
-  - npm run test:callouts
-  - npm run test:communication
-  - npm run test:activity-logs
-  - npm run test:storage
-  - npm run test:journey
+  - npm run test:nightly
 
 notifications:
   email:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:auth-entities": "jest ---forceExit ---runInBand --config ./test/config/jest.config.auth-entities.js",
     "test:auth-global-roles": "jest ---forceExit --maxWorkers=4 --config ./test/config/jest.config.auth-global-roles.js",
     "test:ut": "jest --detectOpenHandles --runInBand --config ./test/config/jest.config.js",
-    "test:nightly": "jest  --maxWorkers=6 --config ./test/config/jest.config.nightly.js",
+    "test:nightly": "jest  --maxWorkers=1 --config ./test/config/jest.config.nightly.js",
     "test:ci": "jest --forceExit --runInBand --config ./test/config/jest.config.ci.js",
     "test:communications": "jest --forceExit --runInBand --config ./test/config/jest.config.communications.js",
     "test:notifications": "jest --forceExit --runInBand --config ./test/config/jest.config.notifications.js",

--- a/test/config/jest.config.nightly.js
+++ b/test/config/jest.config.nightly.js
@@ -1,9 +1,15 @@
 module.exports = {
   ...require('./jest.config'),
-  testMatch: [
-    '**/?(*.)+(spec).ts',
-    '**/?(*.)+(it-spec).ts',
-    '**/?(*.)+(e2e-spec).ts',
+  testRegex: [
+    '/test/functional-api/contributor-management/organization/.*\\.it-spec\\.ts',
+    '/test/functional-api/preferences/.*\\.it-spec\\.ts',
+    '/test/functional-api/roleset/.*\\.it-spec\\.ts',
+    '/test/functional-api/contributor-management/.*\\.it-spec\\.ts',
+    '/test/functional-api/callout/.*\\.it-spec\\.ts',
+    '/test/functional-api/zcommunications/.*\\.it-spec\\.ts',
+    '/test/functional-api/activity-logs/.*\\.it-spec\\.ts',
+    '/test/functional-api/journey/.*\\.it-spec\\.ts',
+    '/test/functional-api/storage/.*\\.it-spec\\.ts',
   ],
   coverageDirectory: '<rootDir>/coverage-nightly',
 };


### PR DESCRIPTION
- test run together, reporting 0 or 1 depending on the full test run
- one report generated

will take the report upload / visualization separately, this is the first step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the testing process by consolidating multiple test commands into a single nightly command.
	- Adjusted the maximum number of workers for the nightly test script to improve execution efficiency.
	- Updated test file matching configuration to enhance specificity in identifying test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->