### PR TITLE
test(collab): unified-collab service-level e2e (memo + whiteboard)

### DIFF
--- a/client-web/config/playwright.config.nightly.ts
+++ b/client-web/config/playwright.config.nightly.ts
@@ -124,6 +124,18 @@ export default defineConfig({
         '/user-profile/view-profile-information.spec.ts',
       ],
     },
+    {
+      // Unified collaboration service-level e2e (epic 003-unify-collab-yjs,
+      // SC-009 / WS-F): two raw y-websocket clients per document asserting CRDT
+      // convergence, per-property merge (whiteboard) and awareness. Heavier than
+      // the 30s default (OIDC login + two WS clients + cold reload), so each spec
+      // raises its own per-test timeout via test.describe.configure.
+      name: 'Collaboration',
+      testMatch: [
+        '/collab/memo-collaboration.spec.ts',
+        '/collab/whiteboard-collaboration.spec.ts',
+      ],
+    },
   ],
   // % or number of the available CPUs
   // workers: '100%',

--- a/client-web/package.json
+++ b/client-web/package.json
@@ -29,7 +29,12 @@
     "axios": "1.13.5",
     "graphql": "^16.6.0",
     "graphql-upload": "^17.0.0",
-    "tsx": "^4.21.0"
+    "lib0": "^0.2.117",
+    "tsx": "^4.21.0",
+    "ws": "^8.18.0",
+    "y-protocols": "^1.0.6",
+    "y-websocket": "^3.0.0",
+    "yjs": "^13.6.27"
   },
   "devDependencies": {
     "@graphql-codegen/add": "^5.0.3",
@@ -41,6 +46,7 @@
     "@graphql-codegen/typescript-resolvers": "4.4.1",
     "@playwright/test": "^1.57.0",
     "@types/node": "^20.13.1",
+    "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "8.18.1",
     "@typescript-eslint/parser": "8.18.1",
     "cross-env": "^7.0.3",

--- a/client-web/src/functional-e2e/collab/README.md
+++ b/client-web/src/functional-e2e/collab/README.md
@@ -1,0 +1,85 @@
+# Unified collaboration — service-level e2e (epic `003-unify-collab-yjs`)
+
+Service-level (protocol/backend) end-to-end tests for the **unified
+collaboration service**, covering both **memo** and **whiteboard** documents.
+They drive two raw `y-websocket` clients straight at the service over the
+canonical y-protocols wire envelope and assert CRDT correctness — **no React,
+no ProseMirror, no Excalidraw UI**. This is the robust, headless, CI-gating
+layer (epic SC-009 / WS-F).
+
+## Files
+
+| File | Role |
+|------|------|
+| `collab-auth.ts` | OIDC/BFF admin login (one short-lived Playwright Chrome → `alkemio_session` cookie) + cookie-authenticated GraphQL helper. The cookie authenticates both GraphQL and the `/collab` WS handshake (Traefik forwardAuth → `X-Alkemio-Actor-Id`). |
+| `collab-fixture.ts` | Creates a fresh Space + MEMO / WHITEBOARD callout via GraphQL; returns the collaboration-document UUID = the WS room id. |
+| `collab-ws.ts` | Raw-WS Yjs client helpers: connect a `y-websocket` client carrying the cookie, plus `waitForDoc` / `waitForAwareness`. |
+| `memo-collaboration.spec.ts` | Memo: convergence + awareness + (opt-in) persistence. |
+| `whiteboard-collaboration.spec.ts` | Whiteboard: convergence + **per-property merge** + awareness + (opt-in) persistence. |
+
+## Scenarios & assertions
+
+Both specs open `ws://localhost:3000/collab/<documentId>?type=<memo|whiteboard>`.
+
+**Memo** (binds to the Y.Doc XmlFragment `"default"`):
+1. **Convergence** — text inserted by A appears in B.
+2. **Awareness/presence** — A's awareness state is visible to B.
+3. **Persistence round-trip** *(opt-in)* — after A+B drop, a cold client C
+   rehydrates the text.
+
+**Whiteboard** (Yjs scene schema: top-level `Y.Map` `elements` keyed by element
+id → a **per-property** nested `Y.Map`; plus `files` and `appState`):
+1. **Convergence** — an element seeded by A appears in B.
+2. **Per-property merge (headline)** — A sets `element.x`, B sets the **same**
+   element's `strokeColor` concurrently → **both survive on both clients**, NOT
+   last-write-wins. Untouched properties stay intact.
+3. **Awareness/presence** — A's awareness state is visible to B.
+4. **Persistence round-trip** *(opt-in)* — cold client C rehydrates the merged
+   element.
+
+> The whiteboard test mirrors the schema the `@alkemio/excalidraw-yjs-binding`
+> writes but does **not** import it — it exercises the WS/CRDT layer, not the
+> binding.
+
+## What's proven headless now vs. what needs a live stack
+
+Everything here needs the **local dev stack up** (gateway `localhost:3000` →
+unified collab service + server BFF for forward-auth + OIDC login). Against that
+stack:
+
+- ✅ **Deterministic / CI-gating**: convergence, **per-property merge**, and
+  awareness/presence — for both memo and whiteboard.
+- ⚠️ **Opt-in / non-gating**: the **persistence cold-rehydrate** assertions. The
+  round-trip works intermittently but the cold client occasionally closes `1006`
+  before the blob / `collaboration-fetch` flush completes, so enforcing it would
+  flake CI. These tests are **skipped by default** with a reason and run only
+  when `COLLAB_ASSERT_PERSISTENCE=true`. Enable once the persistence path is
+  reliable.
+
+## Running
+
+Stack must be up. From the repo root (pnpm workspace):
+
+```bash
+# Both collab specs:
+pnpm --filter @alkemio/test-suite-client-web exec \
+  playwright test src/functional-e2e/collab
+
+# Include the opt-in persistence assertions:
+COLLAB_ASSERT_PERSISTENCE=true pnpm --filter @alkemio/test-suite-client-web exec \
+  playwright test src/functional-e2e/collab
+```
+
+In CI they run via the `Collaboration` project in
+`config/playwright.config.nightly.ts`
+(`pnpm --filter @alkemio/test-suite-client-web run test:nightly`).
+
+## Overrides (env)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `COLLAB_BASE_URL` | `http://localhost:3000` | Apex origin (web + GraphQL + `/collab` WS). |
+| `COLLAB_ADMIN_EMAIL` | `admin@alkem.io` | Login identity. |
+| `COLLAB_ADMIN_PASSWORD` | `$AUTH_TEST_HARNESS_PASSWORD` then a fallback | Login secret. |
+| `COLLAB_GQL` | `${BASE}/api/private/non-interactive/graphql` | Fixture GraphQL endpoint. |
+| `COLLAB_ASSERT_PERSISTENCE` | _(unset → skipped)_ | `true` enforces the persistence round-trip. |

--- a/client-web/src/functional-e2e/collab/collab-auth.ts
+++ b/client-web/src/functional-e2e/collab/collab-auth.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared OIDC/BFF login + GraphQL fixture helpers for the unified
+ * collaboration service-level e2e (epic 003-unify-collab-yjs).
+ *
+ * Both the memo and the whiteboard service-level specs drive two RAW WebSocket
+ * clients straight at the unified collaboration service —
+ *
+ *     ws://localhost:3000/collab/<documentId>?type=memo
+ *     ws://localhost:3000/collab/<documentId>?type=whiteboard
+ *
+ * — and assert CRDT convergence, per-property merge, awareness and persistence at
+ * the y-protocols wire level. They do NOT touch the React UI (no ProseMirror, no
+ * Excalidraw). This is the robust, headless, CI-gating layer: it tests the
+ * WS/CRDT protocol + backend, not the editor bindings.
+ *
+ * The one place a real browser is still needed is AUTH. Post the develop OIDC
+ * cutover the server no longer accepts the `@alkemio/client-lib` Bearer token
+ * (it fails `ERR_JWS_INVALID` / `unauthenticated`). The working identity is the
+ * OIDC/BFF session cookie (`alkemio_session`), minted by driving the full
+ * browser login once with Playwright:
+ *
+ *     GET /api/auth/oidc/login?returnTo=/      (BFF kicks off OIDC)
+ *       → Hydra → Kratos /login?flow=…         (the SPA renders the password form)
+ *       → fill admin email/password → SIGN IN
+ *       → Hydra consent auto-grants → GET /api/auth/oidc/callback
+ *       → server req.session.regenerate() stamps alkemio_actor_id
+ *         and Set-Cookie alkemio_session → 302 to the app.
+ *
+ * The resulting cookie jar (notably `alkemio_session`) authenticates BOTH:
+ *   1. the GraphQL fixture calls — `Cookie:` instead of the dead Bearer; the
+ *      server's cookie-session strategy resolves it to the admin actor.
+ *   2. the two `/collab` WS clients — Traefik's `alkemio-resolve` forwardAuth
+ *      resolves `alkemio_session` to `X-Alkemio-Actor-Id`, which the collab
+ *      service consumes at the WS handshake (cookie → 101 + actor id;
+ *      Bearer/no-cookie → 401).
+ *
+ * @see ../../../../client-web/src/core/collab/UnifiedCollabProvider.ts (the prod client)
+ */
+import { chromium, type Browser } from '@playwright/test';
+
+export const ADMIN_EMAIL = process.env.COLLAB_ADMIN_EMAIL || 'admin@alkem.io';
+export const ADMIN_PASSWORD =
+  process.env.COLLAB_ADMIN_PASSWORD ||
+  process.env.AUTH_TEST_HARNESS_PASSWORD ||
+  'Alk3mio$Collab!2026';
+
+/**
+ * Apex origin the browser + WS must use. In the single-host dev stack Traefik
+ * serves the web client, the GraphQL API and the `/collab` WS on the SAME apex
+ * origin (`http://localhost:3000`). The server CORS allow-list only contains the
+ * apex, so everything must speak to :3000.
+ */
+export const BASE_URL = process.env.COLLAB_BASE_URL || 'http://localhost:3000';
+export const GQL_PRIVATE =
+  process.env.COLLAB_GQL || `${BASE_URL}/api/private/non-interactive/graphql`;
+const OIDC_LOGIN = `${BASE_URL}/api/auth/oidc/login?returnTo=/`;
+/** `ws://localhost:3000/collab` — y-websocket appends `/<documentId>?type=…`. */
+export const WS_BASE = BASE_URL.replace(/^http/, 'ws') + '/collab';
+
+/**
+ * Drives the full OIDC/BFF browser login as admin and returns a serialized
+ * `Cookie:` header (`name=value; …`) that authenticates GraphQL and rides the
+ * `/collab` WS handshake.
+ *
+ * Launches its own short-lived chromium (system Chrome channel) so the caller
+ * does not need a Playwright `page` fixture — the WS clients are raw `ws`, not a
+ * browser. Cached process-wide: one login per spec run.
+ */
+let cachedCookie: string | undefined;
+
+export async function loginAsAdminCookie(): Promise<string> {
+  if (cachedCookie) return cachedCookie;
+
+  // Default to the Playwright-bundled chromium (always installed by
+  // `playwright install` in CI). The existing base config uses the system
+  // `chrome` channel; allow opting into it (or any channel) via env for parity.
+  const channel = process.env.COLLAB_BROWSER_CHANNEL || undefined;
+  const browser: Browser = await chromium.launch({
+    ...(channel ? { channel } : {}),
+    headless: true,
+  });
+  try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto(OIDC_LOGIN, { waitUntil: 'domcontentloaded' });
+
+    // The BFF bounces to the Kratos login flow; the SPA renders the real
+    // email/password form at /login?flow=<id>.
+    await page.locator('input[name="identifier"]').waitFor({ timeout: 25000 });
+
+    const cookieBtn = page.getByRole('button', { name: /Accept All Cookies/i });
+    if (await cookieBtn.isVisible({ timeout: 4000 }).catch(() => false)) {
+      await cookieBtn.click();
+    }
+
+    await page.locator('input[name="identifier"]').fill(ADMIN_EMAIL);
+    await page.locator('input[name="password"]').fill(ADMIN_PASSWORD);
+    await page.getByRole('button', { name: /^SIGN IN$/i }).click();
+
+    // The flow completes through Hydra consent → BFF callback → app. We only
+    // need to leave the Kratos /login?flow form; the callback sets the
+    // alkemio_session cookie along the way.
+    await page
+      .waitForURL(u => !/\/login\?flow/.test(u.toString()), { timeout: 30000 })
+      .catch(() => undefined);
+    // Settle the redirect chain so the Set-Cookie from the BFF callback is in
+    // the jar before we read it.
+    await page
+      .waitForLoadState('networkidle', { timeout: 15000 })
+      .catch(() => undefined);
+
+    const cookies = await ctx.cookies();
+    const names = cookies.map(c => c.name);
+    if (!names.includes('alkemio_session')) {
+      throw new Error(
+        `OIDC/BFF login did not yield an alkemio_session cookie (got: ${names.join(', ')}). ` +
+          `Is the dev stack up at ${BASE_URL} with OIDC routed?`
+      );
+    }
+    cachedCookie = cookies.map(c => `${c.name}=${c.value}`).join('; ');
+    return cachedCookie;
+  } finally {
+    await browser.close();
+  }
+}
+
+/** POSTs a GraphQL operation as admin (cookie-authenticated). */
+export async function gql<T = any>(
+  cookie: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const res = await fetch(GQL_PRIVATE, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie,
+      origin: BASE_URL,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = (await res.json()) as { data?: T; errors?: unknown };
+  if (json.errors) {
+    throw new Error(`GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data as T;
+}

--- a/client-web/src/functional-e2e/collab/collab-fixture.ts
+++ b/client-web/src/functional-e2e/collab/collab-fixture.ts
@@ -1,0 +1,164 @@
+/**
+ * GraphQL fixtures for the unified collaboration service-level e2e
+ * (epic 003-unify-collab-yjs).
+ *
+ * A freshly-seeded DB has no spaces, so each spec creates its own fixture as
+ * global admin:
+ *
+ *   createSpace (on the admin's account)
+ *     → space.collaboration.calloutsSet.id
+ *   createCalloutOnCalloutsSet (framing.type = MEMO | WHITEBOARD)
+ *     → callout.framing.memo.id        (memo collaboration-document UUID)
+ *     → callout.framing.whiteboard.id  (whiteboard collaboration-document UUID)
+ *
+ * That UUID is exactly the `<documentId>` the prod `UnifiedCollabProvider` uses
+ * to open `ws://localhost:3000/collab/<documentId>?type=<memo|whiteboard>` — so
+ * the service-level WS clients open the identical room a real browser would.
+ */
+import { gql } from './collab-auth';
+
+export interface CollabFixture {
+  spaceNameId: string;
+  calloutNameId: string;
+  /** The collaboration-document UUID — the WS room id. */
+  documentId: string;
+}
+
+let cachedAccountId: string | undefined;
+
+async function adminAccountId(cookie: string): Promise<string> {
+  if (cachedAccountId) return cachedAccountId;
+  const data = await gql<{ me: { user: { account: { id: string } } } }>(
+    cookie,
+    'query { me { user { account { id } } } }'
+  );
+  if (!data.me?.user) {
+    throw new Error(
+      'me.user resolved to null — the OIDC/BFF cookie did not authenticate as admin'
+    );
+  }
+  cachedAccountId = data.me.user.account.id;
+  return cachedAccountId;
+}
+
+async function createSpaceWithCalloutsSet(
+  cookie: string,
+  label: string
+): Promise<{ spaceNameId: string; calloutsSetID: string }> {
+  const accountID = await adminAccountId(cookie);
+  const sfx = Date.now();
+  const nameID = `${label}-${sfx}`.slice(0, 25);
+
+  const space = await gql<{
+    createSpace: {
+      nameID: string;
+      collaboration: { calloutsSet: { id: string } };
+    };
+  }>(
+    cookie,
+    `mutation CreateSpace($spaceData: CreateSpaceOnAccountInput!) {
+      createSpace(spaceData: $spaceData) {
+        nameID
+        collaboration { calloutsSet { id } }
+      }
+    }`,
+    {
+      spaceData: {
+        accountID,
+        nameID,
+        about: { profileData: { displayName: `${label} ${sfx}` } },
+        collaborationData: { addTutorialCallouts: false, calloutsSetData: {} },
+      },
+    }
+  );
+
+  return {
+    spaceNameId: space.createSpace.nameID,
+    calloutsSetID: space.createSpace.collaboration.calloutsSet.id,
+  };
+}
+
+/** Creates a Space + a single MEMO-framed callout; returns the memo room id. */
+export async function createMemoFixture(cookie: string): Promise<CollabFixture> {
+  const { spaceNameId, calloutsSetID } = await createSpaceWithCalloutsSet(
+    cookie,
+    'memo-e2e'
+  );
+  const sfx = Date.now();
+
+  const callout = await gql<{
+    createCalloutOnCalloutsSet: {
+      nameID: string;
+      framing: { memo: { id: string } };
+    };
+  }>(
+    cookie,
+    `mutation CreateCallout($calloutData: CreateCalloutOnCalloutsSetInput!) {
+      createCalloutOnCalloutsSet(calloutData: $calloutData) {
+        nameID
+        framing { type memo { id } }
+      }
+    }`,
+    {
+      calloutData: {
+        calloutsSetID,
+        framing: {
+          profile: { displayName: `Memo Callout ${sfx}` },
+          type: 'MEMO',
+          memo: { profile: { displayName: `E2E Memo ${sfx}` }, markdown: '' },
+        },
+      },
+    }
+  );
+
+  return {
+    spaceNameId,
+    calloutNameId: callout.createCalloutOnCalloutsSet.nameID,
+    documentId: callout.createCalloutOnCalloutsSet.framing.memo.id,
+  };
+}
+
+/** Creates a Space + a single WHITEBOARD-framed callout; returns the whiteboard room id. */
+export async function createWhiteboardFixture(
+  cookie: string
+): Promise<CollabFixture> {
+  const { spaceNameId, calloutsSetID } = await createSpaceWithCalloutsSet(
+    cookie,
+    'wb-e2e'
+  );
+  const sfx = Date.now();
+
+  const callout = await gql<{
+    createCalloutOnCalloutsSet: {
+      nameID: string;
+      framing: { whiteboard: { id: string } };
+    };
+  }>(
+    cookie,
+    `mutation CreateCallout($calloutData: CreateCalloutOnCalloutsSetInput!) {
+      createCalloutOnCalloutsSet(calloutData: $calloutData) {
+        nameID
+        framing { type whiteboard { id } }
+      }
+    }`,
+    {
+      calloutData: {
+        calloutsSetID,
+        framing: {
+          profile: { displayName: `Whiteboard Callout ${sfx}` },
+          type: 'WHITEBOARD',
+          whiteboard: {
+            profile: { displayName: `E2E Whiteboard ${sfx}` },
+            content: '{"elements":[],"appState":{},"files":{}}',
+          },
+        },
+      },
+    }
+  );
+
+  return {
+    spaceNameId,
+    calloutNameId: callout.createCalloutOnCalloutsSet.nameID,
+    documentId: callout.createCalloutOnCalloutsSet.framing.whiteboard.id,
+  };
+}

--- a/client-web/src/functional-e2e/collab/collab-ws.ts
+++ b/client-web/src/functional-e2e/collab/collab-ws.ts
@@ -1,0 +1,137 @@
+/**
+ * Raw-WebSocket Yjs client helpers for the unified collaboration service-level
+ * e2e (epic 003-unify-collab-yjs).
+ *
+ * Each "client" is a `y-websocket` WebsocketProvider driving a Y.Doc straight at
+ * the unified collaboration service over the canonical y-protocols envelope
+ * (byte 0 sync / byte 1 awareness / byte 2 ephemeral / byte 3 control — see
+ * `UnifiedCollabProvider.ts` / epic contracts/ws-protocol.md). The Alkemio
+ * `alkemio_session` cookie rides the handshake via the `ws` `Cookie` header, so
+ * Traefik's forwardAuth resolves the actor exactly as it does for the browser.
+ *
+ * No browser, no editor binding — this is the protocol/backend layer.
+ */
+import WebSocket from 'ws';
+import { WebsocketProvider } from 'y-websocket';
+import type { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+import { BASE_URL, WS_BASE } from './collab-auth';
+
+export interface CollabClient {
+  readonly doc: Y.Doc;
+  readonly provider: WebsocketProvider;
+  readonly awareness: Awareness;
+  destroy(): void;
+}
+
+const SYNC_TIMEOUT_MS = 15000;
+
+/**
+ * Connects a fresh Yjs client to `<WS_BASE>/<documentId>?type=<type>` carrying
+ * `cookie` on the WS handshake, and resolves once the provider reports `synced`
+ * (initial server state applied).
+ */
+export function connectCollabClient(
+  documentId: string,
+  type: 'memo' | 'whiteboard',
+  cookie: string,
+  label = 'client'
+): Promise<CollabClient> {
+  // y-websocket appends `/<roomname>` to the base URL and the params as a query
+  // string → `<WS_BASE>/<documentId>?type=<type>`. The cookie/origin ride the
+  // handshake via the `ws` options (browsers do this implicitly, same-origin).
+  // `ws` is structurally a WebSocket but its TS types omit some DOM members, so
+  // cast through `unknown` to the constructor shape y-websocket expects.
+  const WebSocketPolyfill = class extends WebSocket {
+    constructor(address: string, protocols?: string | string[]) {
+      super(address, protocols, {
+        headers: { cookie, origin: BASE_URL },
+      });
+    }
+  } as unknown as typeof globalThis.WebSocket;
+
+  const doc = new Y.Doc();
+  return new Promise<CollabClient>((resolve, reject) => {
+    const provider = new WebsocketProvider(WS_BASE, documentId, doc, {
+      params: { type },
+      WebSocketPolyfill,
+      // The unified service is the single source of truth; no cross-tab channel.
+      disableBc: true,
+      connect: true,
+    });
+
+    const timer = setTimeout(() => {
+      provider.destroy();
+      reject(new Error(`${label}: did not sync within ${SYNC_TIMEOUT_MS}ms`));
+    }, SYNC_TIMEOUT_MS);
+
+    // y-websocket@3 emits 'sync' (boolean) when the initial server state applied.
+    provider.on('sync', (isSynced: boolean) => {
+      if (isSynced) {
+        clearTimeout(timer);
+        resolve({
+          doc,
+          provider,
+          awareness: provider.awareness,
+          destroy: () => provider.destroy(),
+        });
+      }
+    });
+  });
+}
+
+/** Resolves once `predicate()` is true, polled on the doc, or rejects on timeout. */
+export function waitForDoc(
+  doc: Y.Doc,
+  predicate: () => boolean,
+  timeoutMs = 8000,
+  what = 'condition'
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (predicate()) return resolve();
+    const onUpdate = () => {
+      if (predicate()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`waitForDoc timed out waiting for ${what}`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      doc.off('update', onUpdate);
+    };
+    doc.on('update', onUpdate);
+  });
+}
+
+/** Resolves once `predicate()` is true, polled on awareness changes, or rejects. */
+export function waitForAwareness(
+  awareness: Awareness,
+  predicate: () => boolean,
+  timeoutMs = 5000,
+  what = 'awareness condition'
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (predicate()) return resolve();
+    const onChange = () => {
+      if (predicate()) {
+        cleanup();
+        resolve();
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`waitForAwareness timed out waiting for ${what}`));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      awareness.off('change', onChange);
+    };
+    awareness.on('change', onChange);
+  });
+}
+
+export const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));

--- a/client-web/src/functional-e2e/collab/memo-collaboration.spec.ts
+++ b/client-web/src/functional-e2e/collab/memo-collaboration.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Memo live-collaboration — SERVICE LEVEL (epic 003-unify-collab-yjs).
+ *
+ * Proves the unified collaboration service converges + presents + persists for a
+ * MEMO document at the y-protocols wire level, with NO React/ProseMirror UI.
+ * Two raw `y-websocket` clients open the same room
+ * (`ws://localhost:3000/collab/<memoId>?type=memo`) carrying the admin OIDC/BFF
+ * session cookie on the handshake, and exchange Yjs sync + awareness.
+ *
+ * The memo binds y-prosemirror to the Y.Doc XmlFragment named "default" (the
+ * ProseMirror top node); the service is agnostic to that — it just relays/persists
+ * the CRDT. So we drive that same fragment directly.
+ *
+ * Assertions:
+ *   1. Convergence — text inserted by A appears in B (CRDT relay).
+ *   2. Awareness/presence — A's awareness state is visible to B.
+ *   3. Persistence round-trip — after A+B drop, a cold client C rehydrates the
+ *      text (server collaboration-fetch + file-service blob). Opt-in: gated
+ *      behind COLLAB_ASSERT_PERSISTENCE because the cold-rehydrate timing is
+ *      currently non-deterministic on the local dev stack (see README).
+ *
+ * Requires the local dev stack up (gateway :3000 → unified collab service +
+ * server BFF). Run:
+ *   pnpm --filter @alkemio/test-suite-client-web exec \
+ *     playwright test src/functional-e2e/collab/memo-collaboration.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+import * as Y from 'yjs';
+import { loginAsAdminCookie } from './collab-auth';
+import { createMemoFixture, type CollabFixture } from './collab-fixture';
+import {
+  connectCollabClient,
+  waitForDoc,
+  waitForAwareness,
+  sleep,
+  type CollabClient,
+} from './collab-ws';
+
+const ASSERT_PERSISTENCE = process.env.COLLAB_ASSERT_PERSISTENCE === 'true';
+const CONVERGENCE_TIMEOUT = 10000;
+const AWARENESS_TIMEOUT = 5000;
+const AUTOSAVE_DEBOUNCE_MS = 8000;
+
+test.describe('Memo collaboration — service level (003-unify-collab-yjs)', () => {
+  // OIDC login + two WS clients + a cold reload is heavier than the default.
+  test.describe.configure({ timeout: 180000 });
+
+  let cookie: string;
+  let fixture: CollabFixture;
+
+  test.beforeAll(async () => {
+    cookie = await loginAsAdminCookie();
+    fixture = await createMemoFixture(cookie);
+    console.log(
+      `[memo-service] memoId=${fixture.documentId}\n` +
+        `              WS=ws://localhost:3000/collab/${fixture.documentId}?type=memo`
+    );
+  });
+
+  test('convergence + awareness over the unified collab service', async () => {
+    let a: CollabClient | undefined;
+    let b: CollabClient | undefined;
+    try {
+      a = await connectCollabClient(fixture.documentId, 'memo', cookie, 'A');
+      b = await connectCollabClient(fixture.documentId, 'memo', cookie, 'B');
+
+      // --- Assertion 2: awareness/presence A → B ---
+      a.awareness.setLocalState({ user: { name: 'memo-client-A' } });
+      await waitForAwareness(
+        b.awareness,
+        () => b!.awareness.getStates().size >= 2,
+        AWARENESS_TIMEOUT,
+        'A presence visible to B'
+      );
+      expect(
+        b.awareness.getStates().size,
+        'B should see A in the awareness/presence map'
+      ).toBeGreaterThanOrEqual(2);
+
+      // --- Assertion 1: CRDT convergence A → B ---
+      const marker = `memo-sync-${Date.now()}`;
+      const fragA = a.doc.getXmlFragment('default');
+      const para = new Y.XmlElement('paragraph');
+      para.insert(0, [new Y.XmlText(marker)]);
+      fragA.insert(fragA.length, [para]);
+
+      await waitForDoc(
+        b.doc,
+        () => b!.doc.getXmlFragment('default').toString().includes(marker),
+        CONVERGENCE_TIMEOUT,
+        'text typed in A to converge into B'
+      );
+      expect(
+        b.doc.getXmlFragment('default').toString(),
+        'text inserted in A should converge into B via the unified collab service'
+      ).toContain(marker);
+    } finally {
+      a?.destroy();
+      b?.destroy();
+    }
+  });
+
+  test('persistence round-trip (cold reload rehydrates)', async () => {
+    test.skip(
+      !ASSERT_PERSISTENCE,
+      'Persistence cold-rehydrate is currently non-deterministic on the local ' +
+        'dev stack (the unified collab room sometimes closes 1006 before the ' +
+        'blob/collaboration-fetch flush completes). Set COLLAB_ASSERT_PERSISTENCE=true ' +
+        'to enforce once the persistence path is reliable.'
+    );
+
+    let a: CollabClient | undefined;
+    let b: CollabClient | undefined;
+    let c: CollabClient | undefined;
+    const marker = `memo-persist-${Date.now()}`;
+    try {
+      a = await connectCollabClient(fixture.documentId, 'memo', cookie, 'A');
+      b = await connectCollabClient(fixture.documentId, 'memo', cookie, 'B');
+
+      const fragA = a.doc.getXmlFragment('default');
+      const para = new Y.XmlElement('paragraph');
+      para.insert(0, [new Y.XmlText(marker)]);
+      fragA.insert(fragA.length, [para]);
+
+      await waitForDoc(
+        b.doc,
+        () => b!.doc.getXmlFragment('default').toString().includes(marker),
+        CONVERGENCE_TIMEOUT,
+        'marker to converge before persistence'
+      );
+
+      // Let the server-side autosave debounce flush to file-service + server.
+      await sleep(AUTOSAVE_DEBOUNCE_MS);
+      a.destroy();
+      b.destroy();
+      a = b = undefined;
+      // Let the room fully flush + release before a cold client reconnects.
+      await sleep(6000);
+
+      c = await connectCollabClient(fixture.documentId, 'memo', cookie, 'C');
+      await waitForDoc(
+        c.doc,
+        () => c!.doc.getXmlFragment('default').toString().includes(marker),
+        CONVERGENCE_TIMEOUT,
+        'cold reload to rehydrate persisted memo content'
+      );
+      expect(
+        c.doc.getXmlFragment('default').toString(),
+        'cold reload should rehydrate persisted memo content (file-service blob + collaboration-fetch)'
+      ).toContain(marker);
+    } finally {
+      a?.destroy();
+      b?.destroy();
+      c?.destroy();
+    }
+  });
+});

--- a/client-web/src/functional-e2e/collab/whiteboard-collaboration.spec.ts
+++ b/client-web/src/functional-e2e/collab/whiteboard-collaboration.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Whiteboard live-collaboration — SERVICE LEVEL (epic 003-unify-collab-yjs).
+ *
+ * Mirrors the memo service-level spec for a WHITEBOARD document, with NO
+ * Excalidraw UI and WITHOUT importing the @alkemio/excalidraw-yjs-binding — it
+ * tests the WS/CRDT layer, not the binding. Two raw `y-websocket` clients open
+ * the same room (`ws://localhost:3000/collab/<whiteboardId>?type=whiteboard`)
+ * carrying the admin OIDC/BFF session cookie on the handshake.
+ *
+ * Yjs scene schema (the convention the binding writes and the service relays):
+ *   - top-level Y.Map "elements" — keyed by element id → a nested per-property
+ *     Y.Map ({ id, type, x, y, width, strokeColor, backgroundColor, ... })
+ *   - top-level Y.Map "files"
+ *   - top-level Y.Map "appState"
+ *
+ * The PER-PROPERTY nested Y.Map is the whole point: two clients editing
+ * DIFFERENT properties of the SAME element merge field-by-field — both survive,
+ * NOT last-write-wins. That is the headline correctness win of the epic and is
+ * impossible with a coarse "serialize the whole scene" approach.
+ *
+ * Assertions:
+ *   1. Convergence — an element seeded by A appears in B.
+ *   2. PER-PROPERTY MERGE (headline) — A sets element.x, B sets the SAME
+ *      element's strokeColor concurrently → BOTH properties survive on BOTH
+ *      clients (NOT last-write-wins).
+ *   3. Awareness/presence — A's awareness state is visible to B.
+ *   4. Persistence round-trip — cold client C rehydrates the merged element.
+ *      Opt-in: gated behind COLLAB_ASSERT_PERSISTENCE (cold-rehydrate timing is
+ *      currently non-deterministic on the local dev stack — see README).
+ *
+ * Requires the local dev stack up (gateway :3000 → unified collab service +
+ * server BFF). Run:
+ *   pnpm --filter @alkemio/test-suite-client-web exec \
+ *     playwright test src/functional-e2e/collab/whiteboard-collaboration.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+import * as Y from 'yjs';
+import { loginAsAdminCookie } from './collab-auth';
+import { createWhiteboardFixture, type CollabFixture } from './collab-fixture';
+import {
+  connectCollabClient,
+  waitForDoc,
+  waitForAwareness,
+  sleep,
+  type CollabClient,
+} from './collab-ws';
+
+const ASSERT_PERSISTENCE = process.env.COLLAB_ASSERT_PERSISTENCE === 'true';
+const CONVERGENCE_TIMEOUT = 10000;
+const MERGE_TIMEOUT = 10000;
+const AWARENESS_TIMEOUT = 5000;
+const AUTOSAVE_DEBOUNCE_MS = 8000;
+
+/** Seeds one rectangle element into the "elements" Y.Map as a per-property Y.Map. */
+function seedElement(doc: Y.Doc, id: string): void {
+  const elements = doc.getMap<Y.Map<unknown>>('elements');
+  doc.transact(() => {
+    const el = new Y.Map<unknown>();
+    el.set('id', id);
+    el.set('type', 'rectangle');
+    el.set('x', 10);
+    el.set('y', 20);
+    el.set('width', 100);
+    el.set('height', 50);
+    el.set('strokeColor', '#000000');
+    el.set('backgroundColor', 'transparent');
+    elements.set(id, el);
+  });
+}
+
+function getElement(doc: Y.Doc, id: string): Y.Map<unknown> | undefined {
+  return doc.getMap<Y.Map<unknown>>('elements').get(id);
+}
+
+test.describe('Whiteboard collaboration — service level (003-unify-collab-yjs)', () => {
+  test.describe.configure({ timeout: 180000 });
+
+  let cookie: string;
+  let fixture: CollabFixture;
+
+  test.beforeAll(async () => {
+    cookie = await loginAsAdminCookie();
+    fixture = await createWhiteboardFixture(cookie);
+    console.log(
+      `[wb-service] whiteboardId=${fixture.documentId}\n` +
+        `             WS=ws://localhost:3000/collab/${fixture.documentId}?type=whiteboard`
+    );
+  });
+
+  test('convergence + per-property merge + awareness over the unified collab service', async () => {
+    let a: CollabClient | undefined;
+    let b: CollabClient | undefined;
+    try {
+      a = await connectCollabClient(fixture.documentId, 'whiteboard', cookie, 'A');
+      b = await connectCollabClient(fixture.documentId, 'whiteboard', cookie, 'B');
+
+      // --- Assertion 3: awareness/presence A → B ---
+      a.awareness.setLocalState({ user: { name: 'wb-client-A' } });
+      await waitForAwareness(
+        b.awareness,
+        () => b!.awareness.getStates().size >= 2,
+        AWARENESS_TIMEOUT,
+        'A presence visible to B'
+      );
+      expect(
+        b.awareness.getStates().size,
+        'B should see A in the awareness/presence map'
+      ).toBeGreaterThanOrEqual(2);
+
+      // --- Assertion 1: convergence — A seeds an element, B sees it ---
+      const elId = `wb-el-${Date.now()}`;
+      seedElement(a.doc, elId);
+      await waitForDoc(
+        b.doc,
+        () => getElement(b!.doc, elId) !== undefined,
+        CONVERGENCE_TIMEOUT,
+        'element seeded by A to converge into B'
+      );
+      const elB = getElement(b.doc, elId);
+      expect(elB, 'element seeded by A should converge into B').toBeDefined();
+
+      // --- Assertion 2: PER-PROPERTY MERGE (headline) ---
+      // A and B concurrently edit DIFFERENT properties of the SAME element.
+      a.doc.transact(() => {
+        getElement(a!.doc, elId)!.set('x', 999);
+      });
+      b.doc.transact(() => {
+        elB!.set('strokeColor', '#ff0000');
+      });
+
+      // Both edits must survive on BOTH clients — NOT last-write-wins.
+      const merged = (doc: Y.Doc) => {
+        const el = getElement(doc, elId);
+        return !!el && el.get('x') === 999 && el.get('strokeColor') === '#ff0000';
+      };
+      await waitForDoc(a.doc, () => merged(a!.doc), MERGE_TIMEOUT, 'A to hold both merged properties');
+      await waitForDoc(b.doc, () => merged(b!.doc), MERGE_TIMEOUT, 'B to hold both merged properties');
+
+      const finalA = getElement(a.doc, elId)!;
+      const finalB = getElement(b.doc, elId)!;
+      // A's own property survived A's view AND B's concurrent edit landed on A.
+      expect(finalA.get('x'), "A's x edit must survive").toBe(999);
+      expect(finalA.get('strokeColor'), "B's concurrent strokeColor edit must survive on A (per-property merge, not last-write-wins)").toBe('#ff0000');
+      // ...and symmetrically on B.
+      expect(finalB.get('x'), "A's concurrent x edit must survive on B (per-property merge, not last-write-wins)").toBe(999);
+      expect(finalB.get('strokeColor'), "B's strokeColor edit must survive").toBe('#ff0000');
+      // Untouched properties remain intact.
+      expect(finalA.get('type'), 'untouched property must remain').toBe('rectangle');
+      expect(finalB.get('height'), 'untouched property must remain').toBe(50);
+    } finally {
+      a?.destroy();
+      b?.destroy();
+    }
+  });
+
+  test('persistence round-trip (cold reload rehydrates merged element)', async () => {
+    test.skip(
+      !ASSERT_PERSISTENCE,
+      'Persistence cold-rehydrate is currently non-deterministic on the local ' +
+        'dev stack (the unified collab room sometimes closes 1006 before the ' +
+        'blob/collaboration-fetch flush completes). Set COLLAB_ASSERT_PERSISTENCE=true ' +
+        'to enforce once the persistence path is reliable.'
+    );
+
+    let a: CollabClient | undefined;
+    let b: CollabClient | undefined;
+    let c: CollabClient | undefined;
+    const elId = `wb-persist-${Date.now()}`;
+    try {
+      a = await connectCollabClient(fixture.documentId, 'whiteboard', cookie, 'A');
+      b = await connectCollabClient(fixture.documentId, 'whiteboard', cookie, 'B');
+
+      seedElement(a.doc, elId);
+      await waitForDoc(
+        b.doc,
+        () => getElement(b!.doc, elId) !== undefined,
+        CONVERGENCE_TIMEOUT,
+        'element to converge before merge'
+      );
+      a.doc.transact(() => getElement(a!.doc, elId)!.set('x', 999));
+      b.doc.transact(() => getElement(b!.doc, elId)!.set('strokeColor', '#ff0000'));
+
+      const merged = (doc: Y.Doc) => {
+        const el = getElement(doc, elId);
+        return !!el && el.get('x') === 999 && el.get('strokeColor') === '#ff0000';
+      };
+      await waitForDoc(a.doc, () => merged(a!.doc), MERGE_TIMEOUT, 'A merge before persistence');
+
+      await sleep(AUTOSAVE_DEBOUNCE_MS);
+      a.destroy();
+      b.destroy();
+      a = b = undefined;
+      await sleep(6000);
+
+      c = await connectCollabClient(fixture.documentId, 'whiteboard', cookie, 'C');
+      await waitForDoc(
+        c.doc,
+        () => merged(c!.doc),
+        CONVERGENCE_TIMEOUT,
+        'cold reload to rehydrate the persisted merged element'
+      );
+      const finalC = getElement(c.doc, elId)!;
+      expect(finalC.get('x'), 'persisted x').toBe(999);
+      expect(finalC.get('strokeColor'), 'persisted merged strokeColor').toBe('#ff0000');
+    } finally {
+      a?.destroy();
+      b?.destroy();
+      c?.destroy();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,24 @@ importers:
       graphql-upload:
         specifier: ^17.0.0
         version: 17.0.0(graphql@16.12.0)
+      lib0:
+        specifier: ^0.2.117
+        version: 0.2.117
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+      y-protocols:
+        specifier: ^1.0.6
+        version: 1.0.7(yjs@13.6.31)
+      y-websocket:
+        specifier: ^3.0.0
+        version: 3.0.0(yjs@13.6.31)
+      yjs:
+        specifier: ^13.6.27
+        version: 13.6.31
     devDependencies:
       '@graphql-codegen/add':
         specifier: ^5.0.3
@@ -63,6 +78,9 @@ importers:
       '@types/node':
         specifier: ^20.13.1
         version: 20.19.33
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: 8.18.1
         version: 8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3)
@@ -3032,6 +3050,9 @@ packages:
     peerDependencies:
       ws: '*'
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
@@ -3100,6 +3121,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -4243,6 +4269,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
+  y-websocket@3.0.0:
+    resolution: {integrity: sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.5.6
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -4276,6 +4314,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -7759,6 +7801,8 @@ snapshots:
     dependencies:
       ws: 8.19.0
 
+  isomorphic.js@0.2.5: {}
+
   jackspeak@4.2.3:
     dependencies:
       '@isaacs/cliui': 9.0.0
@@ -7813,6 +7857,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lilconfig@3.1.3: {}
 
@@ -9000,6 +9048,17 @@ snapshots:
 
   ws@8.19.0: {}
 
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
+  y-websocket@3.0.0(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
@@ -9040,6 +9099,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
## What

Promotes the unified-collaboration e2e from an uncommitted debugging `.mjs` into the `test-suites` standard `functional-e2e` structure as a **committed, CI-gating** suite covering **both memo and whiteboard** (epic `003-unify-collab-yjs`, SC-009 / WS-F).

## Approach — service level (protocol/backend)

Two raw `y-websocket` clients per document open `ws://localhost:3000/collab/<id>?type=<memo|whiteboard>` carrying the admin OIDC/BFF session cookie on the handshake, exchanging Yjs sync + awareness. **No React/ProseMirror/Excalidraw UI.** The whiteboard test mirrors the `@alkemio/excalidraw-yjs-binding` Yjs scene schema (`elements`/`files`/`appState`, per-property nested `Y.Map`) **without importing it** — it tests the WS/CRDT layer, not the binding.

The OIDC/BFF login (one short-lived Playwright Chrome → `alkemio_session` cookie) is extracted into a reusable helper and shared by both specs.

## Scenarios & assertions

**Memo** (`memo-collaboration.spec.ts`):
- CRDT convergence A → B
- Awareness / presence
- Persistence round-trip *(opt-in, see below)*

**Whiteboard** (`whiteboard-collaboration.spec.ts`):
- Convergence A → B
- **Per-property merge (headline)** — A edits `element.x`, B edits the **same** element's `strokeColor` concurrently → **both survive on both clients, NOT last-write-wins**; untouched props intact
- Awareness / presence
- Persistence round-trip *(opt-in)*

## Files

| File | Role |
|------|------|
| `collab/collab-auth.ts` | OIDC/BFF admin login → cookie + cookie-authed GraphQL |
| `collab/collab-fixture.ts` | `createMemoFixture` / `createWhiteboardFixture` via GraphQL |
| `collab/collab-ws.ts` | raw-WS Yjs client + `waitForDoc` / `waitForAwareness` |
| `collab/memo-collaboration.spec.ts` | memo scenarios |
| `collab/whiteboard-collaboration.spec.ts` | whiteboard scenarios |
| `collab/README.md` | scenarios, headless-vs-live, run instructions |

## CI wiring

- New **`Collaboration`** project in `config/playwright.config.nightly.ts` (runs via `pnpm run test:nightly`).
- Adds `yjs` / `y-websocket` / `y-protocols` / `lib0` / `ws` (+ `@types/ws`) to `client-web` so `pnpm install --frozen-lockfile` provides them in CI (lockfile updated).

## Proven headless now vs. live-only

Against the running local dev stack:
- ✅ **Deterministic / gating**: convergence, **per-property merge**, awareness — both memo and whiteboard. Default run: **2 passed / 2 skipped (18s)**.
- ⚠️ **Opt-in / non-gating**: the **persistence cold-rehydrate** assertions. The round-trip works intermittently but the cold client occasionally closes `1006` before the blob / `collaboration-fetch` flush completes, so enforcing it would flake CI. Skipped by default with a reason; run with `COLLAB_ASSERT_PERSISTENCE=true`. Enable once the persistence path is reliable.

## Requires (to execute)

The local dev stack must be up: gateway `localhost:3000` → unified collaboration service + server BFF (forward-auth + OIDC login). Tests scaffold fully and lint/typecheck without it; the live assertions need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end tests for memo and whiteboard collaboration, verifying real-time synchronization, user presence tracking, and data persistence.

* **Chores**
  * Added test infrastructure, configuration, and dependencies for collaboration service testing.

* **Documentation**
  * Added documentation detailing collaboration test suite structure and execution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->