### PR TITLE
test(017-combined-subspace-application): hierarchy-parity matrix + live-verification guards

### DIFF
--- a/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
@@ -1,0 +1,144 @@
+/**
+ * API/integration guard — actor-relative reachability (workspace#017).
+ *
+ * Explicit scope decision (2026-07-07, recorded in ADR 0001): reachability
+ * for the combined Subspace-application flow is evaluated PER APPLICANT, not
+ * for a generic non-member. Ancestors the applicant already belongs to impose
+ * no requirements (the missing-only grant skips them); every ancestor the
+ * applicant would actually be granted into must be PUBLIC with
+ * `allowSubspaceAdminsToInviteMembers` enabled.
+ *
+ * Canonical case: PRIVATE L0 -> PUBLIC L1 -> PUBLIC L2 target. An applicant
+ * who IS a member of the private L0 (but of nothing below) applies directly
+ * to L2; approval grants L1 + L2 (L0 already held). A stranger to the same
+ * hierarchy is still rejected (the generic negative cell is unchanged).
+ */
+import {
+  CommunityMembershipPolicy,
+  RoleName,
+  SpacePrivacyMode,
+} from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  TestScenarioFactory,
+  TestUser,
+  TestUserManager,
+} from '@alkemio/tests-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { createApplication } from '@functional-api/roleset/application/application.request.params';
+import { assignRoleToUser } from '@functional-api/roleset/roles-request.params';
+import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
+import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
+import {
+  buildHierarchyScenarioConfig,
+  HIERARCHY_TEST_TIMEOUT_MS,
+} from './hierarchy-parity.fixture';
+
+const APPLICANT = TestUser.NON_SPACE_MEMBER;
+const applicantId = () => TestUserManager.users.nonSpaceMember.id;
+
+const isMemberOf = async (roleSetId: string): Promise<boolean> => {
+  const members = await getRoleSetUsersInMemberRole(roleSetId);
+  return members.some(m => m.id === applicantId());
+};
+
+const privateRootCombo = {
+  spacePrivacy: SpacePrivacyMode.Private,
+  subspacePrivacy: SpacePrivacyMode.Public,
+  subsubspacePrivacy: SpacePrivacyMode.Public,
+};
+
+describe('Actor-relative reachability — combined flow (workspace#017 / ADR 0001)', () => {
+  test(
+    'a member of the PRIVATE root can apply directly to the public SubSub; approval grants the missing ancestry',
+    async () => {
+      const scenarioConfig = buildHierarchyScenarioConfig(
+        'actor-reachability',
+        privateRootCombo,
+        {
+          subsubspaceMembershipPolicy: CommunityMembershipPolicy.Applications,
+          settingEnabled: true,
+        }
+      );
+      const scenario: OrganizationWithSpaceModel =
+        await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+      try {
+        // Precondition: make the applicant a member of the PRIVATE root only.
+        await assignRoleToUser(
+          applicantId(),
+          scenario.space.community.roleSetId,
+          RoleName.Member
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          false
+        );
+
+        // Actor-relative reachability: the private root is OWNED by this
+        // applicant, so it imposes no requirement; L1 is public + opted in.
+        const applicationResult = await createApplication(
+          scenario.subsubspace.community.roleSetId,
+          APPLICANT
+        );
+        expect(applicationResult?.error).toBeUndefined();
+        const applicationId =
+          applicationResult?.data?.applyForEntryRoleOnRoleSet?.id;
+        expect(applicationId?.length).toEqual(36);
+
+        await eventOnRoleSetApplication(applicationId as string, 'APPROVE');
+
+        // Approval grants the MISSING ancestry (L1 + L2); L0 already held.
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
+      } finally {
+        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+      }
+    },
+    HIERARCHY_TEST_TIMEOUT_MS
+  );
+
+  test(
+    'a stranger to the same PRIVATE-root hierarchy is still rejected (generic negative cell unchanged)',
+    async () => {
+      const scenarioConfig = buildHierarchyScenarioConfig(
+        'actor-reachability-stranger',
+        privateRootCombo,
+        {
+          subsubspaceMembershipPolicy: CommunityMembershipPolicy.Applications,
+          settingEnabled: true,
+        }
+      );
+      const scenario: OrganizationWithSpaceModel =
+        await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+      try {
+        const applicationResult = await createApplication(
+          scenario.subsubspace.community.roleSetId,
+          APPLICANT
+        );
+        expect(applicationResult?.error?.errors?.[0]?.message).toBeDefined();
+        expect(
+          applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
+        ).toBeFalsy();
+
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          false
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          false
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+          false
+        );
+      } finally {
+        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+      }
+    },
+    HIERARCHY_TEST_TIMEOUT_MS
+  );
+});

--- a/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
@@ -30,6 +30,8 @@ import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-event
 import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
   buildHierarchyScenarioConfig,
+  cleanupScenarioSafely,
+  COMBINED_FLOW_REJECTION,
   HIERARCHY_TEST_TIMEOUT_MS,
 } from './hierarchy-parity.fixture';
 
@@ -96,7 +98,7 @@ describe('Actor-relative reachability — combined flow (workspace#017 / ADR 000
         );
         expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
       } finally {
-        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        await cleanupScenarioSafely(scenario);
       }
     },
     HIERARCHY_TEST_TIMEOUT_MS
@@ -121,7 +123,9 @@ describe('Actor-relative reachability — combined flow (workspace#017 / ADR 000
           scenario.subsubspace.community.roleSetId,
           APPLICANT
         );
-        expect(applicationResult?.error?.errors?.[0]?.message).toBeDefined();
+        expect(applicationResult?.error?.errors?.[0]?.message).toMatch(
+          COMBINED_FLOW_REJECTION
+        );
         expect(
           applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
         ).toBeFalsy();
@@ -136,7 +140,7 @@ describe('Actor-relative reachability — combined flow (workspace#017 / ADR 000
           false
         );
       } finally {
-        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        await cleanupScenarioSafely(scenario);
       }
     },
     HIERARCHY_TEST_TIMEOUT_MS

--- a/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/actor-reachability.it-spec.ts
@@ -27,21 +27,19 @@ import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/O
 import { createApplication } from '@functional-api/roleset/application/application.request.params';
 import { assignRoleToUser } from '@functional-api/roleset/roles-request.params';
 import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
-import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
   buildHierarchyScenarioConfig,
   cleanupScenarioSafely,
   COMBINED_FLOW_REJECTION,
   HIERARCHY_TEST_TIMEOUT_MS,
+  isUserMemberOfRoleSet,
 } from './hierarchy-parity.fixture';
 
 const APPLICANT = TestUser.NON_SPACE_MEMBER;
 const applicantId = () => TestUserManager.users.nonSpaceMember.id;
 
-const isMemberOf = async (roleSetId: string): Promise<boolean> => {
-  const members = await getRoleSetUsersInMemberRole(roleSetId);
-  return members.some(m => m.id === applicantId());
-};
+const isMemberOf = (roleSetId: string): Promise<boolean> =>
+  isUserMemberOfRoleSet(roleSetId, applicantId());
 
 const privateRootCombo = {
   spacePrivacy: SpacePrivacyMode.Private,

--- a/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
@@ -26,14 +26,15 @@ import {
   getRoleSetInvitationsApplications,
 } from '@functional-api/roleset/application/application.request.params';
 import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
-import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
+  ALL_PUBLIC_COMBO,
   buildHierarchyScenarioConfig,
   cleanupScenarioSafely,
   COMBINED_FLOW_REJECTION,
   comboLabel,
   expectCombinedAncestryGrant,
   HIERARCHY_TEST_TIMEOUT_MS,
+  isUserMemberOfRoleSet,
   PRIVACY_COMBOS,
   PrivacyCombo,
 } from './hierarchy-parity.fixture';
@@ -41,10 +42,8 @@ import {
 const APPLICANT = TestUser.NON_SPACE_MEMBER;
 const applicantId = () => TestUserManager.users.nonSpaceMember.id;
 
-const isMemberOf = async (roleSetId: string): Promise<boolean> => {
-  const members = await getRoleSetUsersInMemberRole(roleSetId);
-  return members.some(m => m.id === applicantId());
-};
+const isMemberOf = (roleSetId: string): Promise<boolean> =>
+  isUserMemberOfRoleSet(roleSetId, applicantId());
 
 const buildAndApply = async (
   name: string,
@@ -58,12 +57,18 @@ const buildAndApply = async (
   const scenario: OrganizationWithSpaceModel =
     await TestScenarioFactory.createBaseScenario(scenarioConfig);
 
-  const applicationResult = await createApplication(
-    scenario.subsubspace.community.roleSetId,
-    APPLICANT
-  );
-
-  return { scenario, applicationResult };
+  // The apply runs after the scenario exists but before the caller's
+  // try/finally starts — an unexpected throw here must not leak the scenario.
+  try {
+    const applicationResult = await createApplication(
+      scenario.subsubspace.community.roleSetId,
+      APPLICANT
+    );
+    return { scenario, applicationResult };
+  } catch (e) {
+    await cleanupScenarioSafely(scenario);
+    throw e;
+  }
 };
 
 describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () => {
@@ -125,9 +130,9 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
               // US3 AS-1/3: a private ancestor -> the combined flow is
               // unavailable; the non-parent-member's apply attempt is
               // rejected the same way it is today ("join the parent first").
-              expect(
-                applicationResult?.error?.errors?.[0]?.message
-              ).toBeDefined();
+              expect(applicationResult?.error?.errors?.[0]?.message).toMatch(
+                COMBINED_FLOW_REJECTION
+              );
               expect(
                 applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
               ).toBeFalsy();
@@ -152,18 +157,12 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
   );
 
   describe('setting-disabled guard (US3 AS-2 / SC-005)', () => {
-    const allPublicCombo: PrivacyCombo = {
-      spacePrivacy: PRIVACY_COMBOS[0].spacePrivacy,
-      subspacePrivacy: PRIVACY_COMBOS[0].subspacePrivacy,
-      subsubspacePrivacy: PRIVACY_COMBOS[0].subsubspacePrivacy,
-    };
-
     test(
       'whole chain public but allowSubspaceAdminsToInviteMembers disabled -> combined flow unavailable',
       async () => {
         const { scenario, applicationResult } = await buildAndApply(
           'app-hierarchy-parity-setting-off',
-          allPublicCombo,
+          ALL_PUBLIC_COMBO,
           false
         );
 
@@ -193,18 +192,12 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
   });
 
   describe('reject guard (FR-007 / SC-004 / US3 AS-4)', () => {
-    const allPublicCombo: PrivacyCombo = {
-      spacePrivacy: PRIVACY_COMBOS[0].spacePrivacy,
-      subspacePrivacy: PRIVACY_COMBOS[0].subspacePrivacy,
-      subsubspacePrivacy: PRIVACY_COMBOS[0].subsubspacePrivacy,
-    };
-
     test(
       'REJECTed application on an all-public/setting-enabled hierarchy grants no membership at all',
       async () => {
         const { scenario, applicationResult } = await buildAndApply(
           'app-hierarchy-parity-reject',
-          allPublicCombo,
+          ALL_PUBLIC_COMBO,
           true
         );
 

--- a/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
@@ -1,0 +1,231 @@
+/**
+ * API/integration parity suite — application (combined) flow.
+ *
+ * Workspace feature `017-combined-subspace-application` (FR-019 / SC-009).
+ * Exercises the public/private ancestry matrix across a Root -> Sub -> SubSub
+ * hierarchy: a non-member applies directly to the SubSub, an admin approves,
+ * and — only when the whole ancestor chain (Root + Sub) is public AND the
+ * `allowSubspaceAdminsToInviteMembers` setting is enabled — the applicant is
+ * granted membership of SubSub *and* every ancestor, in one action (FR-006).
+ *
+ * IMPORTANT — rollout ordering: these specs assert NEW server behaviour
+ * (relaxed apply-time precondition + approval-time ancestor grant). They only
+ * go green once the `server` slice of workspace#017 has merged; until then
+ * they are expected to fail end-to-end (this file is authored so it
+ * typechecks/collects cleanly now — see plan.md "Rollout ordering").
+ */
+import { CommunityMembershipPolicy } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  TestScenarioFactory,
+  TestUser,
+  TestUserManager,
+} from '@alkemio/tests-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import {
+  createApplication,
+  getRoleSetInvitationsApplications,
+} from '@functional-api/roleset/application/application.request.params';
+import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
+import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
+import {
+  buildHierarchyScenarioConfig,
+  comboLabel,
+  expectCombinedAncestryGrant,
+  HIERARCHY_TEST_TIMEOUT_MS,
+  PRIVACY_COMBOS,
+  PrivacyCombo,
+} from './hierarchy-parity.fixture';
+
+const APPLICANT = TestUser.NON_SPACE_MEMBER;
+const applicantId = () => TestUserManager.users.nonSpaceMember.id;
+
+const isMemberOf = async (roleSetId: string): Promise<boolean> => {
+  const members = await getRoleSetUsersInMemberRole(roleSetId);
+  return members.some(m => m.id === applicantId());
+};
+
+const buildAndApply = async (
+  name: string,
+  combo: PrivacyCombo,
+  settingEnabled: boolean
+) => {
+  const scenarioConfig = buildHierarchyScenarioConfig(name, combo, {
+    subsubspaceMembershipPolicy: CommunityMembershipPolicy.Applications,
+    settingEnabled,
+  });
+  const scenario: OrganizationWithSpaceModel =
+    await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+  const applicationResult = await createApplication(
+    scenario.subsubspace.community.roleSetId,
+    APPLICANT
+  );
+
+  return { scenario, applicationResult };
+};
+
+describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () => {
+  describe.each(PRIVACY_COMBOS)(
+    'privacy combo: $spacePrivacy/$subspacePrivacy/$subsubspacePrivacy (setting enabled)',
+    combo => {
+      const expectFullAncestry = expectCombinedAncestryGrant(combo, true);
+
+      test(
+        `${
+          expectFullAncestry ? 'grants' : 'does not grant'
+        } full ancestry on approval — ${comboLabel(combo)}`,
+        async () => {
+          const { scenario, applicationResult } = await buildAndApply(
+            'app-hierarchy-parity',
+            combo,
+            true
+          );
+
+          try {
+            if (expectFullAncestry) {
+              // US1 AS-4/5/6: whole chain public + setting enabled -> apply succeeds.
+              expect(applicationResult?.error).toBeUndefined();
+              const applicationId =
+                applicationResult?.data?.applyForEntryRoleOnRoleSet?.id;
+              expect(applicationId?.length).toEqual(36);
+
+              await eventOnRoleSetApplication(
+                applicationId as string,
+                'APPROVE'
+              );
+
+              expect(
+                await isMemberOf(scenario.subsubspace.community.roleSetId)
+              ).toBe(true);
+              expect(
+                await isMemberOf(scenario.subspace.community.roleSetId)
+              ).toBe(true);
+              expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+                true
+              );
+
+              // FR-004: the application lives only in the SubSub community
+              // context — no application is ever created against an ancestor
+              // role-set.
+              const rootApplications = await getRoleSetInvitationsApplications(
+                scenario.space.community.roleSetId
+              );
+              const subApplications = await getRoleSetInvitationsApplications(
+                scenario.subspace.community.roleSetId
+              );
+              expect(
+                rootApplications?.data?.lookup?.roleSet?.applications
+              ).toHaveLength(0);
+              expect(
+                subApplications?.data?.lookup?.roleSet?.applications
+              ).toHaveLength(0);
+            } else {
+              // US3 AS-1/3: a private ancestor -> the combined flow is
+              // unavailable; the non-parent-member's apply attempt is
+              // rejected the same way it is today ("join the parent first").
+              expect(
+                applicationResult?.error?.errors?.[0]?.message
+              ).toBeDefined();
+              expect(
+                applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
+              ).toBeFalsy();
+
+              expect(
+                await isMemberOf(scenario.subsubspace.community.roleSetId)
+              ).toBe(false);
+              expect(
+                await isMemberOf(scenario.subspace.community.roleSetId)
+              ).toBe(false);
+              expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+                false
+              );
+            }
+          } finally {
+            await TestScenarioFactory.cleanUpBaseScenario(scenario);
+          }
+        },
+        HIERARCHY_TEST_TIMEOUT_MS
+      );
+    }
+  );
+
+  describe('setting-disabled guard (US3 AS-2 / SC-005)', () => {
+    const allPublicCombo: PrivacyCombo = {
+      spacePrivacy: PRIVACY_COMBOS[0].spacePrivacy,
+      subspacePrivacy: PRIVACY_COMBOS[0].subspacePrivacy,
+      subsubspacePrivacy: PRIVACY_COMBOS[0].subsubspacePrivacy,
+    };
+
+    test(
+      'whole chain public but allowSubspaceAdminsToInviteMembers disabled -> combined flow unavailable',
+      async () => {
+        const { scenario, applicationResult } = await buildAndApply(
+          'app-hierarchy-parity-setting-off',
+          allPublicCombo,
+          false
+        );
+
+        try {
+          expect(applicationResult?.error?.errors?.[0]?.message).toBeDefined();
+          expect(
+            applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
+          ).toBeFalsy();
+
+          expect(
+            await isMemberOf(scenario.subsubspace.community.roleSetId)
+          ).toBe(false);
+          expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+            false
+          );
+          expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+            false
+          );
+        } finally {
+          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        }
+      },
+      HIERARCHY_TEST_TIMEOUT_MS
+    );
+  });
+
+  describe('reject guard (FR-007 / SC-004 / US3 AS-4)', () => {
+    const allPublicCombo: PrivacyCombo = {
+      spacePrivacy: PRIVACY_COMBOS[0].spacePrivacy,
+      subspacePrivacy: PRIVACY_COMBOS[0].subspacePrivacy,
+      subsubspacePrivacy: PRIVACY_COMBOS[0].subsubspacePrivacy,
+    };
+
+    test(
+      'REJECTed application on an all-public/setting-enabled hierarchy grants no membership at all',
+      async () => {
+        const { scenario, applicationResult } = await buildAndApply(
+          'app-hierarchy-parity-reject',
+          allPublicCombo,
+          true
+        );
+
+        try {
+          expect(applicationResult?.error).toBeUndefined();
+          const applicationId =
+            applicationResult?.data?.applyForEntryRoleOnRoleSet?.id;
+          expect(applicationId?.length).toEqual(36);
+
+          await eventOnRoleSetApplication(applicationId as string, 'REJECT');
+
+          expect(
+            await isMemberOf(scenario.subsubspace.community.roleSetId)
+          ).toBe(false);
+          expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+            false
+          );
+          expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+            false
+          );
+        } finally {
+          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        }
+      },
+      HIERARCHY_TEST_TIMEOUT_MS
+    );
+  });
+});

--- a/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/application-hierarchy-parity.it-spec.ts
@@ -29,6 +29,8 @@ import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-event
 import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
   buildHierarchyScenarioConfig,
+  cleanupScenarioSafely,
+  COMBINED_FLOW_REJECTION,
   comboLabel,
   expectCombinedAncestryGrant,
   HIERARCHY_TEST_TIMEOUT_MS,
@@ -141,7 +143,7 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
               );
             }
           } finally {
-            await TestScenarioFactory.cleanUpBaseScenario(scenario);
+            await cleanupScenarioSafely(scenario);
           }
         },
         HIERARCHY_TEST_TIMEOUT_MS
@@ -166,7 +168,9 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
         );
 
         try {
-          expect(applicationResult?.error?.errors?.[0]?.message).toBeDefined();
+          expect(applicationResult?.error?.errors?.[0]?.message).toMatch(
+            COMBINED_FLOW_REJECTION
+          );
           expect(
             applicationResult?.data?.applyForEntryRoleOnRoleSet?.id
           ).toBeFalsy();
@@ -181,7 +185,7 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
             false
           );
         } finally {
-          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+          await cleanupScenarioSafely(scenario);
         }
       },
       HIERARCHY_TEST_TIMEOUT_MS
@@ -222,7 +226,7 @@ describe('Application hierarchy parity — combined flow (FR-019/SC-009)', () =>
             false
           );
         } finally {
-          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+          await cleanupScenarioSafely(scenario);
         }
       },
       HIERARCHY_TEST_TIMEOUT_MS

--- a/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared fixture for the public/private ancestry parity matrix (FR-019 /
+ * SC-009 — workspace feature 017-combined-subspace-application).
+ *
+ * Builds a Root (L0) -> Sub (L1) -> SubSub (L2) hierarchy via
+ * `TestScenarioFactory.createBaseScenario`'s recursive `space.subspace.subspace`
+ * config, each level carrying its own `settings.privacy.mode` +
+ * `settings.membership.policy`. Consumed by both
+ * `application-hierarchy-parity.it-spec.ts` and
+ * `invitation-hierarchy-parity.it-spec.ts` so the two flows are exercised
+ * against an identical hierarchy shape.
+ *
+ * Hooks that build a hierarchy are heavy (org + 3 spaces via the real API),
+ * so each test.each row builds and tears down its own scenario inside the
+ * test body rather than relying on a single shared `beforeAll` — this keeps
+ * every cell independent (no cross-cell contamination) at the cost of one
+ * scenario per cell. Callers should pass a generous per-test timeout (see
+ * `HIERARCHY_TEST_TIMEOUT_MS`).
+ */
+import {
+  CommunityMembershipPolicy,
+  SpacePrivacyMode,
+} from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import { TestScenarioConfig } from '@alkemio/tests-lib';
+
+/** Hooks are heavy (org + 3 spaces created per cell) — raise past the default hookTimeout/testTimeout budget is already generous (30 min global), but keep an explicit constant so specs can reference it consistently. */
+export const HIERARCHY_TEST_TIMEOUT_MS = 300_000; // 5 minutes per cell
+
+export interface PrivacyCombo {
+  /** Root (L0) Space privacy mode. */
+  spacePrivacy: SpacePrivacyMode;
+  /** Sub (L1) Subspace privacy mode — the immediate ancestor of SubSub. */
+  subspacePrivacy: SpacePrivacyMode;
+  /** SubSub (L2) Sub-subspace privacy mode — the application/invitation target. */
+  subsubspacePrivacy: SpacePrivacyMode;
+}
+
+const { Public, Private } = SpacePrivacyMode;
+
+/**
+ * The full 2x2x2 public/private matrix across Root -> Sub -> SubSub
+ * (FR-019 / SC-009 / research R5).
+ */
+export const PRIVACY_COMBOS: PrivacyCombo[] = [
+  { spacePrivacy: Public, subspacePrivacy: Public, subsubspacePrivacy: Public },
+  {
+    spacePrivacy: Public,
+    subspacePrivacy: Public,
+    subsubspacePrivacy: Private,
+  },
+  {
+    spacePrivacy: Public,
+    subspacePrivacy: Private,
+    subsubspacePrivacy: Public,
+  },
+  {
+    spacePrivacy: Public,
+    subspacePrivacy: Private,
+    subsubspacePrivacy: Private,
+  },
+  {
+    spacePrivacy: Private,
+    subspacePrivacy: Public,
+    subsubspacePrivacy: Public,
+  },
+  {
+    spacePrivacy: Private,
+    subspacePrivacy: Public,
+    subsubspacePrivacy: Private,
+  },
+  {
+    spacePrivacy: Private,
+    subspacePrivacy: Private,
+    subsubspacePrivacy: Public,
+  },
+  {
+    spacePrivacy: Private,
+    subspacePrivacy: Private,
+    subsubspacePrivacy: Private,
+  },
+];
+
+/**
+ * FR-002 reachability precondition for the combined (application) flow: the
+ * ancestor chain — Root and Sub, i.e. every ancestor of the SubSub target up
+ * to the reachable root — must be public. Per the cross-repo contract (plan.md
+ * "Cross-repo overview": `parent(+ancestors) PUBLIC`), the SubSub's *own*
+ * privacy is not part of this gate — it is varied independently in the matrix
+ * precisely to prove it has no bearing on the ancestor-grant outcome.
+ */
+export const isAncestorChainPublic = (combo: PrivacyCombo): boolean =>
+  combo.spacePrivacy === Public && combo.subspacePrivacy === Public;
+
+/**
+ * Type-correct expected outcome for the application (combined) flow per
+ * FR-002/FR-003: the full ancestor grant (Sub + Root, in addition to SubSub
+ * itself) fires only when the whole ancestor chain is public AND the
+ * `allowSubspaceAdminsToInviteMembers` setting is enabled on that chain.
+ */
+export const expectCombinedAncestryGrant = (
+  combo: PrivacyCombo,
+  settingEnabled: boolean
+): boolean => isAncestorChainPublic(combo) && settingEnabled;
+
+export const comboLabel = (combo: PrivacyCombo): string =>
+  `space=${combo.spacePrivacy}/subspace=${combo.subspacePrivacy}/subsubspace=${combo.subsubspacePrivacy}`;
+
+/**
+ * Builds the `TestScenarioConfig` for one matrix cell: Root -> Sub -> SubSub,
+ * each with its own privacy mode; SubSub carries `membershipPolicy` (the
+ * application suite uses `Applications`, the invitation suite doesn't need a
+ * particular policy since invitations are admin-authorised directly). The
+ * `allowSubspaceAdminsToInviteMembers` setting is applied uniformly to Root
+ * and Sub — the two ancestors whose setting gates the combined grant per the
+ * spec's single-scalar `settingEnabled` axis.
+ */
+export const buildHierarchyScenarioConfig = (
+  name: string,
+  combo: PrivacyCombo,
+  opts: {
+    subsubspaceMembershipPolicy?: CommunityMembershipPolicy;
+    settingEnabled: boolean;
+  }
+): TestScenarioConfig => ({
+  name,
+  space: {
+    collaboration: { addTutorialCallouts: false },
+    settings: {
+      privacy: { mode: combo.spacePrivacy },
+      membership: {
+        allowSubspaceAdminsToInviteMembers: opts.settingEnabled,
+      },
+    },
+    subspace: {
+      collaboration: { addTutorialCallouts: false },
+      settings: {
+        privacy: { mode: combo.subspacePrivacy },
+        membership: {
+          allowSubspaceAdminsToInviteMembers: opts.settingEnabled,
+        },
+      },
+      subspace: {
+        collaboration: { addTutorialCallouts: false },
+        settings: {
+          privacy: { mode: combo.subsubspacePrivacy },
+          membership: opts.subsubspaceMembershipPolicy
+            ? { policy: opts.subsubspaceMembershipPolicy }
+            : undefined,
+        },
+      },
+    },
+  },
+});

--- a/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
@@ -21,10 +21,42 @@ import {
   CommunityMembershipPolicy,
   SpacePrivacyMode,
 } from '@alkemio/tests-lib/core/generated/alkemio-schema';
-import { TestScenarioConfig } from '@alkemio/tests-lib';
+import { TestScenarioConfig, TestScenarioFactory } from '@alkemio/tests-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
 
-/** Hooks are heavy (org + 3 spaces created per cell) — raise past the default hookTimeout/testTimeout budget is already generous (30 min global), but keep an explicit constant so specs can reference it consistently. */
-export const HIERARCHY_TEST_TIMEOUT_MS = 300_000; // 5 minutes per cell
+/**
+ * Per-test budget. Each cell builds an org + 3 spaces via the real API, so it
+ * needs the same generous budget the rest of the integration suite gets —
+ * match the global 30-minute testTimeout (a per-test timeout OVERRIDES the
+ * global one, so a smaller value here would LOWER the budget, not raise it).
+ */
+export const HIERARCHY_TEST_TIMEOUT_MS = 1_800_000; // 30 minutes, = global testTimeout
+
+/**
+ * The combined application flow's rejection message for a non-eligible
+ * non-parent-member applicant (today's "join the parent first" rule). Negative
+ * cells assert THIS rejection — not merely that some error occurred — so a
+ * scenario-setup failure or an unrelated 500 cannot green-light the cell.
+ */
+export const COMBINED_FLOW_REJECTION = /not a member of the parent Community/i;
+
+/**
+ * Tear down a scenario without masking an in-flight test failure: a throw
+ * inside `finally` REPLACES the original assertion error (JS semantics), so a
+ * flaky teardown would otherwise hide the real reason a cell failed.
+ */
+export const cleanupScenarioSafely = async (
+  scenario: OrganizationWithSpaceModel
+): Promise<void> => {
+  try {
+    await TestScenarioFactory.cleanUpBaseScenario(scenario);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `hierarchy-parity: scenario cleanup failed (original test outcome preserved): ${e}`
+    );
+  }
+};
 
 export interface PrivacyCombo {
   /** Root (L0) Space privacy mode. */

--- a/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
@@ -34,12 +34,18 @@ import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.req
 export const HIERARCHY_TEST_TIMEOUT_MS = 1_800_000; // 30 minutes, = global testTimeout
 
 /**
- * The combined application flow's rejection message for a non-eligible
- * non-parent-member applicant (today's "join the parent first" rule). Negative
- * cells assert THIS rejection — not merely that some error occurred — so a
- * scenario-setup failure or an unrelated 500 cannot green-light the cell.
+ * The combined application flow's rejection for a non-eligible
+ * non-parent-member applicant. Two legitimate rejection layers exist —
+ * negative cells assert one of THESE (not merely that some error occurred,
+ * so a scenario-setup failure or an unrelated 500 cannot green-light a cell):
+ * - authorization: the APPLY privilege is not exposed on the subspace
+ *   role-set (the privilege is the client's single trusted signal, so
+ *   ineligible applicants are stopped here first);
+ * - precondition: today's "join the parent first" rule inside the mutation
+ *   (defence in depth, e.g. authorisation revoked between exposure and call).
  */
-export const COMBINED_FLOW_REJECTION = /not a member of the parent Community/i;
+export const COMBINED_FLOW_REJECTION =
+  /not a member of the parent Community|Authorization: unable to grant 'roleset-entry-role-apply'/i;
 
 /**
  * Tear down a scenario without masking an in-flight test failure: a throw

--- a/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture.ts
@@ -23,6 +23,7 @@ import {
 } from '@alkemio/tests-lib/core/generated/alkemio-schema';
 import { TestScenarioConfig, TestScenarioFactory } from '@alkemio/tests-lib';
 import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 
 /**
  * Per-test budget. Each cell builds an org + 3 spaces via the real API, so it
@@ -75,6 +76,7 @@ const { Public, Private } = SpacePrivacyMode;
  */
 export const PRIVACY_COMBOS: PrivacyCombo[] = [
   { spacePrivacy: Public, subspacePrivacy: Public, subsubspacePrivacy: Public },
+  // (ALL_PUBLIC_COMBO below aliases this first entry — keep it first.)
   {
     spacePrivacy: Public,
     subspacePrivacy: Public,
@@ -111,6 +113,26 @@ export const PRIVACY_COMBOS: PrivacyCombo[] = [
     subsubspacePrivacy: Private,
   },
 ];
+
+/**
+ * Canonical baseline for non-matrix guard tests (setting-off, reject,
+ * removal-cascade, single-hop): the all-public cell, named explicitly so the
+ * guards do not depend on PRIVACY_COMBOS array ordering.
+ */
+export const ALL_PUBLIC_COMBO: PrivacyCombo = PRIVACY_COMBOS[0];
+
+/**
+ * Membership check shared by every parity assertion: is the given user a
+ * MEMBER of the role-set? (Centralised here — the specs previously duplicated
+ * this helper four times.)
+ */
+export const isUserMemberOfRoleSet = async (
+  roleSetId: string,
+  userId: string
+): Promise<boolean> => {
+  const members = await getRoleSetUsersInMemberRole(roleSetId);
+  return members.some(m => m.id === userId);
+};
 
 /**
  * FR-002 reachability precondition for the combined (application) flow: the

--- a/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
@@ -42,15 +42,14 @@ import {
   inviteForEntryRoleOnRoleSet,
 } from '@functional-api/roleset/invitations/invitation.request.params';
 import { eventOnRoleSetInvitation } from '@functional-api/roleset/roleset-events.request.params';
+import { getSingleInvitationResult } from '@functional-api/roleset/roleset.request.params';
 import {
-  getRoleSetUsersInMemberRole,
-  getSingleInvitationResult,
-} from '@functional-api/roleset/roleset.request.params';
-import {
+  ALL_PUBLIC_COMBO,
   buildHierarchyScenarioConfig,
   cleanupScenarioSafely,
   comboLabel,
   HIERARCHY_TEST_TIMEOUT_MS,
+  isUserMemberOfRoleSet,
   PRIVACY_COMBOS,
   PrivacyCombo,
 } from './hierarchy-parity.fixture';
@@ -60,10 +59,8 @@ const message = 'Hello, feel free to join our community!';
 
 const inviteeId = () => TestUserManager.users.nonSpaceMember.id;
 
-const isMemberOf = async (roleSetId: string): Promise<boolean> => {
-  const members = await getRoleSetUsersInMemberRole(roleSetId);
-  return members.some(m => m.id === inviteeId());
-};
+const isMemberOf = (roleSetId: string): Promise<boolean> =>
+  isUserMemberOfRoleSet(roleSetId, inviteeId());
 
 const inviteAndAccept = async (roleSetId: string) => {
   const invitationData = await inviteForEntryRoleOnRoleSet(
@@ -132,7 +129,7 @@ describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () =
   test(
     'setting disabled does not block the invitation ancestor grant (unlike applications, invitations are not setting-gated)',
     async () => {
-      const allPublicCombo: PrivacyCombo = PRIVACY_COMBOS[0];
+      const allPublicCombo: PrivacyCombo = ALL_PUBLIC_COMBO;
       const scenarioConfig = buildHierarchyScenarioConfig(
         'inv-hierarchy-parity-setting-off',
         allPublicCombo,
@@ -165,7 +162,7 @@ describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () =
     test(
       'inviting directly into the immediate parent (Sub) still grants Root ancestor membership, unchanged',
       async () => {
-        const allPublicCombo: PrivacyCombo = PRIVACY_COMBOS[0];
+        const allPublicCombo: PrivacyCombo = ALL_PUBLIC_COMBO;
         const scenarioConfig = buildHierarchyScenarioConfig(
           'inv-hierarchy-parity-single-hop',
           allPublicCombo,

--- a/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
@@ -1,0 +1,199 @@
+/**
+ * API/integration parity suite — invitation flow (behaviour-preservation
+ * guard).
+ *
+ * Workspace feature `017-combined-subspace-application` (FR-018/FR-019,
+ * SC-008/SC-009, research R2/R5). Exercises the same Root -> Sub -> SubSub
+ * public/private matrix as `application-hierarchy-parity.it-spec.ts`, but via
+ * the invitation flow, to prove the refactor that extracts the shared
+ * ancestor-chain grant service (R1) does not change invitation's observable
+ * behaviour for the cases that already pass today, and that (unlike
+ * applications) invitations are never gated by Space privacy or the
+ * `allowSubspaceAdminsToInviteMembers` setting — an admin invitation is always
+ * authorised directly.
+ *
+ * Nuance (research R2 — read before editing): today, `acceptInvitationToRoleSet`
+ * only walks a single hop (the immediate parent) and `assignActorToRole`
+ * requires the actor already be a member of *that* role-set's immediate
+ * parent. So inviting a genuine non-member (member of nothing) directly into
+ * the SubSub (2 hops from Root) THROWS on accept today — it is a latent bug,
+ * not a passing case. Post-refactor, the shared service walks the full chain,
+ * so this exact scenario starts succeeding (SubSub + Sub + Root all granted).
+ * That is an intentional superset (FR-018/SC-008 only guarantees *currently
+ * passing* invitation scenarios stay green) — the assertions below encode the
+ * POST-refactor expected outcome, and — per the rollout ordering documented in
+ * plan.md — only go green once the `server` slice has merged.
+ *
+ * The single-hop "regression guard" describe block at the bottom asserts the
+ * pre-existing, already-working "invite to parent" mechanism (invitee invited
+ * directly into Sub) is untouched — this is the true SC-008 baseline; it does
+ * not depend on the new full-chain walk and should hold both before and after
+ * the server change.
+ */
+import {
+  TestScenarioFactory,
+  TestUser,
+  TestUserManager,
+} from '@alkemio/tests-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { RoleName } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  deleteInvitation,
+  inviteForEntryRoleOnRoleSet,
+} from '@functional-api/roleset/invitations/invitation.request.params';
+import { eventOnRoleSetInvitation } from '@functional-api/roleset/roleset-events.request.params';
+import {
+  getRoleSetUsersInMemberRole,
+  getSingleInvitationResult,
+} from '@functional-api/roleset/roleset.request.params';
+import {
+  buildHierarchyScenarioConfig,
+  comboLabel,
+  HIERARCHY_TEST_TIMEOUT_MS,
+  PRIVACY_COMBOS,
+  PrivacyCombo,
+} from './hierarchy-parity.fixture';
+
+const INVITEE = TestUser.NON_SPACE_MEMBER;
+const message = 'Hello, feel free to join our community!';
+
+const inviteeId = () => TestUserManager.users.nonSpaceMember.id;
+
+const isMemberOf = async (roleSetId: string): Promise<boolean> => {
+  const members = await getRoleSetUsersInMemberRole(roleSetId);
+  return members.some(m => m.id === inviteeId());
+};
+
+const inviteAndAccept = async (roleSetId: string) => {
+  const invitationData = await inviteForEntryRoleOnRoleSet(
+    roleSetId,
+    [inviteeId()],
+    [],
+    message,
+    [RoleName.Member],
+    TestUser.GLOBAL_ADMIN
+  );
+  const invitationResult = getSingleInvitationResult(invitationData);
+  const invitationId = invitationResult?.invitation?.id;
+
+  if (invitationId) {
+    await eventOnRoleSetInvitation(invitationId, 'ACCEPT', INVITEE);
+    await deleteInvitation(invitationId);
+  }
+
+  return { invitationData, invitationId };
+};
+
+describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () => {
+  describe.each(PRIVACY_COMBOS)(
+    'privacy combo: $spacePrivacy/$subspacePrivacy/$subsubspacePrivacy',
+    (combo: PrivacyCombo) => {
+      test(
+        `invite+accept into SubSub grants full ancestry irrespective of privacy — ${comboLabel(
+          combo
+        )}`,
+        async () => {
+          const scenarioConfig = buildHierarchyScenarioConfig(
+            'inv-hierarchy-parity',
+            combo,
+            { settingEnabled: true }
+          );
+          const scenario: OrganizationWithSpaceModel =
+            await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+          try {
+            const { invitationId } = await inviteAndAccept(
+              scenario.subsubspace.community.roleSetId
+            );
+            expect(invitationId?.length).toEqual(36);
+
+            // Invitations are admin-authorised directly — unlike the
+            // application flow, Space privacy never gates them. The
+            // full-chain walk (R1) grants SubSub + every ancestor.
+            expect(
+              await isMemberOf(scenario.subsubspace.community.roleSetId)
+            ).toBe(true);
+            expect(
+              await isMemberOf(scenario.subspace.community.roleSetId)
+            ).toBe(true);
+            expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+              true
+            );
+          } finally {
+            await TestScenarioFactory.cleanUpBaseScenario(scenario);
+          }
+        },
+        HIERARCHY_TEST_TIMEOUT_MS
+      );
+    }
+  );
+
+  test(
+    'setting disabled does not block the invitation ancestor grant (unlike applications, invitations are not setting-gated)',
+    async () => {
+      const allPublicCombo: PrivacyCombo = PRIVACY_COMBOS[0];
+      const scenarioConfig = buildHierarchyScenarioConfig(
+        'inv-hierarchy-parity-setting-off',
+        allPublicCombo,
+        { settingEnabled: false }
+      );
+      const scenario: OrganizationWithSpaceModel =
+        await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+      try {
+        const { invitationId } = await inviteAndAccept(
+          scenario.subsubspace.community.roleSetId
+        );
+        expect(invitationId?.length).toEqual(36);
+
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
+      } finally {
+        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+      }
+    },
+    HIERARCHY_TEST_TIMEOUT_MS
+  );
+
+  describe('single-hop regression guard — the proven, already-working invitation path', () => {
+    test(
+      'inviting directly into the immediate parent (Sub) still grants Root ancestor membership, unchanged',
+      async () => {
+        const allPublicCombo: PrivacyCombo = PRIVACY_COMBOS[0];
+        const scenarioConfig = buildHierarchyScenarioConfig(
+          'inv-hierarchy-parity-single-hop',
+          allPublicCombo,
+          { settingEnabled: true }
+        );
+        const scenario: OrganizationWithSpaceModel =
+          await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+        try {
+          const { invitationId } = await inviteAndAccept(
+            scenario.subspace.community.roleSetId
+          );
+          expect(invitationId?.length).toEqual(36);
+
+          expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+            true
+          );
+          expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+            true
+          );
+          // Never invited into SubSub — no membership grant there.
+          expect(
+            await isMemberOf(scenario.subsubspace.community.roleSetId)
+          ).toBe(false);
+        } finally {
+          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        }
+      },
+      HIERARCHY_TEST_TIMEOUT_MS
+    );
+  });
+});

--- a/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/invitation-hierarchy-parity.it-spec.ts
@@ -48,6 +48,7 @@ import {
 } from '@functional-api/roleset/roleset.request.params';
 import {
   buildHierarchyScenarioConfig,
+  cleanupScenarioSafely,
   comboLabel,
   HIERARCHY_TEST_TIMEOUT_MS,
   PRIVACY_COMBOS,
@@ -120,7 +121,7 @@ describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () =
               true
             );
           } finally {
-            await TestScenarioFactory.cleanUpBaseScenario(scenario);
+            await cleanupScenarioSafely(scenario);
           }
         },
         HIERARCHY_TEST_TIMEOUT_MS
@@ -154,7 +155,7 @@ describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () =
         );
         expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
       } finally {
-        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        await cleanupScenarioSafely(scenario);
       }
     },
     HIERARCHY_TEST_TIMEOUT_MS
@@ -190,7 +191,7 @@ describe('Invitation hierarchy parity — behaviour preservation (SC-008)', () =
             await isMemberOf(scenario.subsubspace.community.roleSetId)
           ).toBe(false);
         } finally {
-          await TestScenarioFactory.cleanUpBaseScenario(scenario);
+          await cleanupScenarioSafely(scenario);
         }
       },
       HIERARCHY_TEST_TIMEOUT_MS

--- a/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
@@ -1,0 +1,123 @@
+/**
+ * API/integration guard — removal cascade + re-application.
+ *
+ * Workspace feature `017-combined-subspace-application` (regression guard).
+ * After the combined apply→approve flow grants an actor membership of a
+ * Subspace and its ancestors, removing that actor from an ANCESTOR Space
+ * must cascade: the descendant memberships are revoked as well, and the
+ * actor can immediately apply to the Subspace again.
+ *
+ * Regression: server#`revokeSpaceTreeCredentials` revoked the descendant
+ * credentials but never invalidated the descendants' role-set membership
+ * caches, so a re-application was rejected with ROLE_SET_ALREADY_MEMBER
+ * even though the membership credential was gone (stale cache-first
+ * `isMember` read in `validateApplicationFromActor`).
+ */
+import { CommunityMembershipPolicy } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import { RoleName } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  TestScenarioFactory,
+  TestUser,
+  TestUserManager,
+} from '@alkemio/tests-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { createApplication } from '@functional-api/roleset/application/application.request.params';
+import { removeRoleFromUser } from '@functional-api/roleset/roles-request.params';
+import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
+import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
+import {
+  buildHierarchyScenarioConfig,
+  HIERARCHY_TEST_TIMEOUT_MS,
+  PRIVACY_COMBOS,
+} from './hierarchy-parity.fixture';
+
+const APPLICANT = TestUser.NON_SPACE_MEMBER;
+const applicantId = () => TestUserManager.users.nonSpaceMember.id;
+
+const isMemberOf = async (roleSetId: string): Promise<boolean> => {
+  const members = await getRoleSetUsersInMemberRole(roleSetId);
+  return members.some(m => m.id === applicantId());
+};
+
+const applyAndApprove = async (roleSetId: string): Promise<void> => {
+  const applicationResult = await createApplication(roleSetId, APPLICANT);
+  expect(applicationResult?.error).toBeUndefined();
+  const applicationId = applicationResult?.data?.applyForEntryRoleOnRoleSet?.id;
+  expect(applicationId?.length).toEqual(36);
+  await eventOnRoleSetApplication(applicationId as string, 'APPROVE');
+};
+
+describe('Removal cascade + re-application (workspace#017 regression guard)', () => {
+  // All-public chain with the setting enabled — the positive combined cell.
+  const allPublicCombo = PRIVACY_COMBOS[0];
+
+  test(
+    'removing the actor from an ancestor cascades to descendants and a fresh application succeeds',
+    async () => {
+      const scenarioConfig = buildHierarchyScenarioConfig(
+        'removal-cascade',
+        allPublicCombo,
+        {
+          subsubspaceMembershipPolicy: CommunityMembershipPolicy.Applications,
+          settingEnabled: true,
+        }
+      );
+      const scenario: OrganizationWithSpaceModel =
+        await TestScenarioFactory.createBaseScenario(scenarioConfig);
+
+      try {
+        // 1. Combined flow: apply to the SubSub, approve, full ancestry granted.
+        await applyAndApprove(scenario.subsubspace.community.roleSetId);
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
+
+        // 2. Remove the actor from the ROOT Space (the ancestor).
+        await removeRoleFromUser(
+          applicantId(),
+          scenario.space.community.roleSetId,
+          RoleName.Member
+        );
+
+        // 3. Cascade: the descendant memberships are revoked too.
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(
+          false
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          false
+        );
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          false
+        );
+
+        // 4. Regression guard: a fresh application to the SubSub succeeds —
+        // no ROLE_SET_ALREADY_MEMBER from a stale membership cache.
+        const reapplication = await createApplication(
+          scenario.subsubspace.community.roleSetId,
+          APPLICANT
+        );
+        expect(reapplication?.error).toBeUndefined();
+        const reapplicationId =
+          reapplication?.data?.applyForEntryRoleOnRoleSet?.id;
+        expect(reapplicationId?.length).toEqual(36);
+
+        // 5. And the combined grant works again end to end.
+        await eventOnRoleSetApplication(reapplicationId as string, 'APPROVE');
+        expect(await isMemberOf(scenario.subsubspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.subspace.community.roleSetId)).toBe(
+          true
+        );
+        expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
+      } finally {
+        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+      }
+    },
+    HIERARCHY_TEST_TIMEOUT_MS
+  );
+});

--- a/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
@@ -24,21 +24,19 @@ import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/O
 import { createApplication } from '@functional-api/roleset/application/application.request.params';
 import { removeRoleFromUser } from '@functional-api/roleset/roles-request.params';
 import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-events.request.params';
-import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
+  ALL_PUBLIC_COMBO,
   buildHierarchyScenarioConfig,
   cleanupScenarioSafely,
   HIERARCHY_TEST_TIMEOUT_MS,
-  PRIVACY_COMBOS,
+  isUserMemberOfRoleSet,
 } from './hierarchy-parity.fixture';
 
 const APPLICANT = TestUser.NON_SPACE_MEMBER;
 const applicantId = () => TestUserManager.users.nonSpaceMember.id;
 
-const isMemberOf = async (roleSetId: string): Promise<boolean> => {
-  const members = await getRoleSetUsersInMemberRole(roleSetId);
-  return members.some(m => m.id === applicantId());
-};
+const isMemberOf = (roleSetId: string): Promise<boolean> =>
+  isUserMemberOfRoleSet(roleSetId, applicantId());
 
 const applyAndApprove = async (roleSetId: string): Promise<void> => {
   const applicationResult = await createApplication(roleSetId, APPLICANT);
@@ -50,7 +48,7 @@ const applyAndApprove = async (roleSetId: string): Promise<void> => {
 
 describe('Removal cascade + re-application (workspace#017 regression guard)', () => {
   // All-public chain with the setting enabled — the positive combined cell.
-  const allPublicCombo = PRIVACY_COMBOS[0];
+  const allPublicCombo = ALL_PUBLIC_COMBO;
 
   test(
     'removing the actor from an ancestor cascades to descendants and a fresh application succeeds',

--- a/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
+++ b/server-api/src/functional-api/roleset/hierarchy-parity/removal-cascade.it-spec.ts
@@ -27,6 +27,7 @@ import { eventOnRoleSetApplication } from '@functional-api/roleset/roleset-event
 import { getRoleSetUsersInMemberRole } from '@functional-api/roleset/roleset.request.params';
 import {
   buildHierarchyScenarioConfig,
+  cleanupScenarioSafely,
   HIERARCHY_TEST_TIMEOUT_MS,
   PRIVACY_COMBOS,
 } from './hierarchy-parity.fixture';
@@ -115,7 +116,7 @@ describe('Removal cascade + re-application (workspace#017 regression guard)', ()
         );
         expect(await isMemberOf(scenario.space.community.roleSetId)).toBe(true);
       } finally {
-        await TestScenarioFactory.cleanUpBaseScenario(scenario);
+        await cleanupScenarioSafely(scenario);
       }
     },
     HIERARCHY_TEST_TIMEOUT_MS


### PR DESCRIPTION
## Summary

**Test-lead slice of `workspace#017-combined-subspace-application`** (alkem-io/server#6189): the API/integration public/private ancestry parity matrix (FR-019/SC-009) for the combined Subspace-application flow, plus the regression guards added during live verification.

### New suite — `server-api/src/functional-api/roleset/hierarchy-parity/`

- **`hierarchy-parity.fixture.ts`** — Root → Sub → SubSub scenario builder over the full 2×2×2 privacy matrix (per-level `privacy.mode` + membership settings), uniform `allowSubspaceAdminsToInviteMembers` axis.
- **`application-hierarchy-parity.it-spec.ts`** (10 cases) — combined flow: full ancestry granted only when every ancestor is public + opted in; negative cells reject the apply itself; REJECT grants nothing; no application is created against ancestor role-sets (FR-004).
- **`invitation-hierarchy-parity.it-spec.ts`** (10 cases) — behaviour preservation (SC-008): invite+accept outcomes irrespective of privacy/setting; single-hop regression cell unchanged.
- **`removal-cascade.it-spec.ts`** — regression guard for the stale membership-cache bug found live: removal from an ancestor cascades to descendants and a **fresh application succeeds** (no `ROLE_SET_ALREADY_MEMBER`).
- **`actor-reachability.it-spec.ts`** — guards the actor-relative reachability decision (workspace ADR 0001 §8): a member of a PRIVATE root applies directly to the public SubSub; a stranger to the same hierarchy is still rejected.

Auto-collected by the existing `roleset` vitest project — no config change.

### Status

**All 23 cases verified green live** (2026-07-07) against a local stack running the server slice (alkem-io/server#6232). ⚠️ Runs green in CI only after the server PR merges (rollout ordering — the suite asserts the new server behaviour). Run the parity files **serially**: concurrent `TestScenarioFactory` scenario creation across files is flaky.

Refs alkem-io/server#6189 · `workspace#017-combined-subspace-application` · companion: alkem-io/server#6232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new integration/functional specs for combined hierarchical membership flows across three levels, covering actor-relative reachability, application hierarchy parity (combined flow), invitation hierarchy parity, and removal/re-application cascade.
  * Introduced a shared hierarchy-parity fixture to run the public/private privacy matrix consistently, including an extended timeout, shared rejection-message assertions, and safer scenario cleanup.
  * Added regression coverage to verify correct membership grant/revocation behavior across ancestor role sets and to prevent stale-membership issues when combined-flow conditions are not met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->