### PR TITLE
chore: link CLAUDE.md to agents-hq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 > **Workspace context.** This repo is part of the Alkemio polyrepo at
-> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> [alkem-io/agents-hq](https://github.com/alkem-io/agents-hq).
 > Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
 > working on a `feat/NNN-...` branch in this repo, the matching workspace
 > spec is the single source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # CLAUDE.md
 
+> **Workspace context.** This repo is part of the Alkemio polyrepo at
+> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
+> working on a `feat/NNN-...` branch in this repo, the matching workspace
+> spec is the single source of truth.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview


### PR DESCRIPTION
Adds a small **Workspace context** blockquote to `CLAUDE.md` so future Claude
sessions opened in this repo know that cross-repo (vertical) feature specs
live in [`alkem-io/alkemio-workspace`](https://github.com/alkem-io/alkemio-workspace).

No behaviour change. Documentation only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>