### PR TITLE
Space type removal schema update and conversion tests fixed

### DIFF
--- a/server-api/src/core/generated/alkemio-schema.ts
+++ b/server-api/src/core/generated/alkemio-schema.ts
@@ -140,10 +140,9 @@ export enum ActivityEventType {
   CalloutPublished = 'CALLOUT_PUBLISHED',
   CalloutWhiteboardContentModified = 'CALLOUT_WHITEBOARD_CONTENT_MODIFIED',
   CalloutWhiteboardCreated = 'CALLOUT_WHITEBOARD_CREATED',
-  ChallengeCreated = 'CHALLENGE_CREATED',
   DiscussionComment = 'DISCUSSION_COMMENT',
   MemberJoined = 'MEMBER_JOINED',
-  OpportunityCreated = 'OPPORTUNITY_CREATED',
+  SubspaceCreated = 'SUBSPACE_CREATED',
   UpdateSent = 'UPDATE_SENT',
 }
 
@@ -199,8 +198,6 @@ export type ActivityLogEntry = {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -225,8 +222,6 @@ export type ActivityLogEntryCalendarEventCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -249,8 +244,6 @@ export type ActivityLogEntryCalloutDiscussionComment = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -275,8 +268,6 @@ export type ActivityLogEntryCalloutLinkCreated = ActivityLogEntry & {
   link: Link;
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -299,8 +290,6 @@ export type ActivityLogEntryCalloutPostComment = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Post that was commented on. */
   post: Post;
   /** The Space where the activity happened */
@@ -325,8 +314,6 @@ export type ActivityLogEntryCalloutPostCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Post that was created. */
   post: Post;
   /** The Space where the activity happened */
@@ -351,8 +338,6 @@ export type ActivityLogEntryCalloutPublished = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -376,8 +361,6 @@ export type ActivityLogEntryCalloutWhiteboardContentModified =
     id: Scalars['UUID']['output'];
     /** The display name of the parent */
     parentDisplayName: Scalars['String']['output'];
-    /** The nameID of the parent */
-    parentNameID: Scalars['NameID']['output'];
     /** The Space where the activity happened */
     space?: Maybe<Space>;
     /** The user that triggered this Activity. */
@@ -402,8 +385,6 @@ export type ActivityLogEntryCalloutWhiteboardCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -412,30 +393,6 @@ export type ActivityLogEntryCalloutWhiteboardCreated = ActivityLogEntry & {
   type: ActivityEventType;
   /** The Whiteboard that was created. */
   whiteboard: Whiteboard;
-};
-
-export type ActivityLogEntryChallengeCreated = ActivityLogEntry & {
-  /** Indicates if this Activity happened on a child Collaboration. Child results can be included via the "includeChild" parameter. */
-  child: Scalars['Boolean']['output'];
-  /** The id of the Collaboration entity within which the Activity was generated. */
-  collaborationID: Scalars['UUID']['output'];
-  /** The timestamp for the Activity. */
-  createdDate: Scalars['DateTime']['output'];
-  /** The text details for this Activity. */
-  description: Scalars['String']['output'];
-  id: Scalars['UUID']['output'];
-  /** The display name of the parent */
-  parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
-  /** The Space where the activity happened */
-  space?: Maybe<Space>;
-  /** The Subspace that was created. */
-  subspace: Space;
-  /** The user that triggered this Activity. */
-  triggeredBy: User;
-  /** The event type for this Activity. */
-  type: ActivityEventType;
 };
 
 export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
@@ -456,8 +413,6 @@ export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -466,7 +421,7 @@ export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
   type: ActivityEventType;
 };
 
-export type ActivityLogEntryOpportunityCreated = ActivityLogEntry & {
+export type ActivityLogEntrySubspaceCreated = ActivityLogEntry & {
   /** Indicates if this Activity happened on a child Collaboration. Child results can be included via the "includeChild" parameter. */
   child: Scalars['Boolean']['output'];
   /** The id of the Collaboration entity within which the Activity was generated. */
@@ -478,12 +433,10 @@ export type ActivityLogEntryOpportunityCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
-  /** The Subsubspace that was created. */
-  subsubspace: Space;
+  /** The Subspace that was created. */
+  subspace: Space;
   /** The user that triggered this Activity. */
   triggeredBy: User;
   /** The event type for this Activity. */
@@ -506,8 +459,6 @@ export type ActivityLogEntryUpdateSent = ActivityLogEntry & {
   message: Scalars['String']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -5279,8 +5230,6 @@ export type RelayPaginatedSpace = {
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
   templatesManager?: Maybe<TemplatesManager>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']['output']>;
   /** Visibility of the Space. */
@@ -5579,14 +5528,12 @@ export type RolesResultCommunity = {
   displayName: Scalars['String']['output'];
   /** A unique identifier for this membership result. */
   id: Scalars['String']['output'];
-  /** The level of the Space e.g. space/challenge/opportunity. */
+  /** The level of the Space e.g. L0/L1/L2. */
   level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID']['output'];
   /** The roles held by the contributor */
   roles: Array<Scalars['String']['output']>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
 };
 
 export type RolesResultOrganization = {
@@ -5609,7 +5556,7 @@ export type RolesResultSpace = {
   displayName: Scalars['String']['output'];
   /** A unique identifier for this membership result. */
   id: Scalars['String']['output'];
-  /** The level of the Space e.g. space/challenge/opportunity. */
+  /** The level of the Space e.g. L0/L1/L2. */
   level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID']['output'];
@@ -5619,8 +5566,6 @@ export type RolesResultSpace = {
   spaceID: Scalars['String']['output'];
   /** Details of the Subspace the user is a member of */
   subspaces: Array<RolesResultCommunity>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** Visibility of the Space. */
   visibility: SpaceVisibility;
 };
@@ -5911,8 +5856,6 @@ export type Space = {
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
   templatesManager?: Maybe<TemplatesManager>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']['output']>;
   /** Visibility of the Space. */
@@ -7577,14 +7520,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           whiteboard: _RefType['Whiteboard'];
         })
       | (Omit<
-          ActivityLogEntryChallengeCreated,
-          'space' | 'subspace' | 'triggeredBy'
-        > & {
-          space?: Maybe<_RefType['Space']>;
-          subspace: _RefType['Space'];
-          triggeredBy: _RefType['User'];
-        })
-      | (Omit<
           ActivityLogEntryMemberJoined,
           'community' | 'contributor' | 'space' | 'triggeredBy'
         > & {
@@ -7594,11 +7529,11 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           triggeredBy: _RefType['User'];
         })
       | (Omit<
-          ActivityLogEntryOpportunityCreated,
-          'space' | 'subsubspace' | 'triggeredBy'
+          ActivityLogEntrySubspaceCreated,
+          'space' | 'subspace' | 'triggeredBy'
         > & {
           space?: Maybe<_RefType['Space']>;
-          subsubspace: _RefType['Space'];
+          subspace: _RefType['Space'];
           triggeredBy: _RefType['User'];
         })
       | (Omit<
@@ -7831,16 +7766,6 @@ export type ResolversTypes = {
       whiteboard: ResolversTypes['Whiteboard'];
     }
   >;
-  ActivityLogEntryChallengeCreated: ResolverTypeWrapper<
-    Omit<
-      ActivityLogEntryChallengeCreated,
-      'space' | 'subspace' | 'triggeredBy'
-    > & {
-      space?: Maybe<ResolversTypes['Space']>;
-      subspace: ResolversTypes['Space'];
-      triggeredBy: ResolversTypes['User'];
-    }
-  >;
   ActivityLogEntryMemberJoined: ResolverTypeWrapper<
     Omit<
       ActivityLogEntryMemberJoined,
@@ -7852,13 +7777,13 @@ export type ResolversTypes = {
       triggeredBy: ResolversTypes['User'];
     }
   >;
-  ActivityLogEntryOpportunityCreated: ResolverTypeWrapper<
+  ActivityLogEntrySubspaceCreated: ResolverTypeWrapper<
     Omit<
-      ActivityLogEntryOpportunityCreated,
-      'space' | 'subsubspace' | 'triggeredBy'
+      ActivityLogEntrySubspaceCreated,
+      'space' | 'subspace' | 'triggeredBy'
     > & {
       space?: Maybe<ResolversTypes['Space']>;
-      subsubspace: ResolversTypes['Space'];
+      subspace: ResolversTypes['Space'];
       triggeredBy: ResolversTypes['User'];
     }
   >;
@@ -9097,14 +9022,6 @@ export type ResolversParentTypes = {
     triggeredBy: ResolversParentTypes['User'];
     whiteboard: ResolversParentTypes['Whiteboard'];
   };
-  ActivityLogEntryChallengeCreated: Omit<
-    ActivityLogEntryChallengeCreated,
-    'space' | 'subspace' | 'triggeredBy'
-  > & {
-    space?: Maybe<ResolversParentTypes['Space']>;
-    subspace: ResolversParentTypes['Space'];
-    triggeredBy: ResolversParentTypes['User'];
-  };
   ActivityLogEntryMemberJoined: Omit<
     ActivityLogEntryMemberJoined,
     'community' | 'contributor' | 'space' | 'triggeredBy'
@@ -9114,12 +9031,12 @@ export type ResolversParentTypes = {
     space?: Maybe<ResolversParentTypes['Space']>;
     triggeredBy: ResolversParentTypes['User'];
   };
-  ActivityLogEntryOpportunityCreated: Omit<
-    ActivityLogEntryOpportunityCreated,
-    'space' | 'subsubspace' | 'triggeredBy'
+  ActivityLogEntrySubspaceCreated: Omit<
+    ActivityLogEntrySubspaceCreated,
+    'space' | 'subspace' | 'triggeredBy'
   > & {
     space?: Maybe<ResolversParentTypes['Space']>;
-    subsubspace: ResolversParentTypes['Space'];
+    subspace: ResolversParentTypes['Space'];
     triggeredBy: ResolversParentTypes['User'];
   };
   ActivityLogEntryUpdateSent: Omit<
@@ -10226,9 +10143,8 @@ export type ActivityLogEntryResolvers<
     | 'ActivityLogEntryCalloutPublished'
     | 'ActivityLogEntryCalloutWhiteboardContentModified'
     | 'ActivityLogEntryCalloutWhiteboardCreated'
-    | 'ActivityLogEntryChallengeCreated'
     | 'ActivityLogEntryMemberJoined'
-    | 'ActivityLogEntryOpportunityCreated'
+    | 'ActivityLogEntrySubspaceCreated'
     | 'ActivityLogEntryUpdateSent',
     ParentType,
     ContextType
@@ -10243,7 +10159,6 @@ export type ActivityLogEntryResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10270,7 +10185,6 @@ export type ActivityLogEntryCalendarEventCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10293,7 +10207,6 @@ export type ActivityLogEntryCalloutDiscussionCommentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10317,7 +10230,6 @@ export type ActivityLogEntryCalloutLinkCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10340,7 +10252,6 @@ export type ActivityLogEntryCalloutPostCommentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   post?: Resolver<ResolversTypes['Post'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
@@ -10364,7 +10275,6 @@ export type ActivityLogEntryCalloutPostCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   post?: Resolver<ResolversTypes['Post'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
@@ -10388,7 +10298,6 @@ export type ActivityLogEntryCalloutPublishedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10411,7 +10320,6 @@ export type ActivityLogEntryCalloutWhiteboardContentModifiedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -10435,34 +10343,10 @@ export type ActivityLogEntryCalloutWhiteboardCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   whiteboard?: Resolver<ResolversTypes['Whiteboard'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ActivityLogEntryChallengeCreatedResolvers<
-  ContextType = any,
-  ParentType extends
-    ResolversParentTypes['ActivityLogEntryChallengeCreated'] = ResolversParentTypes['ActivityLogEntryChallengeCreated'],
-> = {
-  child?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  collaborationID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  createdDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
-  description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  parentDisplayName?: Resolver<
-    ResolversTypes['String'],
-    ParentType,
-    ContextType
-  >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
-  space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
-  subspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
-  triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -10492,17 +10376,16 @@ export type ActivityLogEntryMemberJoinedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ActivityLogEntryOpportunityCreatedResolvers<
+export type ActivityLogEntrySubspaceCreatedResolvers<
   ContextType = any,
   ParentType extends
-    ResolversParentTypes['ActivityLogEntryOpportunityCreated'] = ResolversParentTypes['ActivityLogEntryOpportunityCreated'],
+    ResolversParentTypes['ActivityLogEntrySubspaceCreated'] = ResolversParentTypes['ActivityLogEntrySubspaceCreated'],
 > = {
   child?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   collaborationID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
@@ -10514,9 +10397,8 @@ export type ActivityLogEntryOpportunityCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
-  subsubspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
+  subspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -10539,7 +10421,6 @@ export type ActivityLogEntryUpdateSentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<Maybe<ResolversTypes['Space']>, ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
@@ -15716,7 +15597,6 @@ export type RelayPaginatedSpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -15994,7 +15874,6 @@ export type RolesResultCommunityResolvers<
   level?: Resolver<ResolversTypes['SpaceLevel'], ParentType, ContextType>;
   nameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   roles?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -16032,7 +15911,6 @@ export type RolesResultSpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   visibility?: Resolver<
     ResolversTypes['SpaceVisibility'],
     ParentType,
@@ -16311,7 +16189,6 @@ export type SpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -17687,9 +17564,8 @@ export type Resolvers<ContextType = any> = {
   ActivityLogEntryCalloutPublished?: ActivityLogEntryCalloutPublishedResolvers<ContextType>;
   ActivityLogEntryCalloutWhiteboardContentModified?: ActivityLogEntryCalloutWhiteboardContentModifiedResolvers<ContextType>;
   ActivityLogEntryCalloutWhiteboardCreated?: ActivityLogEntryCalloutWhiteboardCreatedResolvers<ContextType>;
-  ActivityLogEntryChallengeCreated?: ActivityLogEntryChallengeCreatedResolvers<ContextType>;
   ActivityLogEntryMemberJoined?: ActivityLogEntryMemberJoinedResolvers<ContextType>;
-  ActivityLogEntryOpportunityCreated?: ActivityLogEntryOpportunityCreatedResolvers<ContextType>;
+  ActivityLogEntrySubspaceCreated?: ActivityLogEntrySubspaceCreatedResolvers<ContextType>;
   ActivityLogEntryUpdateSent?: ActivityLogEntryUpdateSentResolvers<ContextType>;
   Agent?: AgentResolvers<ContextType>;
   AgentBeginVerifiedCredentialOfferOutput?: AgentBeginVerifiedCredentialOfferOutputResolvers<ContextType>;
@@ -34106,7 +33982,6 @@ export type SpaceDataFragment = {
   id: string;
   nameID: string;
   visibility: SpaceVisibility;
-  type: SpaceType;
   account: {
     id: string;
     spaces: Array<{ id: string }>;
@@ -47634,7 +47509,6 @@ export type ConvertSpaceL1ToSpaceL0Mutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
-    type: SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -53449,7 +53323,6 @@ export type ConvertSpaceL2ToSpaceL1Mutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
-    type: SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -59282,7 +59155,6 @@ export type UpdateSpaceMutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
-    type: SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -78557,12 +78429,6 @@ export type GetActivityLogOnCollaborationQuery = {
         type: ActivityEventType;
         triggeredBy: { id: string };
       }
-    | {
-        collaborationID: string;
-        description: string;
-        type: ActivityEventType;
-        triggeredBy: { id: string };
-      }
   >;
 };
 
@@ -91470,7 +91336,6 @@ export type SearchQuery = {
                   about: {
                     __typename: 'SpaceAbout';
                     id: string;
-                    isContentPublic: boolean;
                     profile: {
                       __typename: 'Profile';
                       id: string;
@@ -91502,18 +91367,12 @@ export type SearchQuery = {
                           }
                         | undefined;
                     };
-                    membership: {
-                      __typename: 'SpaceAboutMembership';
-                      myMembershipStatus?:
-                        | CommunityMembershipStatus
-                        | undefined;
-                      myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                      communityID: string;
-                      roleSetID: string;
-                    };
-                    guidelines: {
-                      __typename: 'CommunityGuidelines';
-                      id: string;
+                  };
+                  settings: {
+                    __typename: 'SpaceSettings';
+                    privacy: {
+                      __typename: 'SpaceSettingsPrivacy';
+                      mode: SpacePrivacyMode;
                     };
                   };
                 }
@@ -91527,7 +91386,6 @@ export type SearchQuery = {
                 __typename: 'SpaceAbout';
                 id: string;
                 why?: any | undefined;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -91551,9 +91409,21 @@ export type SearchQuery = {
                     name: string;
                   }>;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
+              };
+              community: {
+                __typename: 'Community';
+                id: string;
+                roleSet: {
+                  __typename: 'RoleSet';
+                  id: string;
                   myMembershipStatus?: CommunityMembershipStatus | undefined;
+                };
+              };
+              settings: {
+                __typename: 'SpaceSettings';
+                privacy: {
+                  __typename: 'SpaceSettingsPrivacy';
+                  mode: SpacePrivacyMode;
                 };
               };
             };
@@ -91629,7 +91499,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -91657,14 +91526,6 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?: CommunityMembershipStatus | undefined;
-                  myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                  communityID: string;
-                  roleSetID: string;
-                };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
           }
@@ -91760,7 +91621,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -91788,14 +91648,6 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?: CommunityMembershipStatus | undefined;
-                  myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                  communityID: string;
-                  roleSetID: string;
-                };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
           }
@@ -91866,7 +91718,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -91894,14 +91745,13 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?: CommunityMembershipStatus | undefined;
-                  myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-                  communityID: string;
-                  roleSetID: string;
+              };
+              settings: {
+                __typename: 'SpaceSettings';
+                privacy: {
+                  __typename: 'SpaceSettingsPrivacy';
+                  mode: SpacePrivacyMode;
                 };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
             callout: {
@@ -91961,7 +91811,6 @@ export type SearchQuery = {
                 displayName: string;
                 id: string;
                 description?: any | undefined;
-                url: string;
                 location?:
                   | {
                       __typename: 'Location';
@@ -91979,14 +91828,6 @@ export type SearchQuery = {
                       allowedValues: Array<string>;
                       type: TagsetType;
                     }>
-                  | undefined;
-                visual?:
-                  | {
-                      __typename: 'Visual';
-                      id: string;
-                      uri: string;
-                      name: string;
-                    }
                   | undefined;
               };
             };
@@ -92020,7 +91861,6 @@ export type SearchQuery = {
                 displayName: string;
                 id: string;
                 description?: any | undefined;
-                url: string;
                 location?:
                   | {
                       __typename: 'Location';
@@ -92038,14 +91878,6 @@ export type SearchQuery = {
                       allowedValues: Array<string>;
                       type: TagsetType;
                     }>
-                  | undefined;
-                visual?:
-                  | {
-                      __typename: 'Visual';
-                      id: string;
-                      uri: string;
-                      name: string;
-                    }
                   | undefined;
               };
             };
@@ -92065,7 +91897,6 @@ export type SearchResultSpaceFragment = {
         about: {
           __typename: 'SpaceAbout';
           id: string;
-          isContentPublic: boolean;
           profile: {
             __typename: 'Profile';
             id: string;
@@ -92083,14 +91914,13 @@ export type SearchResultSpaceFragment = {
               | { __typename: 'Visual'; id: string; uri: string; name: string }
               | undefined;
           };
-          membership: {
-            __typename: 'SpaceAboutMembership';
-            myMembershipStatus?: CommunityMembershipStatus | undefined;
-            myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-            communityID: string;
-            roleSetID: string;
+        };
+        settings: {
+          __typename: 'SpaceSettings';
+          privacy: {
+            __typename: 'SpaceSettingsPrivacy';
+            mode: SpacePrivacyMode;
           };
-          guidelines: { __typename: 'CommunityGuidelines'; id: string };
         };
       }
     | undefined;
@@ -92103,7 +91933,6 @@ export type SearchResultSpaceFragment = {
       __typename: 'SpaceAbout';
       id: string;
       why?: any | undefined;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -92127,10 +91956,19 @@ export type SearchResultSpaceFragment = {
           name: string;
         }>;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
+    };
+    community: {
+      __typename: 'Community';
+      id: string;
+      roleSet: {
+        __typename: 'RoleSet';
+        id: string;
         myMembershipStatus?: CommunityMembershipStatus | undefined;
       };
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: { __typename: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
     };
   };
 };
@@ -92138,7 +91976,6 @@ export type SearchResultSpaceFragment = {
 export type SpaceAboutLightFragment = {
   __typename: 'SpaceAbout';
   id: string;
-  isContentPublic: boolean;
   profile: {
     __typename: 'Profile';
     id: string;
@@ -92156,14 +91993,6 @@ export type SpaceAboutLightFragment = {
       | { __typename: 'Visual'; id: string; uri: string; name: string }
       | undefined;
   };
-  membership: {
-    __typename: 'SpaceAboutMembership';
-    myMembershipStatus?: CommunityMembershipStatus | undefined;
-    myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-    communityID: string;
-    roleSetID: string;
-  };
-  guidelines: { __typename: 'CommunityGuidelines'; id: string };
 };
 
 export type VisualUriFragment = {
@@ -92225,7 +92054,6 @@ export type SearchResultCalloutFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -92243,14 +92071,6 @@ export type SearchResultCalloutFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
 };
@@ -92264,7 +92084,6 @@ export type CalloutParentFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -92282,14 +92101,6 @@ export type CalloutParentFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
 };
@@ -92337,7 +92148,6 @@ export type SearchResultPostFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -92355,14 +92165,10 @@ export type SearchResultPostFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: { __typename: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
     };
   };
   callout: {
@@ -92407,7 +92213,6 @@ export type PostParentFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -92425,14 +92230,10 @@ export type PostParentFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: { __typename: 'SpaceSettingsPrivacy'; mode: SpacePrivacyMode };
     };
   };
   callout: {
@@ -92462,7 +92263,6 @@ export type SearchResultUserFragment = {
       displayName: string;
       id: string;
       description?: any | undefined;
-      url: string;
       location?:
         | {
             __typename: 'Location';
@@ -92481,18 +92281,13 @@ export type SearchResultUserFragment = {
             type: TagsetType;
           }>
         | undefined;
-      visual?:
-        | { __typename: 'Visual'; id: string; uri: string; name: string }
-        | undefined;
     };
   };
 };
 
 export type SearchResultProfileFragment = {
-  __typename: 'Profile';
   id: string;
   description?: any | undefined;
-  url: string;
   location?:
     | {
         __typename: 'Location';
@@ -92511,9 +92306,6 @@ export type SearchResultProfileFragment = {
         type: TagsetType;
       }>
     | undefined;
-  visual?:
-    | { __typename: 'Visual'; id: string; uri: string; name: string }
-    | undefined;
 };
 
 export type SearchResultOrganizationFragment = {
@@ -92526,7 +92318,6 @@ export type SearchResultOrganizationFragment = {
       displayName: string;
       id: string;
       description?: any | undefined;
-      url: string;
       location?:
         | {
             __typename: 'Location';
@@ -92544,9 +92335,6 @@ export type SearchResultOrganizationFragment = {
             allowedValues: Array<string>;
             type: TagsetType;
           }>
-        | undefined;
-      visual?:
-        | { __typename: 'Visual'; id: string; uri: string; name: string }
         | undefined;
     };
   };
@@ -92580,7 +92368,6 @@ export type GetSpaceDataQuery = {
           id: string;
           nameID: string;
           visibility: SpaceVisibility;
-          type: SpaceType;
           account: {
             id: string;
             spaces: Array<{ id: string }>;

--- a/server-api/src/core/generated/alkemio-schema.ts
+++ b/server-api/src/core/generated/alkemio-schema.ts
@@ -33982,6 +33982,7 @@ export type SpaceDataFragment = {
   id: string;
   nameID: string;
   visibility: SpaceVisibility;
+  level: SpaceLevel;
   account: {
     id: string;
     spaces: Array<{ id: string }>;
@@ -47509,6 +47510,7 @@ export type ConvertSpaceL1ToSpaceL0Mutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
+    level: SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -53323,6 +53325,7 @@ export type ConvertSpaceL2ToSpaceL1Mutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
+    level: SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -59155,6 +59158,7 @@ export type UpdateSpaceMutation = {
     id: string;
     nameID: string;
     visibility: SpaceVisibility;
+    level: SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -92368,6 +92372,7 @@ export type GetSpaceDataQuery = {
           id: string;
           nameID: string;
           visibility: SpaceVisibility;
+          level: SpaceLevel;
           account: {
             id: string;
             spaces: Array<{ id: string }>;

--- a/server-api/src/core/generated/graphql.ts
+++ b/server-api/src/core/generated/graphql.ts
@@ -146,10 +146,9 @@ export enum ActivityEventType {
   CalloutPublished = 'CALLOUT_PUBLISHED',
   CalloutWhiteboardContentModified = 'CALLOUT_WHITEBOARD_CONTENT_MODIFIED',
   CalloutWhiteboardCreated = 'CALLOUT_WHITEBOARD_CREATED',
-  ChallengeCreated = 'CHALLENGE_CREATED',
   DiscussionComment = 'DISCUSSION_COMMENT',
   MemberJoined = 'MEMBER_JOINED',
-  OpportunityCreated = 'OPPORTUNITY_CREATED',
+  SubspaceCreated = 'SUBSPACE_CREATED',
   UpdateSent = 'UPDATE_SENT',
 }
 
@@ -205,8 +204,6 @@ export type ActivityLogEntry = {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -231,8 +228,6 @@ export type ActivityLogEntryCalendarEventCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -255,8 +250,6 @@ export type ActivityLogEntryCalloutDiscussionComment = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -281,8 +274,6 @@ export type ActivityLogEntryCalloutLinkCreated = ActivityLogEntry & {
   link: Link;
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -305,8 +296,6 @@ export type ActivityLogEntryCalloutPostComment = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Post that was commented on. */
   post: Post;
   /** The Space where the activity happened */
@@ -331,8 +320,6 @@ export type ActivityLogEntryCalloutPostCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Post that was created. */
   post: Post;
   /** The Space where the activity happened */
@@ -357,8 +344,6 @@ export type ActivityLogEntryCalloutPublished = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -382,8 +367,6 @@ export type ActivityLogEntryCalloutWhiteboardContentModified =
     id: Scalars['UUID']['output'];
     /** The display name of the parent */
     parentDisplayName: Scalars['String']['output'];
-    /** The nameID of the parent */
-    parentNameID: Scalars['NameID']['output'];
     /** The Space where the activity happened */
     space?: Maybe<Space>;
     /** The user that triggered this Activity. */
@@ -408,8 +391,6 @@ export type ActivityLogEntryCalloutWhiteboardCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -418,30 +399,6 @@ export type ActivityLogEntryCalloutWhiteboardCreated = ActivityLogEntry & {
   type: ActivityEventType;
   /** The Whiteboard that was created. */
   whiteboard: Whiteboard;
-};
-
-export type ActivityLogEntryChallengeCreated = ActivityLogEntry & {
-  /** Indicates if this Activity happened on a child Collaboration. Child results can be included via the "includeChild" parameter. */
-  child: Scalars['Boolean']['output'];
-  /** The id of the Collaboration entity within which the Activity was generated. */
-  collaborationID: Scalars['UUID']['output'];
-  /** The timestamp for the Activity. */
-  createdDate: Scalars['DateTime']['output'];
-  /** The text details for this Activity. */
-  description: Scalars['String']['output'];
-  id: Scalars['UUID']['output'];
-  /** The display name of the parent */
-  parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
-  /** The Space where the activity happened */
-  space?: Maybe<Space>;
-  /** The Subspace that was created. */
-  subspace: Space;
-  /** The user that triggered this Activity. */
-  triggeredBy: User;
-  /** The event type for this Activity. */
-  type: ActivityEventType;
 };
 
 export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
@@ -462,8 +419,6 @@ export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -472,7 +427,7 @@ export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
   type: ActivityEventType;
 };
 
-export type ActivityLogEntryOpportunityCreated = ActivityLogEntry & {
+export type ActivityLogEntrySubspaceCreated = ActivityLogEntry & {
   /** Indicates if this Activity happened on a child Collaboration. Child results can be included via the "includeChild" parameter. */
   child: Scalars['Boolean']['output'];
   /** The id of the Collaboration entity within which the Activity was generated. */
@@ -484,12 +439,10 @@ export type ActivityLogEntryOpportunityCreated = ActivityLogEntry & {
   id: Scalars['UUID']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
-  /** The Subsubspace that was created. */
-  subsubspace: Space;
+  /** The Subspace that was created. */
+  subspace: Space;
   /** The user that triggered this Activity. */
   triggeredBy: User;
   /** The event type for this Activity. */
@@ -512,8 +465,6 @@ export type ActivityLogEntryUpdateSent = ActivityLogEntry & {
   message: Scalars['String']['output'];
   /** The display name of the parent */
   parentDisplayName: Scalars['String']['output'];
-  /** The nameID of the parent */
-  parentNameID: Scalars['NameID']['output'];
   /** The Space where the activity happened */
   space?: Maybe<Space>;
   /** The user that triggered this Activity. */
@@ -5285,8 +5236,6 @@ export type RelayPaginatedSpace = {
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
   templatesManager?: Maybe<TemplatesManager>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']['output']>;
   /** Visibility of the Space. */
@@ -5585,14 +5534,12 @@ export type RolesResultCommunity = {
   displayName: Scalars['String']['output'];
   /** A unique identifier for this membership result. */
   id: Scalars['String']['output'];
-  /** The level of the Space e.g. space/challenge/opportunity. */
+  /** The level of the Space e.g. L0/L1/L2. */
   level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID']['output'];
   /** The roles held by the contributor */
   roles: Array<Scalars['String']['output']>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
 };
 
 export type RolesResultOrganization = {
@@ -5615,7 +5562,7 @@ export type RolesResultSpace = {
   displayName: Scalars['String']['output'];
   /** A unique identifier for this membership result. */
   id: Scalars['String']['output'];
-  /** The level of the Space e.g. space/challenge/opportunity. */
+  /** The level of the Space e.g. L0/L1/L2. */
   level: SpaceLevel;
   /** Name Identifier of the entity */
   nameID: Scalars['NameID']['output'];
@@ -5625,8 +5572,6 @@ export type RolesResultSpace = {
   spaceID: Scalars['String']['output'];
   /** Details of the Subspace the user is a member of */
   subspaces: Array<RolesResultCommunity>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** Visibility of the Space. */
   visibility: SpaceVisibility;
 };
@@ -5917,8 +5862,6 @@ export type Space = {
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
   templatesManager?: Maybe<TemplatesManager>;
-  /** The Type of the Space e.g. space/challenge/opportunity. */
-  type: SpaceType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']['output']>;
   /** Visibility of the Space. */
@@ -7583,14 +7526,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           whiteboard: _RefType['Whiteboard'];
         })
       | (Omit<
-          SchemaTypes.ActivityLogEntryChallengeCreated,
-          'space' | 'subspace' | 'triggeredBy'
-        > & {
-          space?: SchemaTypes.Maybe<_RefType['Space']>;
-          subspace: _RefType['Space'];
-          triggeredBy: _RefType['User'];
-        })
-      | (Omit<
           SchemaTypes.ActivityLogEntryMemberJoined,
           'community' | 'contributor' | 'space' | 'triggeredBy'
         > & {
@@ -7600,11 +7535,11 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           triggeredBy: _RefType['User'];
         })
       | (Omit<
-          SchemaTypes.ActivityLogEntryOpportunityCreated,
-          'space' | 'subsubspace' | 'triggeredBy'
+          SchemaTypes.ActivityLogEntrySubspaceCreated,
+          'space' | 'subspace' | 'triggeredBy'
         > & {
           space?: SchemaTypes.Maybe<_RefType['Space']>;
-          subsubspace: _RefType['Space'];
+          subspace: _RefType['Space'];
           triggeredBy: _RefType['User'];
         })
       | (Omit<
@@ -7847,16 +7782,6 @@ export type ResolversTypes = {
       whiteboard: ResolversTypes['Whiteboard'];
     }
   >;
-  ActivityLogEntryChallengeCreated: ResolverTypeWrapper<
-    Omit<
-      SchemaTypes.ActivityLogEntryChallengeCreated,
-      'space' | 'subspace' | 'triggeredBy'
-    > & {
-      space?: SchemaTypes.Maybe<ResolversTypes['Space']>;
-      subspace: ResolversTypes['Space'];
-      triggeredBy: ResolversTypes['User'];
-    }
-  >;
   ActivityLogEntryMemberJoined: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryMemberJoined,
@@ -7868,13 +7793,13 @@ export type ResolversTypes = {
       triggeredBy: ResolversTypes['User'];
     }
   >;
-  ActivityLogEntryOpportunityCreated: ResolverTypeWrapper<
+  ActivityLogEntrySubspaceCreated: ResolverTypeWrapper<
     Omit<
-      SchemaTypes.ActivityLogEntryOpportunityCreated,
-      'space' | 'subsubspace' | 'triggeredBy'
+      SchemaTypes.ActivityLogEntrySubspaceCreated,
+      'space' | 'subspace' | 'triggeredBy'
     > & {
       space?: SchemaTypes.Maybe<ResolversTypes['Space']>;
-      subsubspace: ResolversTypes['Space'];
+      subspace: ResolversTypes['Space'];
       triggeredBy: ResolversTypes['User'];
     }
   >;
@@ -9185,14 +9110,6 @@ export type ResolversParentTypes = {
     triggeredBy: ResolversParentTypes['User'];
     whiteboard: ResolversParentTypes['Whiteboard'];
   };
-  ActivityLogEntryChallengeCreated: Omit<
-    SchemaTypes.ActivityLogEntryChallengeCreated,
-    'space' | 'subspace' | 'triggeredBy'
-  > & {
-    space?: SchemaTypes.Maybe<ResolversParentTypes['Space']>;
-    subspace: ResolversParentTypes['Space'];
-    triggeredBy: ResolversParentTypes['User'];
-  };
   ActivityLogEntryMemberJoined: Omit<
     SchemaTypes.ActivityLogEntryMemberJoined,
     'community' | 'contributor' | 'space' | 'triggeredBy'
@@ -9202,12 +9119,12 @@ export type ResolversParentTypes = {
     space?: SchemaTypes.Maybe<ResolversParentTypes['Space']>;
     triggeredBy: ResolversParentTypes['User'];
   };
-  ActivityLogEntryOpportunityCreated: Omit<
-    SchemaTypes.ActivityLogEntryOpportunityCreated,
-    'space' | 'subsubspace' | 'triggeredBy'
+  ActivityLogEntrySubspaceCreated: Omit<
+    SchemaTypes.ActivityLogEntrySubspaceCreated,
+    'space' | 'subspace' | 'triggeredBy'
   > & {
     space?: SchemaTypes.Maybe<ResolversParentTypes['Space']>;
-    subsubspace: ResolversParentTypes['Space'];
+    subspace: ResolversParentTypes['Space'];
     triggeredBy: ResolversParentTypes['User'];
   };
   ActivityLogEntryUpdateSent: Omit<
@@ -10356,9 +10273,8 @@ export type ActivityLogEntryResolvers<
     | 'ActivityLogEntryCalloutPublished'
     | 'ActivityLogEntryCalloutWhiteboardContentModified'
     | 'ActivityLogEntryCalloutWhiteboardCreated'
-    | 'ActivityLogEntryChallengeCreated'
     | 'ActivityLogEntryMemberJoined'
-    | 'ActivityLogEntryOpportunityCreated'
+    | 'ActivityLogEntrySubspaceCreated'
     | 'ActivityLogEntryUpdateSent',
     ParentType,
     ContextType
@@ -10373,7 +10289,6 @@ export type ActivityLogEntryResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10404,7 +10319,6 @@ export type ActivityLogEntryCalendarEventCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10431,7 +10345,6 @@ export type ActivityLogEntryCalloutDiscussionCommentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10459,7 +10372,6 @@ export type ActivityLogEntryCalloutLinkCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10486,7 +10398,6 @@ export type ActivityLogEntryCalloutPostCommentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   post?: Resolver<ResolversTypes['Post'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
@@ -10514,7 +10425,6 @@ export type ActivityLogEntryCalloutPostCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   post?: Resolver<ResolversTypes['Post'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
@@ -10542,7 +10452,6 @@ export type ActivityLogEntryCalloutPublishedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10569,7 +10478,6 @@ export type ActivityLogEntryCalloutWhiteboardContentModifiedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10597,7 +10505,6 @@ export type ActivityLogEntryCalloutWhiteboardCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10606,33 +10513,6 @@ export type ActivityLogEntryCalloutWhiteboardCreatedResolvers<
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   whiteboard?: Resolver<ResolversTypes['Whiteboard'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ActivityLogEntryChallengeCreatedResolvers<
-  ContextType = any,
-  ParentType extends
-    ResolversParentTypes['ActivityLogEntryChallengeCreated'] = ResolversParentTypes['ActivityLogEntryChallengeCreated'],
-> = {
-  child?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  collaborationID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  createdDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
-  description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  parentDisplayName?: Resolver<
-    ResolversTypes['String'],
-    ParentType,
-    ContextType
-  >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
-  space?: Resolver<
-    SchemaTypes.Maybe<ResolversTypes['Space']>,
-    ParentType,
-    ContextType
-  >;
-  subspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
-  triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -10662,7 +10542,6 @@ export type ActivityLogEntryMemberJoinedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -10673,10 +10552,10 @@ export type ActivityLogEntryMemberJoinedResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ActivityLogEntryOpportunityCreatedResolvers<
+export type ActivityLogEntrySubspaceCreatedResolvers<
   ContextType = any,
   ParentType extends
-    ResolversParentTypes['ActivityLogEntryOpportunityCreated'] = ResolversParentTypes['ActivityLogEntryOpportunityCreated'],
+    ResolversParentTypes['ActivityLogEntrySubspaceCreated'] = ResolversParentTypes['ActivityLogEntrySubspaceCreated'],
 > = {
   child?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   collaborationID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
@@ -10688,13 +10567,12 @@ export type ActivityLogEntryOpportunityCreatedResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
     ContextType
   >;
-  subsubspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
+  subspace?: Resolver<ResolversTypes['Space'], ParentType, ContextType>;
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -10717,7 +10595,6 @@ export type ActivityLogEntryUpdateSentResolvers<
     ParentType,
     ContextType
   >;
-  parentNameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   space?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['Space']>,
     ParentType,
@@ -16312,7 +16189,6 @@ export type RelayPaginatedSpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -16590,7 +16466,6 @@ export type RolesResultCommunityResolvers<
   level?: Resolver<ResolversTypes['SpaceLevel'], ParentType, ContextType>;
   nameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
   roles?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -16628,7 +16503,6 @@ export type RolesResultSpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   visibility?: Resolver<
     ResolversTypes['SpaceVisibility'],
     ParentType,
@@ -16917,7 +16791,6 @@ export type SpaceResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['SpaceType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     SchemaTypes.Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -18359,9 +18232,8 @@ export type Resolvers<ContextType = any> = {
   ActivityLogEntryCalloutPublished?: ActivityLogEntryCalloutPublishedResolvers<ContextType>;
   ActivityLogEntryCalloutWhiteboardContentModified?: ActivityLogEntryCalloutWhiteboardContentModifiedResolvers<ContextType>;
   ActivityLogEntryCalloutWhiteboardCreated?: ActivityLogEntryCalloutWhiteboardCreatedResolvers<ContextType>;
-  ActivityLogEntryChallengeCreated?: ActivityLogEntryChallengeCreatedResolvers<ContextType>;
   ActivityLogEntryMemberJoined?: ActivityLogEntryMemberJoinedResolvers<ContextType>;
-  ActivityLogEntryOpportunityCreated?: ActivityLogEntryOpportunityCreatedResolvers<ContextType>;
+  ActivityLogEntrySubspaceCreated?: ActivityLogEntrySubspaceCreatedResolvers<ContextType>;
   ActivityLogEntryUpdateSent?: ActivityLogEntryUpdateSentResolvers<ContextType>;
   Agent?: AgentResolvers<ContextType>;
   AgentBeginVerifiedCredentialOfferOutput?: AgentBeginVerifiedCredentialOfferOutputResolvers<ContextType>;
@@ -36927,7 +36799,6 @@ export type SpaceDataFragment = {
   id: string;
   nameID: string;
   visibility: SchemaTypes.SpaceVisibility;
-  type: SchemaTypes.SpaceType;
   account: {
     id: string;
     spaces: Array<{ id: string }>;
@@ -52215,7 +52086,6 @@ export type ConvertSpaceL1ToSpaceL0Mutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
-    type: SchemaTypes.SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -58529,7 +58399,6 @@ export type ConvertSpaceL2ToSpaceL1Mutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
-    type: SchemaTypes.SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -64861,7 +64730,6 @@ export type UpdateSpaceMutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
-    type: SchemaTypes.SpaceType;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -85915,12 +85783,6 @@ export type GetActivityLogOnCollaborationQuery = {
         type: SchemaTypes.ActivityEventType;
         triggeredBy: { id: string };
       }
-    | {
-        collaborationID: string;
-        description: string;
-        type: SchemaTypes.ActivityEventType;
-        triggeredBy: { id: string };
-      }
   >;
 };
 
@@ -99432,7 +99294,6 @@ export type SearchQuery = {
                   about: {
                     __typename: 'SpaceAbout';
                     id: string;
-                    isContentPublic: boolean;
                     profile: {
                       __typename: 'Profile';
                       id: string;
@@ -99464,20 +99325,12 @@ export type SearchQuery = {
                           }
                         | undefined;
                     };
-                    membership: {
-                      __typename: 'SpaceAboutMembership';
-                      myMembershipStatus?:
-                        | SchemaTypes.CommunityMembershipStatus
-                        | undefined;
-                      myPrivileges?:
-                        | Array<SchemaTypes.AuthorizationPrivilege>
-                        | undefined;
-                      communityID: string;
-                      roleSetID: string;
-                    };
-                    guidelines: {
-                      __typename: 'CommunityGuidelines';
-                      id: string;
+                  };
+                  settings: {
+                    __typename: 'SpaceSettings';
+                    privacy: {
+                      __typename: 'SpaceSettingsPrivacy';
+                      mode: SchemaTypes.SpacePrivacyMode;
                     };
                   };
                 }
@@ -99491,7 +99344,6 @@ export type SearchQuery = {
                 __typename: 'SpaceAbout';
                 id: string;
                 why?: any | undefined;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -99515,11 +99367,23 @@ export type SearchQuery = {
                     name: string;
                   }>;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
+              };
+              community: {
+                __typename: 'Community';
+                id: string;
+                roleSet: {
+                  __typename: 'RoleSet';
+                  id: string;
                   myMembershipStatus?:
                     | SchemaTypes.CommunityMembershipStatus
                     | undefined;
+                };
+              };
+              settings: {
+                __typename: 'SpaceSettings';
+                privacy: {
+                  __typename: 'SpaceSettingsPrivacy';
+                  mode: SchemaTypes.SpacePrivacyMode;
                 };
               };
             };
@@ -99595,7 +99459,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -99623,18 +99486,6 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?:
-                    | SchemaTypes.CommunityMembershipStatus
-                    | undefined;
-                  myPrivileges?:
-                    | Array<SchemaTypes.AuthorizationPrivilege>
-                    | undefined;
-                  communityID: string;
-                  roleSetID: string;
-                };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
           }
@@ -99730,7 +99581,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -99758,18 +99608,6 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?:
-                    | SchemaTypes.CommunityMembershipStatus
-                    | undefined;
-                  myPrivileges?:
-                    | Array<SchemaTypes.AuthorizationPrivilege>
-                    | undefined;
-                  communityID: string;
-                  roleSetID: string;
-                };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
           }
@@ -99840,7 +99678,6 @@ export type SearchQuery = {
               about: {
                 __typename: 'SpaceAbout';
                 id: string;
-                isContentPublic: boolean;
                 profile: {
                   __typename: 'Profile';
                   id: string;
@@ -99868,18 +99705,13 @@ export type SearchQuery = {
                       }
                     | undefined;
                 };
-                membership: {
-                  __typename: 'SpaceAboutMembership';
-                  myMembershipStatus?:
-                    | SchemaTypes.CommunityMembershipStatus
-                    | undefined;
-                  myPrivileges?:
-                    | Array<SchemaTypes.AuthorizationPrivilege>
-                    | undefined;
-                  communityID: string;
-                  roleSetID: string;
+              };
+              settings: {
+                __typename: 'SpaceSettings';
+                privacy: {
+                  __typename: 'SpaceSettingsPrivacy';
+                  mode: SchemaTypes.SpacePrivacyMode;
                 };
-                guidelines: { __typename: 'CommunityGuidelines'; id: string };
               };
             };
             callout: {
@@ -99939,7 +99771,6 @@ export type SearchQuery = {
                 displayName: string;
                 id: string;
                 description?: any | undefined;
-                url: string;
                 location?:
                   | {
                       __typename: 'Location';
@@ -99957,14 +99788,6 @@ export type SearchQuery = {
                       allowedValues: Array<string>;
                       type: SchemaTypes.TagsetType;
                     }>
-                  | undefined;
-                visual?:
-                  | {
-                      __typename: 'Visual';
-                      id: string;
-                      uri: string;
-                      name: string;
-                    }
                   | undefined;
               };
             };
@@ -99998,7 +99821,6 @@ export type SearchQuery = {
                 displayName: string;
                 id: string;
                 description?: any | undefined;
-                url: string;
                 location?:
                   | {
                       __typename: 'Location';
@@ -100016,14 +99838,6 @@ export type SearchQuery = {
                       allowedValues: Array<string>;
                       type: SchemaTypes.TagsetType;
                     }>
-                  | undefined;
-                visual?:
-                  | {
-                      __typename: 'Visual';
-                      id: string;
-                      uri: string;
-                      name: string;
-                    }
                   | undefined;
               };
             };
@@ -100043,7 +99857,6 @@ export type SearchResultSpaceFragment = {
         about: {
           __typename: 'SpaceAbout';
           id: string;
-          isContentPublic: boolean;
           profile: {
             __typename: 'Profile';
             id: string;
@@ -100061,18 +99874,13 @@ export type SearchResultSpaceFragment = {
               | { __typename: 'Visual'; id: string; uri: string; name: string }
               | undefined;
           };
-          membership: {
-            __typename: 'SpaceAboutMembership';
-            myMembershipStatus?:
-              | SchemaTypes.CommunityMembershipStatus
-              | undefined;
-            myPrivileges?:
-              | Array<SchemaTypes.AuthorizationPrivilege>
-              | undefined;
-            communityID: string;
-            roleSetID: string;
+        };
+        settings: {
+          __typename: 'SpaceSettings';
+          privacy: {
+            __typename: 'SpaceSettingsPrivacy';
+            mode: SchemaTypes.SpacePrivacyMode;
           };
-          guidelines: { __typename: 'CommunityGuidelines'; id: string };
         };
       }
     | undefined;
@@ -100085,7 +99893,6 @@ export type SearchResultSpaceFragment = {
       __typename: 'SpaceAbout';
       id: string;
       why?: any | undefined;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -100109,9 +99916,21 @@ export type SearchResultSpaceFragment = {
           name: string;
         }>;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
+    };
+    community: {
+      __typename: 'Community';
+      id: string;
+      roleSet: {
+        __typename: 'RoleSet';
+        id: string;
         myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
+      };
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: {
+        __typename: 'SpaceSettingsPrivacy';
+        mode: SchemaTypes.SpacePrivacyMode;
       };
     };
   };
@@ -100120,7 +99939,6 @@ export type SearchResultSpaceFragment = {
 export type SpaceAboutLightFragment = {
   __typename: 'SpaceAbout';
   id: string;
-  isContentPublic: boolean;
   profile: {
     __typename: 'Profile';
     id: string;
@@ -100138,14 +99956,6 @@ export type SpaceAboutLightFragment = {
       | { __typename: 'Visual'; id: string; uri: string; name: string }
       | undefined;
   };
-  membership: {
-    __typename: 'SpaceAboutMembership';
-    myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
-    myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined;
-    communityID: string;
-    roleSetID: string;
-  };
-  guidelines: { __typename: 'CommunityGuidelines'; id: string };
 };
 
 export type VisualUriFragment = {
@@ -100207,7 +100017,6 @@ export type SearchResultCalloutFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -100225,14 +100034,6 @@ export type SearchResultCalloutFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
 };
@@ -100246,7 +100047,6 @@ export type CalloutParentFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -100264,14 +100064,6 @@ export type CalloutParentFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
-      };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
 };
@@ -100319,7 +100111,6 @@ export type SearchResultPostFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -100337,14 +100128,13 @@ export type SearchResultPostFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: {
+        __typename: 'SpaceSettingsPrivacy';
+        mode: SchemaTypes.SpacePrivacyMode;
       };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
   callout: {
@@ -100389,7 +100179,6 @@ export type PostParentFragment = {
     about: {
       __typename: 'SpaceAbout';
       id: string;
-      isContentPublic: boolean;
       profile: {
         __typename: 'Profile';
         id: string;
@@ -100407,14 +100196,13 @@ export type PostParentFragment = {
           | { __typename: 'Visual'; id: string; uri: string; name: string }
           | undefined;
       };
-      membership: {
-        __typename: 'SpaceAboutMembership';
-        myMembershipStatus?: SchemaTypes.CommunityMembershipStatus | undefined;
-        myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined;
-        communityID: string;
-        roleSetID: string;
+    };
+    settings: {
+      __typename: 'SpaceSettings';
+      privacy: {
+        __typename: 'SpaceSettingsPrivacy';
+        mode: SchemaTypes.SpacePrivacyMode;
       };
-      guidelines: { __typename: 'CommunityGuidelines'; id: string };
     };
   };
   callout: {
@@ -100444,7 +100232,6 @@ export type SearchResultUserFragment = {
       displayName: string;
       id: string;
       description?: any | undefined;
-      url: string;
       location?:
         | {
             __typename: 'Location';
@@ -100463,18 +100250,13 @@ export type SearchResultUserFragment = {
             type: SchemaTypes.TagsetType;
           }>
         | undefined;
-      visual?:
-        | { __typename: 'Visual'; id: string; uri: string; name: string }
-        | undefined;
     };
   };
 };
 
 export type SearchResultProfileFragment = {
-  __typename: 'Profile';
   id: string;
   description?: any | undefined;
-  url: string;
   location?:
     | {
         __typename: 'Location';
@@ -100493,9 +100275,6 @@ export type SearchResultProfileFragment = {
         type: SchemaTypes.TagsetType;
       }>
     | undefined;
-  visual?:
-    | { __typename: 'Visual'; id: string; uri: string; name: string }
-    | undefined;
 };
 
 export type SearchResultOrganizationFragment = {
@@ -100508,7 +100287,6 @@ export type SearchResultOrganizationFragment = {
       displayName: string;
       id: string;
       description?: any | undefined;
-      url: string;
       location?:
         | {
             __typename: 'Location';
@@ -100526,9 +100304,6 @@ export type SearchResultOrganizationFragment = {
             allowedValues: Array<string>;
             type: SchemaTypes.TagsetType;
           }>
-        | undefined;
-      visual?:
-        | { __typename: 'Visual'; id: string; uri: string; name: string }
         | undefined;
     };
   };
@@ -100566,7 +100341,6 @@ export type GetSpaceDataQuery = {
           id: string;
           nameID: string;
           visibility: SchemaTypes.SpaceVisibility;
-          type: SchemaTypes.SpaceType;
           account: {
             id: string;
             spaces: Array<{ id: string }>;
@@ -123416,7 +123190,6 @@ export const SpaceDataFragmentDoc = gql`
     id
     nameID
     visibility
-    type
     account {
       ...AccountData
     }
@@ -123984,18 +123757,6 @@ export const SpaceAboutLightFragmentDoc = gql`
       }
       __typename
     }
-    isContentPublic
-    membership {
-      myMembershipStatus
-      myPrivileges
-      communityID
-      roleSetID
-      __typename
-    }
-    guidelines {
-      id
-      __typename
-    }
     __typename
   }
   ${VisualUriFragmentDoc}
@@ -124007,6 +123768,13 @@ export const SearchResultSpaceFragmentDoc = gql`
       level
       about {
         ...SpaceAboutLight
+        __typename
+      }
+      settings {
+        privacy {
+          mode
+          __typename
+        }
         __typename
       }
       __typename
@@ -124032,9 +123800,20 @@ export const SearchResultSpaceFragmentDoc = gql`
           }
           __typename
         }
-        isContentPublic
-        membership {
+        __typename
+      }
+      community {
+        id
+        roleSet {
+          id
           myMembershipStatus
+          __typename
+        }
+        __typename
+      }
+      settings {
+        privacy {
+          mode
           __typename
         }
         __typename
@@ -124141,6 +123920,13 @@ export const PostParentFragmentDoc = gql`
         ...SpaceAboutLight
         __typename
       }
+      settings {
+        privacy {
+          mode
+          __typename
+        }
+        __typename
+      }
       __typename
     }
     callout {
@@ -124214,15 +124000,8 @@ export const SearchResultProfileFragmentDoc = gql`
       ...TagsetDetails
       __typename
     }
-    visual(type: AVATAR) {
-      ...VisualUri
-      __typename
-    }
-    url
-    __typename
   }
   ${TagsetDetailsFragmentDoc}
-  ${VisualUriFragmentDoc}
 `;
 export const SearchResultUserFragmentDoc = gql`
   fragment SearchResultUser on SearchResultUser {

--- a/server-api/src/core/generated/graphql.ts
+++ b/server-api/src/core/generated/graphql.ts
@@ -36799,6 +36799,7 @@ export type SpaceDataFragment = {
   id: string;
   nameID: string;
   visibility: SchemaTypes.SpaceVisibility;
+  level: SchemaTypes.SpaceLevel;
   account: {
     id: string;
     spaces: Array<{ id: string }>;
@@ -52086,6 +52087,7 @@ export type ConvertSpaceL1ToSpaceL0Mutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
+    level: SchemaTypes.SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -58399,6 +58401,7 @@ export type ConvertSpaceL2ToSpaceL1Mutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
+    level: SchemaTypes.SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -64730,6 +64733,7 @@ export type UpdateSpaceMutation = {
     id: string;
     nameID: string;
     visibility: SchemaTypes.SpaceVisibility;
+    level: SchemaTypes.SpaceLevel;
     account: {
       id: string;
       spaces: Array<{ id: string }>;
@@ -100341,6 +100345,7 @@ export type GetSpaceDataQuery = {
           id: string;
           nameID: string;
           visibility: SchemaTypes.SpaceVisibility;
+          level: SchemaTypes.SpaceLevel;
           account: {
             id: string;
             spaces: Array<{ id: string }>;
@@ -123190,6 +123195,7 @@ export const SpaceDataFragmentDoc = gql`
     id
     nameID
     visibility
+    level
     account {
       ...AccountData
     }

--- a/server-api/src/functional-api/journey/conversion/convert-L1-to-L0-basic.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/convert-L1-to-L0-basic.it-spec.ts
@@ -5,6 +5,7 @@ import { TestScenarioFactory } from '@src/scenario/TestScenarioFactory';
 import { convertSpaceL1ToSpaceL0 } from './conversion.request.params';
 import { getSpaceData } from '../space/space.request.params';
 import { getSpaceLicenseSubscriptions } from '@functional-api/license/license.params.request';
+import { SpaceLevel } from '@generated/alkemio-schema';
 
 let baseScenario: OrganizationWithSpaceModel;
 
@@ -92,7 +93,7 @@ describe('Promoting of L1 subspace', () => {
     expect(subspaceBefore.data?.lookup.space?.visibility).toEqual(
       subspaceAfter?.visibility
     );
-    expect(subspaceAfter?.type).toEqual('SPACE');
+    expect(subspaceAfter?.level).toEqual(SpaceLevel.L0);
     expect(sortedLicenseBefore).toEqual(sortedLicenseAfter);
 
     expect(

--- a/server-api/src/functional-api/journey/conversion/convert-L1-to-L0-with-L2-to-L1.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/convert-L1-to-L0-with-L2-to-L1.it-spec.ts
@@ -7,6 +7,7 @@ import { getSpaceData } from '../space/space.request.params';
 import { inviteForEntryRoleOnRoleSet } from '@functional-api/roleset/invitations/invitation.request.params';
 import { TestUserManager } from '@src/scenario/TestUserManager';
 import { createApplication } from '@functional-api/roleset/application/application.request.params';
+import { SpaceLevel } from '@generated/alkemio-schema';
 import {
   CommunityMembershipPolicy,
   SpacePrivacyMode,
@@ -104,7 +105,7 @@ describe('Promoting of L1 subspace', () => {
     expect(subspaceBefore.data?.lookup.space?.visibility).toEqual(
       subspaceAfter?.visibility
     );
-    expect(subspaceAfter?.type).toEqual('SPACE');
+    expect(subspaceAfter?.level).toEqual(SpaceLevel.L0);
 
     expect(
       Array.isArray(subspaceBefore.data?.lookup.space?.community)
@@ -132,7 +133,7 @@ describe('Promoting of L1 subspace', () => {
     expect(subsubspaceBefore.data?.lookup.space?.visibility).toEqual(
       subsubspaceAfterData?.visibility
     );
-    expect(subsubspaceAfterData?.type).toEqual('CHALLENGE');
+    expect(subsubspaceAfterData?.level).toEqual(SpaceLevel.L1);
     expect(
       Array.isArray(subsubspaceBefore.data?.lookup.space?.community)
         ? subsubspaceBefore.data.lookup.space.community.slice().sort()

--- a/server-api/src/functional-api/journey/conversion/convert-L1-to-L0.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/convert-L1-to-L0.it-spec.ts
@@ -17,6 +17,7 @@ import {
   SpacePrivacyMode,
 } from '@alkemio/client-lib';
 import { getSingleInvitationResult } from '@functional-api/roleset/roleset.request.params';
+import { SpaceLevel } from '@generated/alkemio-schema';
 
 let baseScenario: OrganizationWithSpaceModel;
 
@@ -98,7 +99,7 @@ describe('Promoting of L1 subspace', () => {
 
     // Assert
     expect(before.data?.lookup.space?.visibility).toEqual(after?.visibility);
-    expect(after?.type).toEqual('SPACE');
+    expect(after?.level).toEqual(SpaceLevel.L0);
 
     expect(
       Array.isArray(before.data?.lookup.space?.community)

--- a/server-api/src/functional-api/journey/conversion/convert-L2-to-L1.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/convert-L2-to-L1.it-spec.ts
@@ -4,6 +4,7 @@ import { OrganizationWithSpaceModel } from '@src/scenario/models/OrganizationWit
 import { TestScenarioFactory } from '@src/scenario/TestScenarioFactory';
 import { convertSpaceL2ToSpaceL1 } from './conversion.request.params';
 import { getSpaceData } from '../space/space.request.params';
+import { SpaceLevel } from '@generated/alkemio-schema';
 
 let baseScenario: OrganizationWithSpaceModel;
 
@@ -82,7 +83,7 @@ describe('Promoting of L2 subspace', () => {
       before.data?.lookup.space?.collaboration.innovationFlow.states
     );
     expect(before.data?.lookup.space?.visibility).toEqual(after?.visibility);
-    expect(after?.type).toEqual('CHALLENGE');
+    expect(after?.level).toEqual(SpaceLevel.L1);
 
     expect(
       Array.isArray(before.data?.lookup.space?.community)

--- a/server-api/src/graphql/fragments/space/spaceData.graphql
+++ b/server-api/src/graphql/fragments/space/spaceData.graphql
@@ -2,7 +2,6 @@ fragment SpaceData on Space {
   id
   nameID
   visibility
-  type
   account {
     ...AccountData
   }

--- a/server-api/src/graphql/fragments/space/spaceData.graphql
+++ b/server-api/src/graphql/fragments/space/spaceData.graphql
@@ -2,6 +2,7 @@ fragment SpaceData on Space {
   id
   nameID
   visibility
+  level
   account {
     ...AccountData
   }


### PR DESCRIPTION
Relates to: https://github.com/alkem-io/server/pull/5112

Updated schema and fixed space conversion tests - use space level instead of type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated tests to verify space levels using a strongly typed enum instead of string values.
  - Modified GraphQL fragment to request the space's level property instead of type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->