### PR TITLE
Disable automatic builds on specific branches in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 # Use Ubuntu 20.04 for better Node.js compatibility
 dist: focal
+branches:
+  only:
+    - __disable_travis_never_build__ # Disable automatic builds on branches
 # Use Node.js 20.11.0 as default (compatible with Ubuntu 20.04)
 node_js:
   - 20.11.0


### PR DESCRIPTION
Disable automatic travis builds by running build on the specific branch `__disable_travis_never_build__`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated continuous integration build configuration to control when automated builds are triggered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->