### PR TITLE
test(roleset): align user.authorization expectations with the 017 exposure fix

### DIFF
--- a/lib/src/common/constants/privileges.ts
+++ b/lib/src/common/constants/privileges.ts
@@ -302,6 +302,24 @@ export const sorted__create_read_update_delete_grant_addMember_apply_invite_addV
     "ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION",
   ].sort();
 
+// Same as above WITHOUT ROLESET_ENTRY_ROLE_APPLY: since the combined-subspace-
+// application exposure fix (workspace#017, server#6232), a subspace role-set
+// only exposes APPLY to parent members or combined-flow-eligible users — the
+// blanket GLOBAL_REGISTERED grant was a false signal (the mutation rejected
+// non-parent-members) and was removed.
+export const sorted__create_read_update_delete_grant_addMember_invite_addVC_accessVC_assignOrganization =
+  [
+    "CREATE",
+    "GRANT",
+    ...readPrivilege,
+    "UPDATE",
+    "DELETE",
+    "ROLESET_ENTRY_ROLE_ASSIGN",
+    "ROLESET_ENTRY_ROLE_INVITE",
+    "COMMUNITY_ASSIGN_VC_FROM_ACCOUNT",
+    "ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION",
+  ].sort();
+
 export const sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC_assignOrganization_notificationsAdmin =
   [
     "CREATE",

--- a/server-api/src/functional-api/roleset/user/user.authorization.it-spec.ts
+++ b/server-api/src/functional-api/roleset/user/user.authorization.it-spec.ts
@@ -2,6 +2,7 @@ import { getRoleSetUserPrivilege } from '../../journey/space/space.request.param
 import {
   sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC,
   sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC_assignOrganization,
+  sorted__create_read_update_delete_grant_addMember_invite_addVC_accessVC_assignOrganization,
   sorted__create_read_update_delete_grant_apply_invite_addVC_accessVC,
   sorted__create_read_update_delete_grant_apply_invite_addVC_accessVC_assignOrganization,
   sorted__read_applyToRoleSet,
@@ -150,11 +151,19 @@ describe('Verify ROLESET_ENTRY_ROLE_ASSIGN privilege', () => {
     // ${TestUser.SPACE_ADMIN}          | ${sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC} - skipped until bug is fixed: https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/server/4860
 
     // Arrange
+    // Since the combined-subspace-application exposure fix (workspace#017,
+    // server#6232) a subspace role-set exposes ROLESET_ENTRY_ROLE_APPLY only
+    // to parent members or combined-flow-eligible users — the old blanket
+    // GLOBAL_REGISTERED grant was a false signal (the apply mutation rejected
+    // non-parent-members). On this subsubspace its parent (the subspace) has
+    // not opted in via allowSubspaceAdminsToInviteMembers, so:
+    //  - GLOBAL_SUPPORT_ADMIN (not a subspace member) no longer sees APPLY;
+    //  - SPACE_MEMBER (grandparent member only) no longer sees APPLY.
     test.each`
       user                             | myPrivileges
       ${TestUser.GLOBAL_ADMIN}         | ${sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC_assignOrganization}
-      ${TestUser.GLOBAL_SUPPORT_ADMIN} | ${sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC_assignOrganization}
-      ${TestUser.SPACE_MEMBER}         | ${['ROLESET_ENTRY_ROLE_APPLY']}
+      ${TestUser.GLOBAL_SUPPORT_ADMIN} | ${sorted__create_read_update_delete_grant_addMember_invite_addVC_accessVC_assignOrganization}
+      ${TestUser.SPACE_MEMBER}         | ${[]}
       ${TestUser.SUBSPACE_ADMIN}       | ${sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC}
       ${TestUser.SUBSPACE_MEMBER}      | ${['ROLESET_ENTRY_ROLE_APPLY']}
       ${TestUser.SUBSUBSPACE_ADMIN}    | ${sorted__create_read_update_delete_grant_addMember_apply_invite_addVC_accessVC}


### PR DESCRIPTION
## Summary

Investigation of the "flagged regressions" in the (stale) nightly report, run locally against the `release/66` server. **Verdict: no storage/entitlement regressions; two genuinely stale privilege expectations from the 017 exposure fix.**

### What was found

| Suite | Local result | Verdict |
|---|---|---|
| storage/auth (document privilege matrices) | 110/110 on the retried file; all executed tests pass | ✅ no regressions — earlier local failures were a traefik connection-reset quirk (requests >~9s via host-gateway get ECONNRESET), not test logic |
| entitlements (space/vc functional) | assertion failures were all connection-class | ✅ no regressions |
| roleset/user.authorization | **2 real failures** | 🔧 stale expectations — fixed here |

### The two stale rows (subsubspace journey)

Both encoded the pre-017 **blanket `GLOBAL_REGISTERED` APPLY** grant, which server#6232's exposure fix removed from subspace role-sets — it was a *false signal*: the apply mutation rejected non-parent-members, so holding the privilege only produced an error toast (the exact UX bug reported on #6189).

- `GLOBAL_SUPPORT_ADMIN` (not a subspace member) → loses APPLY (new no-apply constant)
- `SPACE_MEMBER` (grandparent member only) → `[]`

The **subspace-journey** rows are deliberately unchanged: there the combined-eligibility rule legitimately exposes APPLY (parent L0 public + opted in) — now a *truthful* signal.

Verified locally against the release/66 server: **25/25 green**.

### Separate finding (not this PR): the CI test env is down

The manual nightly run after #552 reached the tests but every suite died at setup with `kratos_unavailable — server could not reach Kratos`; the test-cluster server pod is in **CrashLoopBackOff** on boot (`Issuer.discover` timeout against Hydra — the server→Ory network path on `k8s-hetzner-test` is broken). Needs ops attention before any CI verdict is meaningful.

Refs alkem-io/server#6189 · `workspace#017-combined-subspace-application`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated role assignment permissions for member invitation and organization assignment flows.
  * Added a new permission set for users with broader admin access in subsubspace journeys.

* **Bug Fixes**
  * Corrected privilege expectations so standard space members no longer receive access in scenarios where they should have none.
  * Refined access behavior for role-based member assignment to match the intended permission model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->