### PR TITLE
fix the playwright auth tests

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -9,3 +9,4 @@ MAIL_SLURPER_ENDPOINT=http://localhost:4437/mail
 ALKEMIO_SERVER_WS=ws://localhost:3000/graphql
 ALKEMIO_SERVER_REST=http://localhost:3000/api/private/non-interactive/rest
 SKIP_USER_REGISTRATION=false
+UI_HEADLESS=true

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "test:configuration": "jest --forceExit --maxWorkers=1 --verbose --config ./test/config/jest.config.configuration.js",
     "innovation-pack-with-templates": "ts-node-dev ./test/functional-api/innovation-pack/innovation-pack-with-templates.ts",
     "test:orphaned": "jest --forceExit --maxWorkers=1 --verbose --config ./test/config/jest.config.orphaned.js",
-    "register-user": "ts-node-dev ./test/utils/register-user.ts"
+    "register-user": "ts-node-dev ./test/utils/register-user.ts",
+    "test:auth-playwright": "playwright test"
   },
   "dependencies": {
     "@alkemio/client-lib": "^0.32.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    headless: false,
   },
   timeout: 60000,
 
@@ -43,10 +44,10 @@ export default defineConfig({
     //   use: { ...devices['Desktop Chrome'] },
     // },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
     // {
     //   name: 'webkit',
@@ -68,10 +69,10 @@ export default defineConfig({
     //   name: 'Microsoft Edge',
     //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
     // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    headless: false,
+    headless: process.env.UI_HEADLESS === 'true',
   },
   timeout: 60000,
 

--- a/test/functional-e2e/authentication/authentication-flows.spec.ts
+++ b/test/functional-e2e/authentication/authentication-flows.spec.ts
@@ -4,13 +4,13 @@ import { delay } from '@test/utils';
 import { deleteMailSlurperMails } from '@test/utils/mailslurper.rest.requests';
 import { getEmails, getRecoveryCode } from '@test/utils/ui.test.helper';
 import {
-  navigateToLoginPageFromHeaderLink,
   navigateToLoginPageFromMenu,
   navigateToRegistrationFromSignUp,
   navigateToSignUpFromSignIn,
 } from './login-page-objects';
 import {
   fillUpSignUpPageElements,
+  fillUpSignUpPasswordElements,
   pressSignUpButtonRegistrationPage,
   verifyRegistrationPageElements,
 } from '../identity-flows/registration-page-objects';
@@ -30,7 +30,7 @@ import {
 } from './common-authentication-page-elements';
 
 const password = process.env.AUTH_TEST_HARNESS_PASSWORD || '';
-const baseUrl = process.env.ALKEMIO_BASE_URL_ || '';
+const baseUrl = process.env.ALKEMIO_BASE_URL || '';
 
 const userEmail = `test+${uniqueId}@alkem.io`;
 const newPassword = 'Test1234!!**';
@@ -61,7 +61,7 @@ test('verify verification page', async ({ page }) => {
 });
 
 test('user successful authentication', async ({ page }) => {
-  await navigateToLoginPageFromHeaderLink(baseUrl, page);
+  await navigateToLoginPageFromMenu(baseUrl, page);
   await fillUpSignInPageElements('admin@alkem.io', password, page);
   await pressSignInButtonSignInPage(page);
   await verifyMyDashboardWelcomeElement(page, 'admin');
@@ -69,7 +69,9 @@ test('user successful authentication', async ({ page }) => {
 
 test('user successful registration email', async ({ page }) => {
   await navigateToRegistrationFromSignUp(baseUrl, page);
-  await fillUpSignUpPageElements(userEmail, password, 'Test', 'Alkemio', page);
+  await fillUpSignUpPageElements(userEmail, 'Test', 'Alkemio', page);
+  await pressSignUpButtonRegistrationPage(page);
+  await fillUpSignUpPasswordElements(password, page);
   await pressSignUpButtonRegistrationPage(page);
 
   await expect(
@@ -97,7 +99,7 @@ test('user successful registration email', async ({ page }) => {
 
   await pressSignInButtonSignInPage(page);
   await expect(
-    page.getByRole('heading', { name: 'Welcome back Test!' })
+    page.getByRole('heading', { name: 'Welcome back, Test!' })
   ).toBeVisible();
 
   // const getUserId = await getUserData(userEmail);
@@ -107,7 +109,7 @@ test('user successful registration email', async ({ page }) => {
 });
 
 test('user successful password recovery', async ({ page }) => {
-  await navigateToLoginPageFromHeaderLink(baseUrl, page);
+  await navigateToLoginPageFromMenu(baseUrl, page);
 
   await page.getByRole('link', { name: 'Reset password' }).click();
   await emailField(page).click();

--- a/test/functional-e2e/authentication/authentication-flows.spec.ts
+++ b/test/functional-e2e/authentication/authentication-flows.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { uniqueId } from '@test/functional-api/contributor-management/user/user.request.params';
+import {
+  deleteUser,
+  getUserData,
+  uniqueId,
+} from '@test/functional-api/contributor-management/user/user.request.params';
 import { delay } from '@test/utils';
 import { deleteMailSlurperMails } from '@test/utils/mailslurper.rest.requests';
 import { getEmails, getRecoveryCode } from '@test/utils/ui.test.helper';
@@ -78,6 +82,7 @@ test('user successful registration email', async ({ page }) => {
     page.getByRole('link', { name: '…or continue to the platform' })
   ).toBeVisible();
 
+  await delay(1000);
   const getEmailsData = await getEmails();
   const urlFromEmail = getEmailsData[0];
   if (urlFromEmail === undefined) {
@@ -102,10 +107,10 @@ test('user successful registration email', async ({ page }) => {
     page.getByRole('heading', { name: 'Welcome back, Test!' })
   ).toBeVisible();
 
-  // const getUserId = await getUserData(userEmail);
-  // const registeredUserId = getUserId.data?.user.id ?? '';
+  const getUserId = await getUserData(userEmail);
+  const registeredUserId = getUserId.data?.user.id ?? '';
 
-  // await deleteUser(registeredUserId);
+  await deleteUser(registeredUserId);
 });
 
 test('user successful password recovery', async ({ page }) => {
@@ -115,7 +120,7 @@ test('user successful password recovery', async ({ page }) => {
   await emailField(page).click();
   await emailField(page).fill('non.space@alkem.io');
   await submitButton(page).click();
-  await delay(2000);
+  await delay(1300);
   const getEmailsData = await getRecoveryCode();
   const recoveryCodeFromEmail = getEmailsData[0];
   if (recoveryCodeFromEmail === undefined) {
@@ -131,7 +136,11 @@ test('user successful password recovery', async ({ page }) => {
     page.getByRole('heading', { name: 'User Settings' })
   ).toBeVisible();
   await saveButton(page).click();
+  await expect(page.getByText('BioKeywordsNo tags available.')).toBeVisible();
   await expect(
-    page.getByLabel('Avatar of non space').getByRole('img')
+    page
+      .locator('div')
+      .filter({ hasText: /^non space$/ })
+      .nth(3)
   ).toBeVisible();
 });

--- a/test/functional-e2e/authentication/login-page-objects.ts
+++ b/test/functional-e2e/authentication/login-page-objects.ts
@@ -11,14 +11,6 @@ export const navigateToLoginPageFromMenu = async (
   await page.getByRole('menuitem', { name: 'Log In | Sign Up' }).click();
 };
 
-export const navigateToLoginPageFromHeaderLink = async (
-  endPoint: string,
-  page: Page
-) => {
-  await page.goto(endPoint);
-  await page.getByRole('link', { name: 'Sign in here', exact: true }).click();
-};
-
 export const navigateToLoginPageFromSpace = async (
   endPoint: string,
   page: Page

--- a/test/functional-e2e/identity-flows/registration-page-objects.ts
+++ b/test/functional-e2e/identity-flows/registration-page-objects.ts
@@ -14,7 +14,6 @@ export const verifyRegistrationPageElements = async (page: Page) => {
     page.getByRole('heading', { name: 'Create an account to start' })
   ).toBeVisible();
   await expect(emailField(page)).toBeVisible();
-  await expect(passwordField(page)).toBeVisible();
   await expect(firstNameField(page)).toBeVisible();
   await expect(lastNameField(page)).toBeVisible();
   await expect(signUpButton(page)).toBeVisible();
@@ -29,19 +28,24 @@ export const verifyRegistrationPageElements = async (page: Page) => {
 
 export const fillUpSignUpPageElements = async (
   email: string,
-  password: string,
   firstName: string,
   lastName: string,
   page: Page
 ) => {
   await emailField(page).click();
   await emailField(page).fill(email);
-  await passwordField(page).click();
-  await passwordField(page).fill(password);
   await firstNameField(page).click();
   await firstNameField(page).fill(firstName);
   await firstNameField(page).press('Tab');
   await lastNameField(page).fill(lastName);
+};
+
+export const fillUpSignUpPasswordElements = async (
+  password: string,
+  page: Page
+) => {
+  await passwordField(page).click();
+  await passwordField(page).fill(password);
 };
 
 export const pressSignUpButtonRegistrationPage = async (page: Page) => {

--- a/test/functional-e2e/identity-flows/signup-page-objects.ts
+++ b/test/functional-e2e/identity-flows/signup-page-objects.ts
@@ -7,7 +7,6 @@ export const verifySignUpPageElements = async (page: Page) => {
   await expect(
     page.getByRole('heading', { name: 'Create an account to start' })
   ).toBeVisible();
-  await expect(page.getByText('To keep the platform safe,')).toBeVisible();
   await expect(page.locator('label')).toBeVisible();
   await expect(
     page.locator('div').filter({ hasText: /^Connect with LinkedIn$/ })

--- a/test/functional-e2e/my-dashboard/my-dashboard-page-objects.ts
+++ b/test/functional-e2e/my-dashboard/my-dashboard-page-objects.ts
@@ -9,7 +9,7 @@ export const verifyMyDashboardWelcomeElement = async (
   await expect(
     page
       .locator('div')
-      .filter({ hasText: `Welcome back ${firstName}` })
+      .filter({ hasText: `Welcome back, ${firstName}` })
       .first()
   ).toBeVisible();
 };


### PR DESCRIPTION
The playwright auth tests were manually fixed. 
Feel free to:
- remove the script from package.json and document how the tests are run;
- remove the changes from the playwright config (I don't use firefox and I wanted to preview the execution - headless: false);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new script for running Playwright tests.
  - Added a new environment variable `UI_HEADLESS` for dynamic headless mode control.

- **Bug Fixes**
  - Improved visibility checks and corrected text assertions in authentication and dashboard tests.

- **Refactor**
  - Enhanced organization of registration and authentication tests by separating password handling into distinct functions. 

- **Chores**
  - Updated Playwright configuration to enable Chrome testing and control headless mode based on environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->