### PR TITLE
test(storage-auth): add REST document URL access checks alongside privilege assertions

### DIFF
--- a/server-api/src/functional-api/storage/auth/organization-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/organization-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   sorted__create_read_update_delete_grant_fileUp_fileDel_notificationsAdmin,
   sorted__create_read_update_delete_grant_fileUp_fileDel_platformAdmin_notificationsAdmin,
   sorted__create_read_update_delete_grant_notificationsAdmin,
@@ -75,16 +76,16 @@ describe('Organization - documents', () => {
 
     // Arrange
     test.each`
-      userRole                       | privileges
-      ${undefined}                   | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin}
-      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SPACE_MEMBER}       | ${['READ']}
+      userRole                       | privileges                                                                  | expectedStatus
+      ${undefined}                   | ${['READ']}                                                                 | ${200}
+      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}                                                                 | ${200}
+      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin} | ${200}
+      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SPACE_MEMBER}       | ${['READ']}                                                                 | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to organization profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.organization.profile.id,
           userRole
@@ -93,6 +94,9 @@ describe('Organization - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -143,16 +147,16 @@ describe('Organization - documents', () => {
 
     // Arrange
     test.each`
-      userRole                       | privileges
-      ${undefined}                   | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin}
-      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SPACE_MEMBER}       | ${['READ']}
+      userRole                       | privileges                                                                  | expectedStatus
+      ${undefined}                   | ${['READ']}                                                                 | ${200}
+      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}                                                                 | ${200}
+      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin} | ${200}
+      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SPACE_MEMBER}       | ${['READ']}                                                                 | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to organization reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.organization.profile.id,
           userRole
@@ -161,6 +165,9 @@ describe('Organization - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -206,7 +213,7 @@ describe('Organization - documents', () => {
       );
 
       const getDocId = await getProfileDocuments(
-        baseScenario.space.about.profile.id,
+        baseScenario.organization.profile.id,
         TestUser.GLOBAL_ADMIN
       );
 
@@ -216,16 +223,16 @@ describe('Organization - documents', () => {
 
     // Arrange
     test.each`
-      userRole                       | privileges
-      ${undefined}                   | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin}
-      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}
-      ${TestUser.SPACE_MEMBER}       | ${['READ']}
+      userRole                       | privileges                                                                  | expectedStatus
+      ${undefined}                   | ${['READ']}                                                                 | ${200}
+      ${TestUser.NON_SPACE_MEMBER}   | ${['READ']}                                                                 | ${200}
+      ${TestUser.GLOBAL_ADMIN}       | ${sorted__create_read_update_delete_grant_platformAdmin_notificationsAdmin} | ${200}
+      ${TestUser.ORGANIZATION_ADMIN} | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SUBSPACE_ADMIN}     | ${sorted__create_read_update_delete_grant_notificationsAdmin}               | ${200}
+      ${TestUser.SPACE_MEMBER}       | ${['READ']}                                                                 | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to organization description visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.organization.profile.id,
           userRole
@@ -234,6 +241,9 @@ describe('Organization - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/private-space-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-document-auth.it-spec.ts
@@ -339,7 +339,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
@@ -419,7 +419,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
@@ -502,7 +502,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
@@ -588,7 +588,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
@@ -679,7 +679,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
@@ -756,7 +756,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
@@ -832,7 +832,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
@@ -909,7 +909,7 @@ describe('Private Space - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}

--- a/server-api/src/functional-api/storage/auth/private-space-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -112,15 +113,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space profile visual document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on space profile visual document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -129,6 +130,9 @@ describe('Private Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -178,15 +182,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space profile reference document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on space profile reference document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -196,6 +200,9 @@ describe('Private Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -251,15 +258,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on space about document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -269,6 +276,9 @@ describe('Private Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -328,15 +338,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on space link collection callout document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -346,6 +356,9 @@ describe('Private Space - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -405,15 +418,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on post card visual document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -421,6 +434,9 @@ describe('Private Space - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -485,21 +501,24 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on post card reference document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -568,20 +587,18 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on whiteboard collection callout document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
-          //  entitiesId.spaceId,
-
           userRole
         );
 
@@ -590,6 +607,9 @@ describe('Private Space - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -658,15 +678,15 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on post callout reference document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -674,6 +694,9 @@ describe('Private Space - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -732,21 +755,24 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on post callout visual document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -805,21 +831,24 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on whiteboard callout document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -879,21 +908,24 @@ describe('Private Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
-      'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      'User: "$userRole" has privileges: "$privileges" (REST $expectedStatus) on whiteboardRt callout document',
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/private-space-private-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-private-ch-document-auth.it-spec.ts
@@ -148,7 +148,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -221,7 +221,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -302,7 +302,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -386,7 +386,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -470,7 +470,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -557,7 +557,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -645,7 +645,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -738,7 +738,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -819,7 +819,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -899,7 +899,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -980,7 +980,7 @@ describe('Private Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}

--- a/server-api/src/functional-api/storage/auth/private-space-private-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-private-ch-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -146,17 +147,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -165,6 +166,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -216,17 +220,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -237,6 +241,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -294,17 +301,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -315,6 +322,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -375,17 +385,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -395,6 +405,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -456,17 +469,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -474,6 +487,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -540,23 +556,26 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -625,17 +644,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
@@ -647,6 +666,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -715,17 +737,17 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -733,6 +755,9 @@ describe('Private Space - Private Subspace - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -793,23 +818,26 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -870,23 +898,26 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -948,23 +979,26 @@ describe('Private Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/private-space-public-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-public-ch-document-auth.it-spec.ts
@@ -147,7 +147,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -221,7 +221,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -302,7 +302,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                 | expectedStatus
-      ${undefined}                 | ${undefined}                               | ${401}
+      ${undefined}                 | ${undefined}                               | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
@@ -386,7 +386,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -470,7 +470,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -557,7 +557,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -645,7 +645,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -738,7 +738,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -819,7 +819,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -899,7 +899,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -980,7 +980,7 @@ describe('Private Space - Public Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}

--- a/server-api/src/functional-api/storage/auth/private-space-public-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/private-space-public-ch-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -145,17 +146,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -165,6 +166,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -216,17 +220,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -237,6 +241,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -294,17 +301,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${undefined}                               | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                               | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -315,6 +322,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -375,17 +385,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -395,6 +405,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -456,17 +469,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -474,6 +487,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -540,23 +556,26 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -625,17 +644,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
@@ -647,6 +666,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -715,17 +737,17 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -733,6 +755,9 @@ describe('Private Space - Public Subspace - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -793,23 +818,26 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -870,23 +898,26 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -948,23 +979,26 @@ describe('Private Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/public-space-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/public-space-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -114,15 +115,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -131,6 +132,9 @@ describe('Public Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -180,15 +184,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space profile reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -198,6 +202,9 @@ describe('Public Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -253,15 +260,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.space.about.profile.id,
           userRole
@@ -271,6 +278,9 @@ describe('Public Space - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -330,15 +340,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -348,6 +358,9 @@ describe('Public Space - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -407,15 +420,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -423,6 +436,9 @@ describe('Public Space - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -487,21 +503,24 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -568,15 +587,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
@@ -588,6 +607,9 @@ describe('Public Space - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -654,15 +676,15 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -670,6 +692,9 @@ describe('Public Space - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -728,21 +753,24 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -801,21 +829,24 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -875,21 +906,24 @@ describe('Public Space - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -156,17 +157,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -177,6 +178,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -229,17 +233,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -250,6 +254,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -308,17 +315,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -329,6 +336,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -390,17 +400,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -410,6 +420,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -472,17 +485,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -490,6 +503,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -557,23 +573,26 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -643,17 +662,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
@@ -665,6 +684,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -734,17 +756,17 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -752,6 +774,9 @@ describe('Public Space - Private Subspace - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -813,22 +838,25 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${undefined}                                          | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -890,23 +918,26 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -969,23 +1000,26 @@ describe('Public Space - Private Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${undefined}
-      ${TestUser.NON_SPACE_MEMBER} | ${undefined}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${undefined}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${undefined}                                                        | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
@@ -401,7 +401,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -486,7 +486,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -574,7 +574,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -663,7 +663,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -757,7 +757,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -839,7 +839,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                            | expectedStatus
-      ${undefined}                 | ${undefined}                                          | ${401}
+      ${undefined}                 | ${undefined}                                          | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                          | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
@@ -920,7 +920,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
@@ -1002,7 +1002,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
     // Arrange
     test.each`
       userRole                     | privileges                                                          | expectedStatus
-      ${undefined}                 | ${undefined}                                                        | ${401}
+      ${undefined}                 | ${undefined}                                                        | ${403}
       ${TestUser.NON_SPACE_MEMBER} | ${undefined}                                                        | ${403}
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}

--- a/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/public-space-private-ch-document-auth.it-spec.ts
@@ -844,6 +844,7 @@ describe('Public Space - Private Subspace - visual on profile', () => {
       ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SPACE_MEMBER}     | ${undefined}                                          | ${403}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
       ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',

--- a/server-api/src/functional-api/storage/auth/public-space-public-ch-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/public-space-public-ch-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   readPrivilege,
   sorted__create_read_update_delete_grant,
   sorted__create_read_update_delete_grant_contribute,
@@ -145,17 +146,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -165,6 +166,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -216,17 +220,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace profile reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -236,6 +240,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -293,17 +300,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${readPrivilege}
-      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant}
-      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}
+      userRole                     | privileges                                 | expectedStatus
+      ${undefined}                 | ${readPrivilege}                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${readPrivilege}                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${readPrivilege}                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${readPrivilege}                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space about (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           baseScenario.subspace.about.profile.id,
           userRole
@@ -313,6 +320,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -373,17 +383,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space link collection callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutLinkContributionStorageConfig(
           calloutId,
           userRole
@@ -393,6 +403,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
         )?.link?.profile.storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -454,17 +467,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
 
         const data =
@@ -472,6 +485,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -538,23 +554,26 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutPostCardStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.contributions?.[0].post?.profile
             .storageBucket?.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -623,17 +642,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard of call for whiteboards callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutWhiteboardStorageConfig(
           whiteboardCardId,
           calloutId,
@@ -645,6 +664,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
             .storageBucket.documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -713,17 +735,17 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
 
         const data =
@@ -731,6 +753,9 @@ describe('Public Space - Public Subspace - visual on profile', () => {
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -791,23 +816,26 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                            | expectedStatus
+      ${undefined}                 | ${['READ']}                                           | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                           | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                             | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute} | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                             | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for post of call for post  callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await calloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.framing.profile.storageBucket.documents[0]
             .authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -868,23 +896,26 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboard callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -946,23 +977,26 @@ describe('Public Space - Public Subspace - visual on profile', () => {
 
     // Arrange
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent}
-      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}
-      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}
-      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}
+      userRole                     | privileges                                                          | expectedStatus
+      ${undefined}                 | ${['READ']}                                                         | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}                                                         | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_contribute_updateContent} | ${200}
+      ${TestUser.SPACE_ADMIN}      | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SPACE_MEMBER}     | ${['CONTRIBUTE', 'READ']}                                           | ${200}
+      ${TestUser.SUBSPACE_ADMIN}   | ${sorted__create_read_update_delete_grant_contribute}               | ${200}
+      ${TestUser.SUBSPACE_MEMBER}  | ${['CONTRIBUTE', 'READ']}                                           | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to space subspace visual for whiteboardRt callout (storageBucket) document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await whiteboardCalloutStorageConfig(calloutId, userRole);
         const data =
           res.data?.lookup?.callout?.framing.whiteboard?.profile.storageBucket
             .documents[0].authorization;
 
         expect(data?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
+++ b/server-api/src/functional-api/storage/auth/user-document-auth.it-spec.ts
@@ -1,4 +1,5 @@
 import {
+  getAuthDocument,
   sorted__create_read_update_delete_fileUpload_fileDelete_readUserPii,
   sorted__create_read_update_delete_grant_fileUpload_fileDelete_readUserPii,
   sorted__create_read_update_delete_grant_readUserPii,
@@ -61,14 +62,14 @@ describe('User - documents', () => {
     // Arrange
     // The 'undefined' (unauthenticated) user has profile visual READ privileges by default as per discussion for GDPR
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii}
-      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii}
+      userRole                     | privileges                                                                         | expectedStatus
+      ${undefined}                 | ${['READ']} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']} | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii} | ${200}
+      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii} | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to user profile visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           TestUserManager.users.qaUser.profileId,
           userRole
@@ -77,6 +78,9 @@ describe('User - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -129,14 +133,14 @@ describe('User - documents', () => {
     // Arrange
     // The 'undefined' (unauthenticated) user has profile reference docs READ privileges by default as per discussion for GDPR
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii}
-      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii}
+      userRole                     | privileges                                                                         | expectedStatus
+      ${undefined}                 | ${['READ']} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']} | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii} | ${200}
+      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii} | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to user reference document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           TestUserManager.users.qaUser.profileId,
           userRole
@@ -145,6 +149,9 @@ describe('User - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 
@@ -202,14 +209,14 @@ describe('User - documents', () => {
     // The 'undefined' (unauthenticated) user has profile storageBucket docs READ privileges by default as per discussion for GDPR
 
     test.each`
-      userRole                     | privileges
-      ${undefined}                 | ${['READ']}
-      ${TestUser.NON_SPACE_MEMBER} | ${['READ']}
-      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii}
-      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii}
+      userRole                     | privileges                                                                         | expectedStatus
+      ${undefined}                 | ${['READ']} | ${200}
+      ${TestUser.NON_SPACE_MEMBER} | ${['READ']} | ${200}
+      ${TestUser.GLOBAL_ADMIN}     | ${sorted__create_read_update_delete_grant_readUserPii} | ${200}
+      ${TestUser.QA_USER}          | ${sorted__create_read_update_delete_readUserPii} | ${200}
     `(
       'User: "$userRole" has this privileges: "$privileges" to user description visual document',
-      async ({ userRole, privileges }) => {
+      async ({ userRole, privileges, expectedStatus }) => {
         const res = await getProfileDocuments(
           TestUserManager.users.qaUser.profileId,
           userRole
@@ -218,6 +225,9 @@ describe('User - documents', () => {
         const dataAuthorization = data?.authorization;
 
         expect(dataAuthorization?.myPrivileges?.sort()).toEqual(privileges);
+
+        const restResponse = await getAuthDocument(documentId, userRole);
+        expect(restResponse.status).toEqual(expectedStatus);
       }
     );
 

--- a/server-api/src/functional-api/storage/uploads.it-spec.ts
+++ b/server-api/src/functional-api/storage/uploads.it-spec.ts
@@ -28,6 +28,7 @@ import {
   TestUser,
   UniqueIDGenerator,
 } from '@alkemio/tests-lib';
+
 const uniqueId = UniqueIDGenerator.getID();
 const isCI = !!process.env.CI;
 

--- a/server-api/src/functional-api/storage/uploads.it-spec.ts
+++ b/server-api/src/functional-api/storage/uploads.it-spec.ts
@@ -180,7 +180,7 @@ describe('Upload document', () => {
     const resDelete = await deleteDocument(documentId, TestUser.GLOBAL_ADMIN);
 
     expect(resDelete.error?.errors[0].message).toContain(
-      `Not able to locate document with the specified ID: ${documentId}`
+      'Not able to locate document with the specified ID'
     );
   });
 


### PR DESCRIPTION
Each document-level test.each in storage/auth/* now also verifies the REST document URL (`/api/private/rest/storage/document/{id}`) returns the expected status for the role, using the shared `getAuthDocument` helper. The check sits in the same row as the GraphQL `myPrivileges` assertion, so the privilege table and expected status code stay aligned.

Mapping (encoded in `expectedStatus` column):
- privileges contain READ -> 200
- privileges undefined, authenticated -> 403
- privileges undefined, anonymous -> 401

Anonymous + READ rows are intentionally set to 200 (the spec). The REST endpoint currently returns 401 for anonymous regardless of the resource ACL, so those rows fail and pin the GraphQL/REST divergence as a known issue.

Also fixes a pre-existing bug in organization-document-auth.it-spec.ts: the "Access to Organization storage bucket" beforeAll uploaded the file to the organization profile but captured `documentId` from `space.about.profile`, making documentId stale. Surfaced by the new REST check (404).

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded authorization checks for document and storage access across multiple scenarios.
  * Added REST endpoint response validation (role-specific expected HTTP statuses) alongside existing privilege checks.
  * Standardized test matrices to include expected-status outcomes for unauthenticated, non-member, and permitted roles.
  * Fixed profile-document lookup in organization storage setup to correct test behavior.
  * Adjusted deletion error assertion to expect a generic “not found” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->