### PR TITLE
 Tests for #4649 and #4650

### DIFF
--- a/server-api/src/functional-api/callout/call-for-whiteboards/whiteboard-collection-callout.params.request.ts
+++ b/server-api/src/functional-api/callout/call-for-whiteboards/whiteboard-collection-callout.params.request.ts
@@ -51,7 +51,7 @@ export const createWhiteboardOnCallout = async (
           whiteboard: {
             content:
               '{"type":"excalidraw","version":2,"source":"https://excalidraw.com","elements":[],"appState":{"gridSize":null,"viewBackgroundColor":"#ffffff"}}',
-            profileData: {
+            profile: {
               displayName: '111',
             },
           },

--- a/server-api/src/functional-api/callout/whiteboard/whiteboard-callout.params.request.ts
+++ b/server-api/src/functional-api/callout/whiteboard/whiteboard-callout.params.request.ts
@@ -27,7 +27,7 @@ export const createWhiteboardCallout = async (
             whiteboard: {
               content:
                 '{"type":"excalidraw","version":2,"source":"https://excalidraw.com","elements":[],"appState":{"gridSize":null,"viewBackgroundColor":"#ffffff"}}',
-              profileData: {
+              profile: {
                 displayName: 'whiteboard',
               },
             },

--- a/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
@@ -131,7 +131,7 @@ describe('User - documents', () => {
     });
 
     // Arrange
-    test.only.each`
+    test.each`
       userRole                     | privileges
       ${undefined}                 | ${undefined}
       ${TestUser.NON_SPACE_MEMBER} | ${['READ']}

--- a/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
@@ -131,7 +131,7 @@ describe('User - documents', () => {
     });
 
     // Arrange
-    test.each`
+    test.only.each`
       userRole                     | privileges
       ${undefined}                 | ${undefined}
       ${TestUser.NON_SPACE_MEMBER} | ${['READ']}

--- a/server-api/src/functional-api/templates/whiteboard/whiteboard-templates.request.params.ts
+++ b/server-api/src/functional-api/templates/whiteboard/whiteboard-templates.request.params.ts
@@ -49,7 +49,7 @@ export const createWhiteboardTemplate = async (
         },
         tags: ['Tag 1', 'Tag 2'],
         whiteboard: {
-          profileData: {
+          profile: {
             displayName: 'Whiteboard Template',
           },
           content,


### PR DESCRIPTION
- now the mutation to create a whiteboard instead of receiving `profileData` receives `profile` to be consistent with the `framing > profile` and to be able to create a whiteboard callout with visuals
- Removed unused file that was giving problems running codegen
- Run codegen to update the model changes:
     - `profile` doesn't have `avatarURL` anymore, it has `visuals` which is an array of `{url: string, name: VisualType}` to properly push all the visuals on any profile creation. 
     - `inputCreator` service now can return the visuals
     -  Some other updates that I don't know of (see the `alkemio-schema` file): LicenseCredential, file extensions...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `profileData` to `profile` in multiple whiteboard-related functions across different files
	- Adjusted profile data structure in whiteboard creation and template methods

- **Tests**
	- Modified test execution to run a specific test case using `.only.each`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->