### PR TITLE
added scaling of synapse-related deployments during cleanup

### DIFF
--- a/.github/workflows/cron-job-reset-postgres.yml
+++ b/.github/workflows/cron-job-reset-postgres.yml
@@ -2,25 +2,39 @@ name: Scheduled Weekly Synapse Reset
 
 on:
   schedule:
-    - cron: '0 0 * * 0' # Runs every week at midnight UTC
+    - cron: "0 0 * * 0" # Runs every week at midnight UTC
 
 jobs:
   cleanup-synapse-db:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout GitHub Action'
+      - name: "Checkout GitHub Action"
         uses: actions/checkout@v4.1.7
 
       - name: Install Kubectl
         uses: azure/setup-kubectl@v4.0.0
         with:
-          version: 'v1.29.6' # Ensure this matches the version used in your cluster
+          version: "v1.29.6" # Ensure this matches the version used in your cluster
 
       - name: Set up Kubeconfig for Hetzner k3s
         run: |
           mkdir -p $HOME/.kube  # Ensure the .kube directory exists
           echo "${{ secrets.KUBECONFIG_SECRET_HETZNER_TEST }}" > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
+
+      - name: Scale down Synapse deployment
+        run: |
+          echo "Scaling down synapse-deployment to 0 replicas"
+          kubectl scale deployment/synapse-deployment --replicas=0
+          kubectl wait --for=condition=Available=False deployment/synapse-deployment --timeout=120s || true
+          echo "Synapse deployment scaled down"
+
+      - name: Scale down Matrix Adapter deployment
+        run: |
+          echo "Scaling down alkemio-matrix-adapter-deployment to 0 replicas"
+          kubectl scale deployment/alkemio-matrix-adapter-deployment --replicas=0
+          kubectl wait --for=condition=Available=False deployment/alkemio-matrix-adapter-deployment --timeout=120s || true
+          echo "Matrix Adapter deployment scaled down"
 
       - name: Install PostgreSQL client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
@@ -79,6 +93,20 @@ jobs:
           # Kill the port-forward process
           kill $PORT_FORWARD_PID
 
+      - name: Scale up Synapse deployment
+        run: |
+          echo "Scaling up synapse-deployment to 1 replicas"
+          kubectl scale deployment/synapse-deployment --replicas=1
+          kubectl wait --for=condition=Available=False deployment/synapse-deployment --timeout=120s || true
+          echo "Synapse deployment scaled up"
+
+      - name: Scale up Matrix Adapter deployment
+        run: |
+          echo "Scaling up alkemio-matrix-adapter-deployment to 1 replicas"
+          kubectl scale deployment/alkemio-matrix-adapter-deployment --replicas=1
+          kubectl wait --for=condition=Available=False deployment/alkemio-matrix-adapter-deployment --timeout=120s || true
+          echo "Matrix Adapter deployment scaled up"
+
   restart-synapse-server:
     needs: cleanup-synapse-db
     runs-on: ubuntu-latest
@@ -86,7 +114,7 @@ jobs:
       - name: Install Kubectl
         uses: azure/setup-kubectl@v4.0.0
         with:
-          version: 'v1.29.6' # Ensure this matches the version used in your cluster
+          version: "v1.29.6" # Ensure this matches the version used in your cluster
 
       - name: Set up Kubeconfig for Hetzner k3s
         run: |
@@ -109,7 +137,7 @@ jobs:
       - name: Install Kubectl
         uses: azure/setup-kubectl@v4.0.0
         with:
-          version: 'v1.29.6' # Ensure this matches the version used in your cluster
+          version: "v1.29.6" # Ensure this matches the version used in your cluster
 
       - name: Set up Kubeconfig for Hetzner k3s
         run: |


### PR DESCRIPTION
Rationale:
- sometimes when the cleanup script runs, connections to the db could not be dropped --> thus the DB could not be dropped --> recreated --> cleaned up
- this leads to very large db in a few weeks with tens of thousands of messages
- matrix adapter fails to sync
- the server dies
- nightly build die

to make the process flow more resilient, I have added scaling down of synapse / matrix adapter before nuking the db and scaling up after recreation

I have tested the flow locally and fixed the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the automated weekly maintenance process to safely manage service scaling before and after scheduled operations, ensuring minimal disruption and enhanced system reliability.
- **Style**
	- Made minor formatting improvements for greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->