### PR TITLE
fix(ci): repair the nightly deploy map — archived repos, lost file-service, missing live deps

### DIFF
--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -47,6 +47,14 @@ on:
         required: false
         type: string
         default: develop
+      kratos_webhooks_branch:
+        required: false
+        type: string
+        default: develop
+      wopi_service_branch:
+        required: false
+        type: string
+        default: develop
   workflow_dispatch:
     inputs:
       server_branch:
@@ -104,6 +112,16 @@ on:
         required: false
         type: string
         default: develop
+      kratos_webhooks_branch:
+        description: "Branch for kratos-webhooks"
+        required: false
+        type: string
+        default: develop
+      wopi_service_branch:
+        description: "Branch for wopi-service"
+        required: false
+        type: string
+        default: develop
 
 jobs:
   trigger-deployments:
@@ -123,11 +141,13 @@ jobs:
             ["whiteboard-collaboration-service"]="${{ inputs.whiteboard_branch }}"
             ["matrix-adapter"]="${{ inputs.matrix_adapter_branch }}"
             ["oidc-service"]="${{ inputs.oidc_branch }}"
-            ["matrix-adapter"]="${{ inputs.file_service_branch }}"
+            ["file-service"]="${{ inputs.file_service_branch }}"
             ["authorization-evaluation-service"]="${{ inputs.auth_eval_branch }}"
             ["documentation"]="${{ inputs.documentations_branch }}"
             ["virtual-contributor-engine-libra-flow"]="${{ inputs.vc_engine_libra_flow_branch }}"
             ["collaborative-document-service"]="${{ inputs.collaborative_document_service_branch }}"
+            ["kratos-webhooks"]="${{ inputs.kratos_webhooks_branch }}"
+            ["wopi-service"]="${{ inputs.wopi_service_branch }}"
           )
 
           run_repo_map=()

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -35,27 +35,7 @@ on:
         required: false
         type: string
         default: develop
-      vc_ingest_branch:
-        required: false
-        type: string
-        default: develop
-      vc_engine_generic_branch:
-        required: false
-        type: string
-        default: develop
-      vc_engine_expert_branch:
-        required: false
-        type: string
-        default: develop
-      vc_engine_openai_branch:
-        required: false
-        type: string
-        default: develop
       documentations_branch:
-        required: false
-        type: string
-        default: develop
-      vc_engine_guidance_branch:
         required: false
         type: string
         default: develop
@@ -109,33 +89,8 @@ on:
         required: false
         type: string
         default: develop
-      vc_ingest_branch:
-        description: "Branch for virtual-contributor-ingest-space"
-        required: false
-        type: string
-        default: develop
-      vc_engine_generic_branch:
-        description: "Branch for virtual-contributor-engine-generic"
-        required: false
-        type: string
-        default: develop
-      vc_engine_expert_branch:
-        description: "Branch for virtual-contributor-engine-expert"
-        required: false
-        type: string
-        default: develop
-      vc_engine_openai_branch:
-        description: "Branch for virtual-contributor-engine-openai-assistant"
-        required: false
-        type: string
-        default: develop
       documentations_branch:
         description: "Branch for documentation"
-        required: false
-        type: string
-        default: develop
-      vc_engine_guidance_branch:
-        description: "Branch for virtual-contributor-engine-guidance"
         required: false
         type: string
         default: develop
@@ -170,12 +125,7 @@ jobs:
             ["oidc-service"]="${{ inputs.oidc_branch }}"
             ["matrix-adapter"]="${{ inputs.file_service_branch }}"
             ["authorization-evaluation-service"]="${{ inputs.auth_eval_branch }}"
-            ["virtual-contributor-ingest-space"]="${{ inputs.vc_ingest_branch }}"
-            ["virtual-contributor-engine-generic"]="${{ inputs.vc_engine_generic_branch }}"
-            ["virtual-contributor-engine-expert"]="${{ inputs.vc_engine_expert_branch }}"
-            ["virtual-contributor-engine-openai-assistant"]="${{ inputs.vc_engine_openai_branch }}"
             ["documentation"]="${{ inputs.documentations_branch }}"
-            ["virtual-contributor-engine-guidance"]="${{ inputs.vc_engine_guidance_branch }}"
             ["virtual-contributor-engine-libra-flow"]="${{ inputs.vc_engine_libra_flow_branch }}"
             ["collaborative-document-service"]="${{ inputs.collaborative_document_service_branch }}"
           )


### PR DESCRIPTION
## Summary

**The nightly server-api tests have not actually run for ~6 weeks**, and the deploy map had three distinct classes of rot. The published vitest report (1667 tests / 463 failures) is a stale artifact of the last executed run — not current signal.

### 1. Five archived repos blocked every run (commit 1)

`deploy-all-services.yml` dispatches deploys and waits for each. Five repos in the map were **archived on 2026-05-28** (`virtual-contributor-ingest-space`, `-engine-generic`, `-engine-expert`, `-engine-openai-assistant`, `-engine-guidance`). Dispatches to archived repos stay `queued` forever → the 15-min `wait-for-deployments` times out → `cleanup-db` + `run-e2e-tests` **skipped**. Verified across 30 nightly runs: skipped every night since at least June 9. All five removed (`virtual-contributor-engine-libra-flow`, not archived, stays).

### 2. `file-service` was silently never deployed (commit 2 — pre-existing bug)

A develop-side rename of `matrix-adapter-go` → `matrix-adapter` accidentally also renamed the **file-service key**, leaving two `["matrix-adapter"]` entries. Bash assoc-array last-wins semantics: matrix-adapter got deployed with `file_service_branch`'s value and **file-service was dropped from nightly deploys entirely**. Restored.

### 3. Missing live dependencies (commit 2)

`kratos-webhooks` and `wopi-service` carry `build-deploy-k8s-test-hetzner.yml` (workflow_dispatch-able, default branch `develop`) but were absent — the test env could drift stale on them. Added. (`authorization-evaluation-service` was already present; **`assistant-service` deliberately omitted** — no test coverage for it yet.)

**Final map: 13 unique repos; every referenced input declared in both `workflow_call` and `workflow_dispatch` blocks; YAML validated.**

### Review notes
- First real run after merge tests `develop` incl. the combined-subspace-application feature. Privilege-matrix suites were checked preemptively: asserted rows derive APPLY from the parent-member rule (unchanged by 017) — no drift expected, but eyeball the first report against the stale baseline.
- Consider a `workflow_dispatch` of the nightly right after merging to get signal today (release/66 currently has zero nightly coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)