### PR TITLE
Updated error message on duplicate org assignment as member

### DIFF
--- a/server-api/src/functional-api/roleset/organization/organization-edge.it-spec.ts
+++ b/server-api/src/functional-api/roleset/organization/organization-edge.it-spec.ts
@@ -13,6 +13,8 @@ import { RoleName } from '@alkemio/tests-lib/core/generated/alkemio-schema';
 
 let newOrgId = '';
 const newOrgNameId = 'ha-new-org-nameid';
+const errorMessage =
+  'Agent already has credential of this type on this resource';
 
 let baseScenario: OrganizationWithSpaceModel;
 const scenarioConfig: TestScenarioConfig = {
@@ -129,9 +131,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-member`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -156,9 +156,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-member`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -183,9 +181,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-member`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -286,9 +282,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-lead`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -312,9 +306,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-lead`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -338,9 +330,7 @@ describe('Assign / Remove organization to community', () => {
 
         // Assert
         expect(data).toHaveLength(1);
-        expect(res.error?.errors[0].message).toContain(
-          `Agent (${baseScenario.organization.agentId}) already has assigned credential: space-lead`
-        );
+        expect(res.error?.errors[0].message).toContain(errorMessage);
         expect(data).toEqual(
           expect.arrayContaining([
             expect.objectContaining({


### PR DESCRIPTION
### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Standardized error validation for duplicate credential assignments across Space, Subspace, and Subsubspace scenarios for Member and Lead roles, using a single unified message.
  - Simplifies and de-duplicates assertions to improve clarity and maintainability of the test suite.
  - No impact on runtime behavior or user experience.
  - Enhances consistency of error handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->