### PR TITLE
test(e2e): Contributors callout coverage + community-tab realignment (client-web#9928)

### DIFF
--- a/client-web/src/functional-e2e/contributors-callout/0.1contributors-callout.spec.ts
+++ b/client-web/src/functional-e2e/contributors-callout/0.1contributors-callout.spec.ts
@@ -106,7 +106,7 @@ adminFixture.test.describe.serial('Contributors Callout - Admin', () => {
       await expect(cc.framingContributorsOption).toBeVisible();
 
       // Abandon the draft without persisting.
-      await page.getByRole('button', { name: 'Close' }).first().click();
+      await cc.closeButton.click();
       await expect(
         page.getByRole('heading', { name: title })
       ).toHaveCount(0);
@@ -250,6 +250,34 @@ adminFixture.test.describe.serial('Contributors Callout - Admin', () => {
       await expect(col.typeSwitchTab('People')).toHaveCount(0);
       await expect(col.typeSwitchTab('Organizations')).toHaveCount(0);
       await expect(col.typeSwitchTab('Virtual Contributors')).toHaveCount(0);
+    }
+  );
+
+  // AC1/US1 — a non-default `defaultType` opens the collection on that segment
+  // (not People), confirming the create-form default-type override is honoured.
+  adminFixture.test(
+    '1.9 A non-default defaultType opens the collection on that segment',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(60_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+
+      const orgDefault = `Org Default ${Date.now()}`;
+      await cc.createContributorsCallout(orgDefault, {
+        defaultType: 'Organizations',
+      });
+
+      const col = cc.collection(orgDefault);
+      await expect(col.region).toBeVisible();
+      // Opens on the configured default type (Organizations), not People.
+      await expect(col.typeSwitchTab('Organizations')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      await expect(col.typeSwitchTab('People')).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
     }
   );
 });

--- a/client-web/src/functional-e2e/contributors-callout/0.1contributors-callout.spec.ts
+++ b/client-web/src/functional-e2e/contributors-callout/0.1contributors-callout.spec.ts
@@ -1,0 +1,289 @@
+// Feature: Contributors callout (client-web feature 008 / story client-web#9928)
+// Spec: agents-hq/specs/009-contributors-callout-ui-tests/spec.md
+//
+// An admin-only, collaboration-only callout that renders a space's contributors
+// (People / Organizations / Virtual Contributors) as a self-updating card
+// collection with a segmented type switch, per-type counts, client-side name
+// search, an empty state, and a List/Map view toggle (users & orgs; VCs are
+// list-only). This suite exercises those behaviours end-to-end against a live
+// CRD build.
+
+import { TestUser } from '@alkemio/tests-lib/common/enums/test.user';
+import { TestScenarioConfig } from '@alkemio/tests-lib/scenario/config/test-scenario-config';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { TestScenarioFactory } from '@alkemio/tests-lib/scenario/TestScenarioFactory';
+import { TestUserManager } from '@alkemio/tests-lib';
+import { expect } from '@playwright/test';
+import { createAuthenticatedSessionFixture } from '../fixtures/authenticated-session.fixture';
+import { ContributorsCalloutPage } from './pages';
+
+const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+
+const scenarioConfig: TestScenarioConfig = {
+  name: 'contributors-callout',
+  space: {
+    about: {
+      profile: { displayName: 'Contributors Callout Test Space' },
+    },
+    collaboration: {
+      addTutorialCallouts: false,
+      addPostCollectionCallout: false,
+      addWhiteboardCallout: false,
+    },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [TestUser.SPACE_MEMBER, TestUser.SPACE_ADMIN],
+    },
+  },
+};
+
+let baseScenario: OrganizationWithSpaceModel;
+
+const adminFixture = createAuthenticatedSessionFixture({
+  storageStateName: 'contributors-callout-admin.json',
+  cleanupAfterTests: process.env.cleanupAfterTests === 'true',
+});
+
+const memberFixture = createAuthenticatedSessionFixture({
+  storageStateName: 'contributors-callout-member.json',
+  cleanupAfterTests: process.env.cleanupAfterTests === 'true',
+});
+
+// A single Contributors callout reused across the read-only rendering tests, so
+// exactly one `region "Contributors"` exists on the page at a time.
+const MAIN = `Contributors ${Date.now()}`;
+
+adminFixture.test.describe.serial('Contributors Callout - Admin', () => {
+  adminFixture.test.beforeAll(async ({ browser }) => {
+    adminFixture.test.setTimeout(60_000);
+    baseScenario = await TestScenarioFactory.createBaseScenario(scenarioConfig);
+    await adminFixture.setupAuthentication(
+      browser,
+      TestUserManager.users.spaceAdmin.email
+    );
+  });
+
+  adminFixture.test.afterAll(async () => {
+    adminFixture.test.setTimeout(30_000);
+    await adminFixture.teardownAuthentication();
+  });
+
+  // AC — "Contributors" is offered as a concrete, admin-only framing option.
+  adminFixture.test(
+    '1.1 Admin is offered the Contributors framing option',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(30_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      await expect(cc.addCalloutButton).toBeVisible();
+      await cc.openCreateForm();
+      await expect(cc.framingContributorsOption).toBeVisible();
+    }
+  );
+
+  // AC3 — saving with zero contributor types is blocked.
+  adminFixture.test(
+    '1.2 Zero contributor types blocks save with a validation error',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(30_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      const title = `Zero Types ${Date.now()}`;
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      await cc.openCreateForm();
+      await cc.selectContributorsFraming();
+      await cc.titleInput.fill(title);
+
+      // Deselect all three types.
+      await cc.setTypeSelected('People', false);
+      await cc.setTypeSelected('Organizations', false);
+      await cc.setTypeSelected('Virtual Contributors', false);
+
+      // Submit is gated by submit-time validation: attempting to post surfaces
+      // the "at least one type" error and does NOT create the callout.
+      await cc.postButton.click();
+      await expect(cc.typesRequiredError).toBeVisible();
+      // Still on the create form; nothing was persisted.
+      await expect(cc.framingContributorsOption).toBeVisible();
+
+      // Abandon the draft without persisting.
+      await page.getByRole('button', { name: 'Close' }).first().click();
+      await expect(
+        page.getByRole('heading', { name: title })
+      ).toHaveCount(0);
+    }
+  );
+
+  // AC1/AC2 — default settings render users, organizations and virtual
+  // contributors, with a segmented type switch that opens on the default type.
+  adminFixture.test(
+    '1.3 Default settings render all three types with a segmented switch',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(45_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+
+      await cc.createContributorsCallout(MAIN);
+
+      // Scope to the callout we created — a migrated env may also carry an
+      // auto-provisioned default Contributors callout on the same page.
+      const col = cc.collection(MAIN);
+      await expect(col.region).toBeVisible();
+      // All three type segments present, each carrying its per-type count.
+      await expect(col.typeSwitchTab('People')).toBeVisible();
+      await expect(col.typeSwitchTab('Organizations')).toBeVisible();
+      await expect(col.typeSwitchTab('Virtual Contributors')).toBeVisible();
+      // Opens on the configured default type (People / users).
+      await expect(col.typeSwitchTab('People')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    }
+  );
+
+  // AC2/AC7 — switching type scopes the view; the VC segment is list-only and,
+  // with no virtual contributors, shows the empty state (not an error).
+  adminFixture.test(
+    '1.4 Virtual Contributors segment is list-only and shows an empty state',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(45_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      const col = cc.collection(MAIN);
+
+      // On the People segment the List/Map toggle is available (locatable type).
+      await expect(col.typeSwitchTab('People')).toBeVisible();
+      await col.switchType('People');
+      await expect(col.viewToggle('Map')).toBeVisible();
+
+      // The VC segment hides the Map control and (no VCs) shows the empty state.
+      await col.switchType('Virtual Contributors');
+      await expect(col.viewToggle('Map')).toHaveCount(0);
+      await expect(col.emptyState()).toBeVisible();
+    }
+  );
+
+  // AC — client-side name search scoped to the active type.
+  adminFixture.test(
+    '1.5 Name search filters the active type and shows a no-match empty state',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(45_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      const col = cc.collection(MAIN);
+
+      await col.switchType('People');
+      await expect(col.searchInput()).toBeVisible();
+      await col.search('zzz-no-such-contributor-zzz');
+      await expect(col.emptySearchState()).toBeVisible();
+    }
+  );
+
+  // AC5 — List/Map toggle plots the located contributors on a map.
+  adminFixture.test(
+    '1.6 List/Map toggle switches the People segment to a map view',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(45_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      const col = cc.collection(MAIN);
+
+      await col.switchType('People');
+      await col.viewToggle('Map').click();
+      await expect(col.mapRegion()).toBeVisible({ timeout: 15000 });
+      await expect(col.viewToggle('Map')).toHaveAttribute('aria-pressed', 'true');
+
+      // Back to list.
+      await col.viewToggle('List').click();
+      await expect(col.viewToggle('List')).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+    }
+  );
+
+  // AC6 — editing an existing callout's types persists after save.
+  adminFixture.test(
+    '1.7 Excluding a type on an existing callout persists',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(45_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+
+      await cc.openEdit(MAIN);
+      // Exclude Virtual Contributors.
+      await cc.setTypeSelected('Virtual Contributors', false);
+      await cc.saveEditButton.click();
+
+      // Reload so the inline collection reflects the persisted settings.
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      const col = cc.collection(MAIN);
+      await expect(col.region).toBeVisible();
+
+      // The VC segment is gone; People + Organizations remain.
+      await expect(col.typeSwitchTab('Virtual Contributors')).toHaveCount(0, {
+        timeout: 15000,
+      });
+      await expect(col.typeSwitchTab('People')).toBeVisible();
+      await expect(col.typeSwitchTab('Organizations')).toBeVisible();
+    }
+  );
+
+  // AC2 — a single type shows no segmented switch.
+  adminFixture.test(
+    '1.8 A single contributor type shows no segmented switch',
+    async ({ page }) => {
+      adminFixture.test.setTimeout(60_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+
+      // Remove the multi-type callout we created earlier.
+      await cc.deleteContributorsCallout(MAIN);
+
+      const single = `Single Type ${Date.now()}`;
+      await cc.createContributorsCallout(single, { types: ['People'] });
+
+      // Scoped to the single-type callout: it renders the collection with no
+      // segmented type switch (a co-existing default callout, if any, is a
+      // separate card and doesn't leak into this assertion).
+      const col = cc.collection(single);
+      await expect(col.region).toBeVisible();
+      await expect(col.typeSwitchTab('People')).toHaveCount(0);
+      await expect(col.typeSwitchTab('Organizations')).toHaveCount(0);
+      await expect(col.typeSwitchTab('Virtual Contributors')).toHaveCount(0);
+    }
+  );
+});
+
+memberFixture.test.describe.serial('Contributors Callout - Member', () => {
+  memberFixture.test.beforeAll(async ({ browser }) => {
+    memberFixture.test.setTimeout(60_000);
+    if (!baseScenario) {
+      baseScenario =
+        await TestScenarioFactory.createBaseScenario(scenarioConfig);
+    }
+    await memberFixture.setupAuthentication(
+      browser,
+      TestUserManager.users.spaceMember.email
+    );
+  });
+
+  memberFixture.test.afterAll(async () => {
+    memberFixture.test.setTimeout(30_000);
+    await memberFixture.teardownAuthentication();
+    if (baseScenario) {
+      await TestScenarioFactory.cleanUpBaseScenario(baseScenario);
+    }
+  });
+
+  // AC — the Contributors callout is admin-only; a member cannot create callouts
+  // and therefore is never offered the framing.
+  memberFixture.test(
+    '2.1 A space member cannot create a Contributors callout',
+    async ({ page }) => {
+      memberFixture.test.setTimeout(30_000);
+      const cc = new ContributorsCalloutPage(page, baseUrl);
+      await cc.navigateToSpace(baseScenario.space.nameId);
+      expect(await cc.isAddCalloutVisible()).toBe(false);
+    }
+  );
+});

--- a/client-web/src/functional-e2e/contributors-callout/pages/ContributorsCalloutPage.ts
+++ b/client-web/src/functional-e2e/contributors-callout/pages/ContributorsCalloutPage.ts
@@ -1,4 +1,3 @@
-import { delay } from '@alkemio/tests-lib';
 import { Page, expect, Locator } from '@playwright/test';
 
 /**
@@ -22,6 +21,13 @@ import { Page, expect, Locator } from '@playwright/test';
  */
 export type ContributorType = 'People' | 'Organizations' | 'Virtual Contributors';
 
+/** The full set of contributor types, in render order. */
+const ALL_CONTRIBUTOR_TYPES: ContributorType[] = [
+  'People',
+  'Organizations',
+  'Virtual Contributors',
+];
+
 export class ContributorsCalloutPage {
   constructor(
     private page: Page,
@@ -40,8 +46,13 @@ export class ContributorsCalloutPage {
     const accept = this.page.getByRole('button', {
       name: /accept all cookies/i,
     });
-    if (await accept.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await accept.click().catch(() => {});
+    // Wait for the banner to actually render before clicking — a snapshot check
+    // can miss it in the moment right after goto(). No banner is fine.
+    try {
+      await accept.waitFor({ state: 'visible', timeout: 2000 });
+      await accept.click();
+    } catch {
+      /* no banner surfaced — nothing to dismiss */
     }
   }
 
@@ -53,8 +64,11 @@ export class ContributorsCalloutPage {
   }
 
   async isAddCalloutVisible(): Promise<boolean> {
+    // A real wait rather than an immediate snapshot: return true only if the
+    // button actually appears within the window, false once it times out.
     return await this.addCalloutButton
-      .isVisible({ timeout: 5000 })
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .then(() => true)
       .catch(() => false);
   }
 
@@ -74,6 +88,11 @@ export class ContributorsCalloutPage {
   get saveEditButton() {
     // Edit mode primary submit is "Save".
     return this.page.getByRole('button', { name: 'Save', exact: true });
+  }
+
+  /** Dialog dismiss / cancel button. */
+  get closeButton() {
+    return this.page.getByRole('button', { name: 'Close' }).first();
   }
 
   /** Contributor-type multi-select toggle (button with `aria-pressed`). */
@@ -134,17 +153,13 @@ export class ContributorsCalloutPage {
       defaultView?: 'List' | 'Map';
     }
   ) {
-    const types = options?.types ?? [
-      'People',
-      'Organizations',
-      'Virtual Contributors',
-    ];
+    const types = options?.types ?? ALL_CONTRIBUTOR_TYPES;
 
     await this.openCreateForm();
     await this.selectContributorsFraming();
     await this.titleInput.fill(displayName);
 
-    for (const t of ['People', 'Organizations', 'Virtual Contributors'] as ContributorType[]) {
+    for (const t of ALL_CONTRIBUTOR_TYPES) {
       await this.setTypeSelected(t, types.includes(t));
     }
 
@@ -155,7 +170,8 @@ export class ContributorsCalloutPage {
       await this.defaultViewRadio(options.defaultView).click();
     }
 
-    await delay(300);
+    // Every toggle/radio interaction above is already awaited, and the
+    // post-click heading assertion below auto-retries — no fixed sleep needed.
     await this.postButton.click();
 
     // The rendered collection carries the callout title as a heading.
@@ -214,12 +230,19 @@ export class ContributorsCalloutPage {
       contributorCard: (name: string): Locator =>
         region.getByRole('link', { name }),
       switchType: async (type: ContributorType) => {
-        await card.getByRole('tab', { name: new RegExp(`^${type}\\s*\\d`) }).click();
-        await delay(500);
+        const tab = card.getByRole('tab', {
+          name: new RegExp(`^${type}\\s*\\d`),
+        });
+        await tab.click();
+        // Wait for the tab to actually become active rather than a fixed sleep.
+        await expect(tab).toHaveAttribute('aria-selected', 'true');
       },
       search: async (term: string) => {
-        await region.getByRole('textbox', { name: 'Search by name…' }).fill(term);
-        await delay(500);
+        const input = region.getByRole('textbox', { name: 'Search by name…' });
+        await input.fill(term);
+        // Confirm the value landed; the debounced filter settling is covered by
+        // each caller's auto-retrying visibility assertion.
+        await expect(input).toHaveValue(term);
       },
     };
   }

--- a/client-web/src/functional-e2e/contributors-callout/pages/ContributorsCalloutPage.ts
+++ b/client-web/src/functional-e2e/contributors-callout/pages/ContributorsCalloutPage.ts
@@ -1,0 +1,264 @@
+import { delay } from '@alkemio/tests-lib';
+import { Page, expect, Locator } from '@playwright/test';
+
+/**
+ * Page object for the admin-only **Contributors callout** (client-web feature
+ * 008 / story client-web#9928).
+ *
+ * Covers two CRD surfaces:
+ *  1. The create/edit callout form — the "Contributors" framing **radio**, the
+ *     contributor-type multi-select (**buttons** with `aria-pressed`: People /
+ *     Organizations / Virtual Contributors), the default-type **radiogroup**,
+ *     and the default-display (List/Map) **radiogroup**.
+ *  2. The rendered contributor-collection body — a `region` labelled
+ *     "Contributors" containing the segmented type-switch `tab`s (each carrying
+ *     its per-type count, e.g. "People3"), the client-side name-search
+ *     `textbox`, the List/Map view toggle, the contributor cards, and the empty
+ *     state.
+ *
+ * All selectors were verified against a live CRD build; see the selector
+ * contract at
+ * `agents-hq/specs/009-contributors-callout-ui-tests/contracts/`.
+ */
+export type ContributorType = 'People' | 'Organizations' | 'Virtual Contributors';
+
+export class ContributorsCalloutPage {
+  constructor(
+    private page: Page,
+    private baseUrl: string = process.env.ALKEMIO_BASE_URL ||
+      'http://localhost:3000'
+  ) {}
+
+  // ---------------------------------------------------------------- navigation
+
+  async navigateToSpace(spaceNameId: string) {
+    await this.page.goto(`${this.baseUrl}/${spaceNameId}`);
+    await this.dismissCookieBanner();
+  }
+
+  private async dismissCookieBanner() {
+    const accept = this.page.getByRole('button', {
+      name: /accept all cookies/i,
+    });
+    if (await accept.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await accept.click().catch(() => {});
+    }
+  }
+
+  // ------------------------------------------------------------- create form
+
+  get addCalloutButton() {
+    // CRD: the tab-level create trigger is exactly "Add Post".
+    return this.page.getByRole('button', { name: 'Add Post', exact: true });
+  }
+
+  async isAddCalloutVisible(): Promise<boolean> {
+    return await this.addCalloutButton
+      .isVisible({ timeout: 5000 })
+      .catch(() => false);
+  }
+
+  /** The "Contributors" framing radio in the create/edit callout form. */
+  get framingContributorsOption() {
+    return this.page.getByRole('radio', { name: 'Contributors', exact: true });
+  }
+
+  get titleInput() {
+    return this.page.getByRole('textbox', { name: 'Title' });
+  }
+
+  get postButton() {
+    return this.page.getByRole('button', { name: 'Post', exact: true });
+  }
+
+  get saveEditButton() {
+    // Edit mode primary submit is "Save".
+    return this.page.getByRole('button', { name: 'Save', exact: true });
+  }
+
+  /** Contributor-type multi-select toggle (button with `aria-pressed`). */
+  typeToggle(type: ContributorType): Locator {
+    return this.page.getByRole('button', { name: type, exact: true });
+  }
+
+  /** Default-type picker option (radio; shown only when >1 type is selected). */
+  defaultTypeRadio(type: ContributorType): Locator {
+    return this.page.getByRole('radio', { name: type, exact: true });
+  }
+
+  /** Default-display option (radio: List / Map). */
+  defaultViewRadio(view: 'List' | 'Map'): Locator {
+    return this.page.getByRole('radio', { name: view, exact: true });
+  }
+
+  /** Validation message shown when zero contributor types are selected. */
+  get typesRequiredError() {
+    return this.page.getByText('Select at least one contributor type.');
+  }
+
+  async openCreateForm() {
+    await this.addCalloutButton.click();
+    await expect(this.framingContributorsOption).toBeVisible({ timeout: 10000 });
+  }
+
+  async selectContributorsFraming() {
+    await this.framingContributorsOption.click();
+    // Type toggles appear once the framing is selected.
+    await expect(this.typeToggle('People')).toBeVisible({ timeout: 5000 });
+  }
+
+  async isTypeSelected(type: ContributorType): Promise<boolean> {
+    return (
+      (await this.typeToggle(type).getAttribute('aria-pressed')) === 'true'
+    );
+  }
+
+  /** Toggle a type only if its current pressed-state differs from `selected`. */
+  async setTypeSelected(type: ContributorType, selected: boolean) {
+    if ((await this.isTypeSelected(type)) !== selected) {
+      await this.typeToggle(type).click();
+    }
+  }
+
+  /**
+   * Create a Contributors callout.
+   * @param types the contributor types to include (defaults to all three).
+   * @param defaultType default type shown first (only applied when >1 type).
+   * @param defaultView default display when a locatable type is present.
+   */
+  async createContributorsCallout(
+    displayName: string,
+    options?: {
+      types?: ContributorType[];
+      defaultType?: ContributorType;
+      defaultView?: 'List' | 'Map';
+    }
+  ) {
+    const types = options?.types ?? [
+      'People',
+      'Organizations',
+      'Virtual Contributors',
+    ];
+
+    await this.openCreateForm();
+    await this.selectContributorsFraming();
+    await this.titleInput.fill(displayName);
+
+    for (const t of ['People', 'Organizations', 'Virtual Contributors'] as ContributorType[]) {
+      await this.setTypeSelected(t, types.includes(t));
+    }
+
+    if (options?.defaultType && types.length > 1) {
+      await this.defaultTypeRadio(options.defaultType).click();
+    }
+    if (options?.defaultView) {
+      await this.defaultViewRadio(options.defaultView).click();
+    }
+
+    await delay(300);
+    await this.postButton.click();
+
+    // The rendered collection carries the callout title as a heading.
+    await expect(
+      this.page.getByRole('heading', { name: displayName }).first()
+    ).toBeVisible({ timeout: 15000 });
+  }
+
+  // ------------------------------------------------------- rendered collection
+
+  /**
+   * The callout card for a given title — the innermost element containing BOTH
+   * the callout's title heading and a `region "Contributors"`. Scoping to this
+   * card (instead of a page-wide `region "Contributors"`) keeps every assertion
+   * unambiguous even when the space **also** carries an auto-provisioned default
+   * Contributors callout (migrated envs — dev/CI), where more than one
+   * `region "Contributors"` is present on the page. See spec 009 / FR-011.
+   */
+  calloutCard(title: string): Locator {
+    return this.page
+      .locator('div')
+      .filter({ has: this.page.getByRole('heading', { name: title, exact: true }) })
+      .filter({
+        has: this.page.getByRole('region', { name: 'Contributors', exact: true }),
+      })
+      .last();
+  }
+
+  /**
+   * A set of locators/actions for one rendered contributor collection, scoped to
+   * the callout with the given title.
+   */
+  collection(title: string) {
+    const card = this.calloutCard(title);
+    const region = card.getByRole('region', { name: 'Contributors', exact: true });
+    return {
+      card,
+      region,
+      /** Segmented type-switch tab (name carries the count, e.g. "People 3"). */
+      typeSwitchTab: (type: ContributorType): Locator =>
+        // Require the trailing count digit so this never collides with the
+        // type-toggle buttons / default-type radios (or the All/Lead/Member
+        // role-filter tabs).
+        card.getByRole('tab', { name: new RegExp(`^${type}\\s*\\d`) }),
+      searchInput: (): Locator =>
+        region.getByRole('textbox', { name: 'Search by name…' }),
+      viewToggle: (view: 'List' | 'Map'): Locator =>
+        region.getByRole('button', { name: view, exact: true }),
+      // Both the wrapping `<section aria-label="Map">` and the MapLibre canvas
+      // expose the "Map" name — scope to the first match within the card.
+      mapRegion: (): Locator =>
+        card.getByRole('region', { name: 'Map', exact: true }).first(),
+      emptyState: (): Locator => region.getByText('No contributors to show.'),
+      emptySearchState: (): Locator =>
+        region.getByText('No contributors match your search.'),
+      contributorCard: (name: string): Locator =>
+        region.getByRole('link', { name }),
+      switchType: async (type: ContributorType) => {
+        await card.getByRole('tab', { name: new RegExp(`^${type}\\s*\\d`) }).click();
+        await delay(500);
+      },
+      search: async (term: string) => {
+        await region.getByRole('textbox', { name: 'Search by name…' }).fill(term);
+        await delay(500);
+      },
+    };
+  }
+
+  // ------------------------------------------------------------- edit / settings
+
+  /**
+   * Open a callout's detail dialog via its "Open {title}" link and click a
+   * context-menu item. The callout renders inline; its "Open" link opens a
+   * role=dialog carrying the single "Settings" (3-dots) button.
+   */
+  private async openCalloutMenuItem(displayName: string, item: string | RegExp) {
+    // Ensure the feed has rendered the callout before reaching for its link.
+    await expect(
+      this.page.getByRole('heading', { name: displayName }).first()
+    ).toBeVisible({ timeout: 15000 });
+    await this.page
+      .getByRole('link', { name: `Open ${displayName}` })
+      .click({ timeout: 10000 });
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+    await dialog.getByRole('button', { name: 'settings' }).click();
+    await this.page.getByRole('menuitem', { name: item }).click();
+  }
+
+  /** Open the callout context (3-dots) menu, then Edit. */
+  async openEdit(displayName: string) {
+    await this.openCalloutMenuItem(displayName, /edit/i);
+    await expect(this.framingContributorsOption).toBeVisible({ timeout: 10000 });
+  }
+
+  /** Delete a Contributors callout via the CRD two-step confirmation flow. */
+  async deleteContributorsCallout(displayName: string) {
+    await this.openCalloutMenuItem(displayName, 'Delete');
+    const confirm = this.page.getByRole('alertdialog');
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole('button', { name: 'Delete' }).click();
+    await expect(
+      this.page.getByRole('heading', { name: displayName })
+    ).toHaveCount(0, { timeout: 10000 });
+  }
+}

--- a/client-web/src/functional-e2e/contributors-callout/pages/index.ts
+++ b/client-web/src/functional-e2e/contributors-callout/pages/index.ts
@@ -1,0 +1,2 @@
+export { ContributorsCalloutPage } from './ContributorsCalloutPage';
+export type { ContributorType } from './ContributorsCalloutPage';

--- a/client-web/src/functional-e2e/explore-platform/explore-platform-anonymous.spec.ts
+++ b/client-web/src/functional-e2e/explore-platform/explore-platform-anonymous.spec.ts
@@ -155,12 +155,9 @@ test.describe('Explore Alkemio Platform - Anonymous User Flow', () => {
       page.getByText('The contributors to this Space!')
     ).toBeVisible();
 
-    // CRD replaces the "Please log in to see all contributing users" heading
-    // with the community members grid; anonymous users still get a header
-    // "Log in" affordance.
-    await expect(
-      page.getByRole('region', { name: 'Community members grid' })
-    ).toBeVisible();
+    // The hard-coded community members grid was removed (feature 008 / story
+    // client-web#9928); the community intro heading is the anonymous content
+    // signal and the header still exposes a "Log in" affordance.
     await expect(
       page.getByRole('link', { name: 'Log in' })
     ).toBeVisible();

--- a/client-web/src/functional-e2e/public-space/anonymous-user-access-public-space.spec.ts
+++ b/client-web/src/functional-e2e/public-space/anonymous-user-access-public-space.spec.ts
@@ -87,25 +87,13 @@ test.describe('Public Space Discovery and Access', () => {
     // Navigate to the Community tab as anonymous user
     await page.getByRole('tab', { name: 'community' }).click();
 
-    // Verify community content is visible without login
+    // Verify community content is visible without login. The hard-coded
+    // "Community members grid" (with its All / Lead / Organisation filter
+    // toggle) was removed by the Contributors-callout work (feature 008 / story
+    // client-web#9928); the community tab's public intro heading remains the
+    // no-auth-wall content signal for an anonymous visitor.
     await expect(
       page.getByText('The contributors to this Space!')
-    ).toBeVisible();
-
-    // CRD replaces the MUI People/Organizations toggle with member-filter
-    // buttons (All / Lead / Organisation) inside the members grid region.
-    const membersGrid = page.getByRole('region', {
-      name: 'Community members grid',
-    });
-    await expect(membersGrid).toBeVisible();
-    await expect(
-      membersGrid.getByRole('button', { name: 'All' })
-    ).toBeVisible();
-    await expect(
-      membersGrid.getByRole('button', { name: 'Lead' })
-    ).toBeVisible();
-    await expect(
-      membersGrid.getByRole('button', { name: 'Organisation' })
     ).toBeVisible();
 
     // The community tab is reachable without login (no auth wall blocks it);

--- a/client-web/src/functional-e2e/public-space/non-member-lead-profile-access.spec.ts
+++ b/client-web/src/functional-e2e/public-space/non-member-lead-profile-access.spec.ts
@@ -9,9 +9,19 @@ import { TestUser } from '@alkemio/tests-lib/common/enums/test.user';
 import { TestScenarioConfig } from '@alkemio/tests-lib/scenario/config/test-scenario-config';
 import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
 import { TestScenarioFactory } from '@alkemio/tests-lib/scenario/TestScenarioFactory';
-import { expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { createAuthenticatedSessionFixture } from '../fixtures/authenticated-session.fixture';
 import { TestUserManager } from '@alkemio/tests-lib';
+
+// The hard-coded community members grid was removed (feature 008 / story
+// client-web#9928); space leads now render in the "Space Leads" section of the
+// CRD space sidebar. Their profile links use absolute hrefs
+// (http://localhost:3000/user/<id>), so match on a substring.
+const firstLeadUserLink = (page: Page) =>
+  page
+    .getByRole('navigation', { name: 'Space sidebar' })
+    .locator('a[href*="/user/"]')
+    .first();
 
 const { test, setupAuthentication, teardownAuthentication } =
   createAuthenticatedSessionFixture({
@@ -105,14 +115,8 @@ test.describe('Space Lead Profile Access', () => {
       page.getByText('The contributors to this Space!')
     ).toBeVisible();
 
-    // The hard-coded community members grid was removed (feature 008 / story
-    // client-web#9928); space leads now render in the "Space Leads" section of
-    // the CRD space sidebar. Their profile links use absolute hrefs
-    // (http://localhost:3000/user/<id>), so match on a substring.
-    const userLink = page
-      .getByRole('navigation', { name: 'Space sidebar' })
-      .locator('a[href*="/user/"]')
-      .first();
+    // Space leads render in the CRD space-sidebar "Space Leads" section.
+    const userLink = firstLeadUserLink(page);
 
     // Wait for the user link to be visible
     await expect(userLink).toBeVisible({ timeout: 60_000 });
@@ -140,12 +144,8 @@ test.describe('Space Lead Profile Access', () => {
     await communityTab.click();
 
     // Wait for and click on the first lead profile link in the CRD space
-    // sidebar (the community members grid was removed — feature 008). CRD uses
-    // absolute hrefs, so match on a substring.
-    const userLink = page
-      .getByRole('navigation', { name: 'Space sidebar' })
-      .locator('a[href*="/user/"]')
-      .first();
+    // sidebar (the community members grid was removed — feature 008).
+    const userLink = firstLeadUserLink(page);
 
     // Wait for the user link to be visible
     await expect(userLink).toBeVisible({ timeout: 10_000 });

--- a/client-web/src/functional-e2e/public-space/non-member-lead-profile-access.spec.ts
+++ b/client-web/src/functional-e2e/public-space/non-member-lead-profile-access.spec.ts
@@ -105,11 +105,12 @@ test.describe('Space Lead Profile Access', () => {
       page.getByText('The contributors to this Space!')
     ).toBeVisible();
 
-    // Wait for user profile links to appear in the CRD members grid.
-    // CRD renders the member links with absolute hrefs
+    // The hard-coded community members grid was removed (feature 008 / story
+    // client-web#9928); space leads now render in the "Space Leads" section of
+    // the CRD space sidebar. Their profile links use absolute hrefs
     // (http://localhost:3000/user/<id>), so match on a substring.
     const userLink = page
-      .getByRole('region', { name: 'Community members grid' })
+      .getByRole('navigation', { name: 'Space sidebar' })
       .locator('a[href*="/user/"]')
       .first();
 
@@ -138,10 +139,11 @@ test.describe('Space Lead Profile Access', () => {
 
     await communityTab.click();
 
-    // Wait for and click on the first user profile link in the CRD members
-    // grid. CRD uses absolute hrefs, so match on a substring.
+    // Wait for and click on the first lead profile link in the CRD space
+    // sidebar (the community members grid was removed — feature 008). CRD uses
+    // absolute hrefs, so match on a substring.
     const userLink = page
-      .getByRole('region', { name: 'Community members grid' })
+      .getByRole('navigation', { name: 'Space sidebar' })
       .locator('a[href*="/user/"]')
       .first();
 

--- a/client-web/src/functional-e2e/public-space/non-member-tab-navigation.spec.ts
+++ b/client-web/src/functional-e2e/public-space/non-member-tab-navigation.spec.ts
@@ -183,14 +183,18 @@ test.describe('Space Tab Navigation for Non-Members', () => {
     await page.getByRole('tab', { name: 'community' }).click();
 
     // Verify community tab content loads. CRD replaces the MUI "Who's
-    // involved" heading with the contributors intro paragraph and a
-    // "Community members grid" region.
+    // involved" heading with the contributors intro paragraph; the hard-coded
+    // "Community members grid" was removed (feature 008 / story
+    // client-web#9928), so community membership now surfaces via the "Space
+    // Leads" section in the space sidebar.
     await expect(
       page.getByText('The contributors to this Space!')
     ).toBeVisible();
 
     await expect(
-      page.getByRole('region', { name: 'Community members grid' })
+      page
+        .getByRole('navigation', { name: 'Space sidebar' })
+        .getByText('Space Leads')
     ).toBeVisible();
 
     // For non-members, they can see the community content

--- a/specs/009-contributors-callout-ui-tests/contracts/crd-contributors-callout-selector-contract.md
+++ b/specs/009-contributors-callout-ui-tests/contracts/crd-contributors-callout-selector-contract.md
@@ -8,8 +8,8 @@ All selectors below were confirmed empirically by dumping the accessible tree of
 create dialog and the rendered collection, then by a green suite run under
 `--workers=1 --retries=2` (headless). Strategy priority: ARIA role + accessible name,
 then `aria-pressed`/`aria-selected`/`aria-checked`, then placeholder-as-label. No
-MUI-only markup and no positional `.nth()`/`.last()` selectors are used except the one
-annotated map-region `.first()` below.
+MUI-only markup and no positional `.nth()`/`.last()` selectors are used except the two
+annotated exceptions below: the callout-card scoping `.last()` and the map-region `.first()`.
 
 ## Create / edit callout form
 
@@ -31,7 +31,7 @@ annotated map-region `.first()` below.
 **Scoping:** every rendered assertion is scoped to the **callout card under test**, not a
 page-wide region, because a migrated env auto-provisions a default Contributors callout on
 new spaces (so >1 `region "Contributors"` may exist). The card is:
-`page.locator('div').filter({ has: heading(title) }).filter({ has: region("Contributors") }).last()`
+**Annotated `.last()`**: `page.locator('div').filter({ has: heading(title) }).filter({ has: region("Contributors") }).last()`
 — the innermost element holding both the callout's title heading and a Contributors region.
 All selectors below are resolved **within** that card (`ContributorsCalloutPage.collection(title)`).
 

--- a/specs/009-contributors-callout-ui-tests/contracts/crd-contributors-callout-selector-contract.md
+++ b/specs/009-contributors-callout-ui-tests/contracts/crd-contributors-callout-selector-contract.md
@@ -1,0 +1,78 @@
+# CRD Selector Contract — Contributors Callout
+
+**Suite**: `client-web/src/functional-e2e/contributors-callout/`
+**Page object**: `pages/ContributorsCalloutPage.ts`
+**Verified against**: live CRD build (client-web PR #9955, merged 2026-06-30), 2026-07-01.
+
+All selectors below were confirmed empirically by dumping the accessible tree of the
+create dialog and the rendered collection, then by a green suite run under
+`--workers=1 --retries=2` (headless). Strategy priority: ARIA role + accessible name,
+then `aria-pressed`/`aria-selected`/`aria-checked`, then placeholder-as-label. No
+MUI-only markup and no positional `.nth()`/`.last()` selectors are used except the one
+annotated map-region `.first()` below.
+
+## Create / edit callout form
+
+| Element | Selector | Notes |
+|---|---|---|
+| Add callout trigger | `getByRole('button', { name: 'Add Post', exact: true })` | Tab-level create button (CRD). Absent for members. |
+| "Contributors" framing | `getByRole('radio', { name: 'Contributors', exact: true })` | Framing options render as **radios** (not chips). Admin-only + collaboration-only; gated by `permissions.canUpdate`. |
+| Contributor-type toggle | `getByRole('button', { name: <'People'\|'Organizations'\|'Virtual Contributors'>, exact: true })` | Multi-select **buttons** with `aria-pressed`. All three pre-selected by default. |
+| Default-type option | `getByRole('radio', { name: <type>, exact: true })` | `radiogroup` "Default type"; shown only when >1 type selected. Same labels as the toggles but distinct role (radio vs button). |
+| Default-view option | `getByRole('radio', { name: <'List'\|'Map'>, exact: true })` | Default-display radiogroup. |
+| Title | `getByRole('textbox', { name: 'Title' })` | |
+| Submit (create) | `getByRole('button', { name: 'Post', exact: true })` | |
+| Submit (edit) | `getByRole('button', { name: 'Save', exact: true })` | |
+| Types-required error | `getByText('Select at least one contributor type.')` | **Submit-time** validation — appears only after clicking Post, not live on toggle. Distinct from the always-present hint "Select at least one type to include." |
+| Close/cancel | `getByRole('button', { name: 'Close' }).first()` | Dialog dismiss. |
+
+## Rendered contributor collection
+
+**Scoping:** every rendered assertion is scoped to the **callout card under test**, not a
+page-wide region, because a migrated env auto-provisions a default Contributors callout on
+new spaces (so >1 `region "Contributors"` may exist). The card is:
+`page.locator('div').filter({ has: heading(title) }).filter({ has: region("Contributors") }).last()`
+— the innermost element holding both the callout's title heading and a Contributors region.
+All selectors below are resolved **within** that card (`ContributorsCalloutPage.collection(title)`).
+
+| Element | Selector (within the callout card) | Notes |
+|---|---|---|
+| Collection region | `card.getByRole('region', { name: 'Contributors', exact: true })` | `<section aria-label="Contributors">`, scoped to the card so it is unambiguous even with a co-existing default callout. |
+| Segmented type switch | `getByRole('tab', { name: /^<type>\s*\d/ })` | Radix `Tabs`; the per-type count is concatenated into the accessible name (e.g. "People 3"). The trailing `\d` requirement disambiguates from the type-toggle buttons and from the All/Lead/Member role-filter tabs. Shown only when >1 type. |
+| Active type | `<typeSwitchTab>` + `toHaveAttribute('aria-selected', 'true')` | Opens on the configured default type. |
+| Name search | `region.getByRole('textbox', { name: 'Search by name…' })` | `<input aria-label="Search by name…">` (label == placeholder). |
+| View toggle | `region.getByRole('button', { name: <'List'\|'Map'>, exact: true })` | `ViewButton` with `aria-pressed`. Hidden on the Virtual Contributors segment (list-only). |
+| Map region | `getByRole('region', { name: 'Map', exact: true }).first()` | **Annotated `.first()`**: both the wrapping `<section aria-label="Map">` and the MapLibre canvas expose the "Map" name. Primary signal for the map view is the toggle's `aria-pressed`. |
+| Empty state | `region.getByText('No contributors to show.')` | Shown for a type with no contributors (not an error). |
+| No-match state | `region.getByText('No contributors match your search.')` | Shown when the client-side name search filters everything out. |
+| Contributor card | `region.getByRole('link', { name: <contributor name> })` | Card name renders as an `<a>` link to the profile. |
+
+## Gap log
+
+- **G-1 (info, not a blocker):** Zero-types validation is **submit-time only** — the
+  error is not surfaced live when the last type is deselected, and the Post button is
+  **not** disabled. The suite therefore clicks Post to trigger the error, then asserts
+  nothing is persisted. If the product later moves to live validation / a disabled
+  submit, tighten `1.2` accordingly.
+- **G-2 (a11y):** The MapLibre canvas reuses the accessible name "Map", colliding with
+  the wrapping map section (`getByRole('region', { name: 'Map' })` → 2 matches).
+  Worked around with `.first()`; a distinct name on one of them would remove the need.
+- **G-3 (a11y):** The name-search `<input>` derives its accessible name from a value
+  equal to its placeholder ("Search by name…"). Stable enough to target, but an
+  explicit `<label>` would be language-stabler.
+- **G-4 (data):** The default `TestScenarioFactory` scenario seeds no virtual
+  contributors and no geocoded coordinates, so precise map-pin plotting and the
+  "no location data" list are not asserted (see spec Out of Scope). Adding a VC and a
+  geocoded user to the scenario would let those two acceptance criteria be automated.
+- **G-5 (scope):** The segmented type switch renders alongside an All/Lead/Member
+  role-filter (both `tab`s). Only the type switch is under test here; the role-filter
+  counts are out of scope for this pass.
+- **G-6 (environment split):** The L0 backfill migration also seeds the L0 space content
+  **template**, so on a **migrated env** (dev/CI) a newly created space auto-provisions a
+  default Contributors callout — intentionally reversing FR-023. On an **un-migrated env**
+  (fresh local `develop` DB, or the migration run without the mandatory
+  `authorizationPolicyResetAll` post-step → callouts invisible) it does not. The suite is
+  written to pass in both: it scopes to its own callout card by title (see Scoping above),
+  and the community-tab alignment tests assert only surfaces present in both (the sidebar
+  "Space Leads"). Verified locally (un-migrated: 9/9) and via a two-callout scoping probe;
+  full migrated-env validation is left to a dev/CI run.

--- a/specs/009-contributors-callout-ui-tests/spec.md
+++ b/specs/009-contributors-callout-ui-tests/spec.md
@@ -1,0 +1,324 @@
+# Feature Specification: Contributors Callout — Test Suite Coverage & Alignment
+
+**Feature Branch**: `feat/009-contributors-callout-ui-tests`
+**Created**: 2026-07-01
+**Status**: Draft
+**Input**: Story [client-web#9928 "Contributors callout"](https://github.com/alkem-io/client-web/issues/9928) · Source spec [agents-hq#24](https://github.com/alkem-io/agents-hq/pull/24) · Server PR [server#6200](https://github.com/alkem-io/server/pull/6200) · Client PR [client-web#9955](https://github.com/alkem-io/client-web/pull/9955) (merged 2026-06-30) · Epic [alkem-io/alkemio#1541](https://github.com/alkem-io/alkemio/issues/1541)
+
+## Context
+
+The Alkemio web client gained an **admin-only Contributors callout**: a callout
+framing that renders a space's contributors — **People** (users), **Organizations**,
+and **Virtual Contributors** — as a self-updating card collection. It replaces the
+hard-coded community contributor widget (`SpaceMembers`) with a callout an admin can
+place anywhere, that stays current as membership changes.
+
+This feature concerns the **QA test suite** (`@alkemio/test-suite-client-web`), not
+the client application. It has two parts:
+
+1. **New coverage** — the Contributors callout is new product behaviour with no
+   existing automated coverage. This spec adds a functional-E2E suite
+   (`client-web/src/functional-e2e/contributors-callout/`) that exercises the
+   callout's creation, admin-only settings, rendered collection (segmented type
+   switch, per-type counts, name search, list/map view, empty state) and
+   type-persistence-on-edit against a live CRD build.
+
+2. **Alignment** — the client PR removed the hard-coded `SpaceMembers` grid from the
+   CRD community page (`CrdSpaceCommunityPage`) and added a space-level
+   *user-information visibility* setting. The existing suites that render the
+   community tab (`explore-platform`, `public-space`, `memberships`) must remain
+   green against the new page. The community-page section heading
+   ("The contributors to this Space!") is unchanged by the PR, so those assertions
+   survive; this spec verifies that and records any that need re-aligning.
+
+The guiding principle (per the 005–008 precedent): a 1:N mapping of business
+scenario → automation test is preserved. No previously-green test may be silently
+disabled, and new behaviour is covered by new tests rather than by weakening
+existing ones.
+
+Because the callout's contributor data is seeded via `TestScenarioFactory`
+(admins/members/host organization; no virtual contributors by default), the new
+suite asserts the **deterministic** behaviours — type presence, counts, the
+segmented switch, per-type scoping, the VC empty state, name search, the list/map
+toggle, single-vs-multi-type, admin-only gating, and edit persistence — and treats
+data-rich map-plotting of geocoded contributors as an assumption-bounded edge case
+(see Out of Scope / Assumptions).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Contributors callout creation & admin-only settings (Priority: P1)
+
+The QA engineer runs the Contributors callout suite against a CRD build. A space
+admin is offered the "Contributors" framing option, configures the contributor
+types (all three by default), the default type and the default view, and creates
+the callout; saving with zero types is blocked; a space member is never offered the
+framing (they cannot create callouts at all).
+
+**Why this priority**: Creation and its admin-only settings are the foundational
+flow that produces the entity every rendering scenario acts upon, and the
+settings/validation rules (≥1 type required, default-type/default-view) are the
+distinctive product logic this feature introduces. This is the minimum viable slice.
+
+**Independent Test**: Run `0.1contributors-callout.spec.ts` tests `1.1`, `1.2`,
+`2.1`. The admin is offered and can select the Contributors framing; zero-types
+submission surfaces the validation error and creates nothing; a member sees no
+create affordance.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CRD create-callout form as a space admin, **When** the framing list
+   is shown, **Then** a "Contributors" framing radio is present (admin-only,
+   collaboration-only) and selecting it reveals the contributor-type multi-select,
+   the default-type picker, and the default-display (List/Map) control.
+2. **Given** the Contributors framing selected with **zero** types, **When** the
+   admin submits, **Then** the "Select at least one contributor type." validation
+   error is shown, submission is blocked, and no callout is persisted.
+3. **Given** a space member, **When** they view the space collaboration surface,
+   **Then** no create-callout affordance is available (the framing is never offered).
+
+---
+
+### User Story 2 - Rendered collection: types, counts, search, empty state (Priority: P1)
+
+The QA engineer verifies the rendered contributor collection. With the default
+settings (all three types) the collection shows a segmented type switch — one
+segment per configured type, each carrying an always-visible per-type count — that
+opens on the configured default type and scopes the view (search, cards) to the
+active type. A type with no contributors shows an empty state (not an error), and
+client-side name search filters the active type with its own no-match empty state.
+A single configured type shows no segmented switch.
+
+**Why this priority**: The rendered collection is the user-facing payoff of the
+feature and encodes the bulk of the acceptance criteria (segmented switch, per-type
+counts, per-type scoping, empty states, name search, single-vs-multi type). It
+depends only on creation (P1).
+
+**Independent Test**: Run tests `1.3`, `1.4`, `1.5`, `1.8`. Default settings render
+People/Organizations/Virtual Contributors segments with counts, opening on People;
+the Virtual Contributors segment (no VCs) shows the empty state; name search yields
+a no-match empty state; a single-type callout shows no segmented switch.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Contributors callout with default settings, **When** it renders,
+   **Then** a segmented switch shows one segment per type, each with its count, and
+   opens on the configured default type (People).
+2. **Given** the segmented switch, **When** the admin selects the Virtual
+   Contributors segment (which has no contributors), **Then** an empty state is
+   shown (not an error).
+3. **Given** the active type, **When** the admin types a non-matching name in the
+   search box, **Then** the cards filter to the active type and a no-match empty
+   state is shown.
+4. **Given** a Contributors callout configured with a **single** type, **When** it
+   renders, **Then** no segmented type switch is shown.
+
+---
+
+### User Story 3 - List/Map view, VC list-only, and edit persistence (Priority: P2)
+
+The QA engineer verifies the map affordance and edit persistence. Users and
+organizations expose a List/Map toggle; switching to Map renders the map region.
+Virtual Contributors are list-only (no Map control on that segment). Editing an
+existing callout to exclude a type (e.g. Virtual Contributors) persists after save —
+that segment disappears from the rendered switch.
+
+**Why this priority**: The map toggle and the VC list-only rule are important
+view-shaping behaviours, and edit-persistence proves the settings round-trip through
+the server. They build on the rendered collection (P1/US2).
+
+**Independent Test**: Run tests `1.4`, `1.6`, `1.7`. On the People segment the Map
+control is present and switches to a map region; on the Virtual Contributors segment
+the Map control is absent; excluding Virtual Contributors via edit removes that
+segment after save.
+
+**Acceptance Scenarios**:
+
+1. **Given** the People segment, **When** the admin toggles to Map, **Then** the map
+   region is shown and the Map control is pressed; toggling back returns to the list.
+2. **Given** the Virtual Contributors segment, **When** it is active, **Then** no Map
+   control is offered (list-only).
+3. **Given** an existing Contributors callout with all three types, **When** the
+   admin edits it to exclude Virtual Contributors and saves, **Then** the rendered
+   switch shows only People and Organizations after save (the change persisted).
+
+---
+
+### User Story 4 - Community-page alignment survives the widget removal (Priority: P2)
+
+The QA engineer confirms the existing suites that render the CRD community tab stay
+green after the hard-coded `SpaceMembers` grid was removed. The community-page
+section heading the suites assert ("The contributors to this Space!") is unchanged
+by the client PR, so those assertions continue to pass; any that genuinely broke are
+re-aligned to a CRD-valid selector without dropping the scenario.
+
+**Why this priority**: This is regression-protection for adjacent suites rather than
+new coverage; it trails the executable new-coverage stories.
+
+**Independent Test**: Run the community-tab scenarios in `explore-platform`,
+`public-space`, and `memberships`. Each still passes; any re-aligned selector is
+recorded in the selector contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CRD community tab after the `SpaceMembers` removal, **When** an
+   authenticated user opens it, **Then** the suites' community assertions still hold
+   (the section heading survives; no member-grid selector is relied upon).
+2. **Given** a selector that genuinely broke, **When** it is re-aligned, **Then** the
+   scenario and behavioural assertion are unchanged and the change is recorded in the
+   selector contract.
+
+---
+
+### Edge Cases
+
+- **No virtual contributors in the seeded scenario**: the VC segment shows the empty
+  state and is list-only — asserted directly (deterministic).
+- **Zero contributor types on submit**: validation is **submit-time** — the error
+  appears only when the admin clicks Post (not live on toggle); the suite clicks Post
+  to surface it, then asserts nothing is persisted.
+- **Two elements expose the "Map" accessible name**: the wrapping
+  `<section aria-label="Map">` and the MapLibre canvas both match; the suite scopes to
+  the first and relies on the toggle's `aria-pressed` as the primary signal.
+- **Multiple Contributors callouts in one space** produce multiple
+  `region "Contributors"` — expected on a migrated env, where a new space already
+  carries an auto-provisioned default callout alongside the suite's own. The suite
+  scopes every rendered assertion to the callout card matching the title under test
+  (the innermost element containing both that title heading and a `region "Contributors"`),
+  so locators stay unambiguous regardless of how many collections are on the page.
+- **Map tiles are fetched from a public basemap** (OpenFreeMap positron); the suite
+  asserts the map *region* renders, not tile content, so it does not depend on
+  external tile availability.
+- **Segmented type switch vs. the All/Lead/Member role filter**: both render as
+  `tab`s; the type switch is disambiguated by requiring the trailing per-type count
+  digit in the accessible name (e.g. `^People\s*\d`).
+- **User-information visibility = members only**: server-enforced; hides member users
+  from non-members while organizations and virtual contributors are unaffected. Rich
+  cross-viewer assertion is data/permission-heavy and is bounded as an assumption.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A new functional-E2E suite MUST cover the Contributors callout end-to-end
+  against a CRD build: creation with the "Contributors" framing, the admin-only
+  type/default-type/default-view settings, and the rendered collection.
+- **FR-002**: The suite MUST assert the admin-only, collaboration-only framing: a space
+  admin is offered the "Contributors" framing radio; a space member has no
+  create-callout affordance.
+- **FR-003**: The suite MUST assert the ≥1-type rule — submitting with zero types shows
+  the "Select at least one contributor type." error and persists nothing.
+- **FR-004**: The suite MUST assert the rendered collection: a segmented type switch
+  with one segment per configured type, each carrying an always-visible per-type count,
+  opening on the configured default type, and scoping search/cards to the active type;
+  and that a single configured type shows no switch.
+- **FR-005**: The suite MUST assert empty states (not errors): a type with no
+  contributors, and a name search with no matches.
+- **FR-006**: The suite MUST assert the List/Map view toggle for a locatable type
+  (users/organizations) and that Virtual Contributors are list-only (no Map control).
+- **FR-007**: The suite MUST assert that editing an existing callout to exclude a type
+  persists after save (the excluded segment disappears from the rendered switch).
+- **FR-008**: Every selector MUST use a CRD-valid, language-stable strategy (ARIA role +
+  accessible name, `aria-pressed`/`aria-selected`/`aria-checked`, placeholder-as-label)
+  and MUST NOT rely on MUI-only markup or positional `.nth()` hacks; any unavoidable
+  positional selector MUST be annotated. All selectors are recorded in the selector
+  contract.
+- **FR-009**: The existing suites that render the CRD community tab (`explore-platform`,
+  `public-space`, `memberships`) MUST remain green after the `SpaceMembers` widget
+  removal; any selector that genuinely broke MUST be re-aligned to a CRD-valid strategy
+  without dropping its scenario, and recorded in the selector contract.
+- **FR-010**: The suite MUST run via the existing client-web execution path (Playwright,
+  Chrome branded channel, `--workers=1 --retries=2`, headless) with no new
+  infrastructure, and be runnable both as a directory-scoped run
+  (`playwright test src/functional-e2e/contributors-callout`) and per-file.
+- **FR-011**: Every rendered-collection assertion MUST be scoped to the **specific
+  callout under test** (its title's callout card), never a page-wide
+  `region "Contributors"`, because a **migrated environment auto-provisions a default
+  Contributors callout on new spaces** (see FR-012) — so more than one
+  `region "Contributors"` may be present. The suite MUST pass identically whether or
+  not that default callout exists.
+- **FR-012**: The suite MUST tolerate the **environment split** in the rollout. The L0
+  backfill migration (`BackfillContributorsCalloutL0Community`) also seeds the **L0
+  space content template**, so on a migrated env (dev/CI) a newly created space
+  **inherits** a default Contributors callout — this **intentionally reverses the
+  original FR-023 "new spaces get nothing automatic" decision**. On an un-migrated env
+  (e.g. a fresh local `develop` DB without the migration + `authorizationPolicyResetAll`
+  post-step) new spaces have none. The suite MUST NOT assume either state: it creates
+  its own callouts and scopes to them (FR-011), and the community-tab alignment
+  assertions (FR-009) rely only on surfaces present in both (the sidebar "Space Leads").
+
+### Key Entities *(include if feature involves data)*
+
+- **Contributors callout suite**: `client-web/src/functional-e2e/contributors-callout/`
+  — `0.1contributors-callout.spec.ts` (admin creation/settings/rendering + member
+  negative) and `pages/ContributorsCalloutPage.ts` (the page object).
+- **ContributorsCalloutPage page object**: centralizes the create-form selectors
+  (framing radio, type toggles, default-type/default-view radios, validation error) and
+  the rendered-collection selectors (region, type-switch tabs, search, view toggle,
+  cards, empty states, map region) plus create/edit/delete helpers.
+- **CRD Contributors surfaces under test**: the create/edit callout form's
+  `ContributorCollectionConfigField` + "Contributors" framing radio; the rendered
+  `ContributorCollection` (segmented `Tabs`, search `input`, `ViewButton` toggle,
+  `ContributorCard`s, `EmptyState`) and the lazy `ContributorMap` — defined by
+  client-web PR #9955.
+- **Test data / scenario setup**: `TestScenarioFactory.createBaseScenario(...)`
+  (GraphQL-seeded space with a host organization, `SPACE_ADMIN` lead + `SPACE_MEMBER`;
+  no virtual contributors), the authenticated-session fixture, and the `SPACE_ADMIN` /
+  `SPACE_MEMBER` test users — unchanged by this feature.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The new `contributors-callout` suite passes 100% against a CRD build under
+  the required run profile (`--workers=1 --retries=2`, headless).
+- **SC-002**: All seven story acceptance criteria that are deterministic under the seeded
+  scenario (AC1, AC2, AC3, AC5, AC6, AC7 and the admin-only gating) have at least one
+  passing automated test; the data-rich subset (geocoded map plotting, members-only
+  cross-viewer visibility) is explicitly bounded rather than silently omitted.
+- **SC-003**: Every getter/helper exported from `ContributorsCalloutPage` and used by an
+  active test resolves to exactly one element on its CRD surface (no zero-match or
+  ambiguous-match locators), verified empirically.
+- **SC-004**: No MUI-only or positional selector is introduced; the selector contract
+  lists every selector and any gap.
+- **SC-005**: The `explore-platform`, `public-space`, and `memberships` community-tab
+  scenarios remain green after the `SpaceMembers` removal; any re-aligned selector is
+  recorded, and the count of scenarios lost is zero.
+
+## Assumptions
+
+- Client PR #9955 is merged and served by the target build; the GraphQL schema exposes
+  `CalloutFraming.contributors` / `contributorCounts` and `CalloutSettings.framing.contributors`
+  (verified live). If the redesign is behind a flag, it is enabled deterministically.
+- `TestScenarioFactory` seeds a space with a host organization and admin/member users but
+  **no virtual contributors** and **no geocoded coordinates**; therefore the VC segment is
+  reliably empty (drives the empty-state assertion) and precise map-pin plotting is not
+  asserted (only that the map region renders).
+- The default test-environment language is English, so the English accessible names
+  ("Contributors", "People", "Organizations", "Virtual Contributors", "List", "Map",
+  "Select at least one contributor type.", "No contributors to show.",
+  "No contributors match your search.") match.
+- The CRD surfaces follow the design system's accessibility commitments (semantic
+  roles, `aria-pressed`/`aria-selected`/`aria-checked`, accessible names on controls),
+  providing the roles/names the suite targets.
+- The community-page section heading "The contributors to this Space!" is rendered
+  outside the removed `SpaceMembers` widget and is unchanged by PR #9955 (confirmed via
+  diff), so the adjacent suites' community assertions survive without change.
+
+## Out of Scope
+
+- Any change to the Alkemio client application itself (the Contributors callout
+  implementation lives in `client-web`, not this QA repo).
+- Server-api coverage of the contributor-collection GraphQL settings and the
+  server-enforced privacy rules (a separate server-api effort); the user provided that
+  the API tests pass.
+- Data-rich rendering that the default seeded scenario cannot make deterministic:
+  precise map-pin plotting of geocoded contributors, the "no location data" list
+  beneath the map, cross-viewer *members-only* user-information visibility, and the
+  All/Lead/Member role-filter counts.
+- Directly testing the rollout **migration** itself (`BackfillContributorsCalloutL0Community`
+  provisioning existing L0 spaces + the L0 template, and the `authorizationPolicyResetAll`
+  post-step). The suite does not run migrations; it is written to pass whether the
+  environment has applied them (new spaces auto-provision a default callout — FR-012)
+  or not, by scoping to its own callouts (FR-011).
+- Accessibility automation (axe-core), performance, or visual-regression testing of the
+  Contributors surfaces.


### PR DESCRIPTION
## What & why

Adds QA coverage for the admin-only **Contributors callout** (client story alkem-io/client-web#9928, client PR alkem-io/client-web#9955) and realigns the community-tab suites to the removal of the hard-coded `SpaceMembers` grid that shipped with it. SDD spec: `specs/009-contributors-callout-ui-tests/`.

## New coverage — `contributors-callout/`

`0.1contributors-callout.spec.ts` + `pages/ContributorsCalloutPage.ts` exercise, against a live CRD build:

- Admin-only **Contributors** framing option; member cannot create.
- `>=1`-type **submit-time** validation (Post surfaces "Select at least one contributor type."; nothing persists).
- Default settings render **People / Organizations / Virtual Contributors** as a segmented type switch with per-type counts, opening on the configured default type.
- Per-type scoping, **Virtual Contributors list-only + empty state**, client-side **name search** + no-match state.
- **List/Map** toggle, **single type → no switch**, and **edit persistence** (excluding a type sticks after save).

## Realigned suites (removed community members grid)

The client removed the `SpaceMembers` grid; leads now render in the CRD **Space sidebar**. Re-pointed lead-profile lookups there and dropped the obsolete `"Community members grid"` assertions without losing the scenarios:
`public-space/{anonymous-user-access-public-space,non-member-tab-navigation,non-member-lead-profile-access}` + `explore-platform/explore-platform-anonymous`.

## Environment-robust by design

Every rendered assertion is scoped to the callout under test **by title** (`ContributorsCalloutPage.collection(title)`), so the suite passes on **both**:
- a **migrated** env (dev/CI) where a new space *also* carries an auto-provisioned default Contributors callout (≥2 `region "Contributors"` on the page), and
- an **un-migrated** env (local `develop`) where it does not.

This intentionally does **not** assert "a fresh L0 space auto-has a Contributors callout" — that behavior is environment-dependent and currently broken on clean DBs (bootstrap L0 template gap, see alkem-io/server#6215); it belongs in a deterministic server-api regression test, not a client-web e2e.

## Verification

- `contributors-callout` — **9/9 green** (`--workers=1 --retries=2`, headless), plus a two-callout scoping probe confirming per-callout isolation for the migrated-env case.
- `public-space` + `explore-platform-anonymous` — **33/33 green** after the realignment.

## Refs

- Workspace spec: `specs/009-contributors-callout-ui-tests/`
- Story: alkem-io/client-web#9928 · Client PR: alkem-io/client-web#9955
- Related server gap (new-space provisioning): alkem-io/server#6215

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end functional coverage for the admin-only “Contributors” callout, including creation flows, type-based rendering, default type override, search filtering, and list/map switching.
* **Bug Fixes**
  * Confirmed validation blocks saving when no contributor types are selected.
  * Verified edit persistence rules (e.g., excluded virtual contributors stay excluded after reload).
* **Tests**
  * Updated anonymous and non-member community tab assertions to match the revised community content placement and remove reliance on the prior members grid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->