### PR TITLE
ci(test-env): reset-pipeline hardening — idempotent jobs + in-cluster readiness probe (#555)

### DIFF
--- a/.github/workflows/cleanup-database.yml
+++ b/.github/workflows/cleanup-database.yml
@@ -280,27 +280,38 @@ jobs:
           kubectl scale deployment/alkemio-server-deployment --replicas=1
           kubectl rollout status deployment/alkemio-server-deployment --timeout=600s
 
-      # `rollout status` returning does NOT mean the API is answering: the pod
-      # can be Ready while the traefik→server path is still settling (stale
-      # conntrack to the pre-wave pod IP), which is what produced ~500 ECONNRESET
-      # test failures in run 28944454812 (test-suites#555). Gate on a real
-      # round-trip to the exact endpoint the tests use before returning.
-      - name: Wait for server API readiness (end-to-end)
+      # `rollout status` returning does NOT mean the API is answering: on a fresh
+      # DB the server does a multi-minute bootstrap (auth reset, platform/space
+      # seeding) before it listens, and the traefik→server path can still be
+      # settling — which produced ~500 ECONNRESET test failures in run
+      # 28944454812 (test-suites#555). Gate on a real round-trip to the exact
+      # endpoint the tests use before returning.
+      #
+      # The probe runs INSIDE the cluster (via a curl pod), not from this
+      # ubuntu-latest runner: test-alkem.io is reachable from the m4 test
+      # runners and from within the cluster, but NOT from GitHub-hosted runners,
+      # so probing here directly returns HTTP 000 (false negative — observed in
+      # run 28956766280 while the server was in fact healthy and listening).
+      - name: Wait for server API readiness (end-to-end, in-cluster)
         env:
           ALKEMIO_SERVER: ${{ vars.ALKEMIO_SERVER }}
         run: |
           set -euo pipefail
-          echo "Probing $ALKEMIO_SERVER for readiness..."
-          for i in $(seq 1 60); do
-            CODE=$(curl -s -o /tmp/probe.out -w '%{http_code}' -X POST "$ALKEMIO_SERVER" \
-              -H 'Content-Type: application/json' \
-              --data '{"query":"{ __typename }"}' || echo 000)
-            if [ "$CODE" = "200" ] && grep -q '"data"' /tmp/probe.out; then
-              echo "Server API ready after ${i} attempt(s)."
-              exit 0
-            fi
-            echo "  attempt $i: HTTP $CODE"
-            sleep 5
-          done
-          echo "Server API not ready after 60 attempts:"; cat /tmp/probe.out || true
-          exit 1
+          echo "Probing $ALKEMIO_SERVER for readiness from inside the cluster..."
+          kubectl run api-readiness-check-${{ github.run_id }}-${{ github.run_attempt }} \
+            --rm -i --restart=Never --image=curlimages/curl:8.10.1 \
+            --env="ALKEMIO_SERVER=$ALKEMIO_SERVER" -- \
+            sh -c '
+              for i in $(seq 1 60); do
+                body=$(curl -s -m 8 -w "\n%{http_code}" -X POST "$ALKEMIO_SERVER" \
+                  -H "Content-Type: application/json" \
+                  --data "{\"query\":\"{ __typename }\"}") || body="000"
+                code=$(printf "%s" "$body" | tail -n1)
+                echo "  attempt $i: HTTP $code"
+                if [ "$code" = "200" ] && printf "%s" "$body" | grep -q "\"data\""; then
+                  echo "Server API ready after $i attempt(s)."
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "Server API not ready after 60 attempts"; exit 1'

--- a/.github/workflows/cleanup-database.yml
+++ b/.github/workflows/cleanup-database.yml
@@ -125,6 +125,11 @@ jobs:
           KRATOS_IMAGE=$(kubectl get deployment kratos -o jsonpath='{.spec.template.spec.containers[0].image}')
           echo "Using Kratos image: $KRATOS_IMAGE"
 
+          # Idempotent: the job name is keyed on github.run_id, so a re-run of a
+          # failed run collides with its own leftover job (a completed Job's spec
+          # is immutable, so `apply` errors). Delete any prior instance first.
+          kubectl delete job "$KRATOS_MIGRATION_JOB" --ignore-not-found --wait=true
+
           kubectl apply -f - <<EOF
           apiVersion: batch/v1
           kind: Job
@@ -162,6 +167,10 @@ jobs:
           HYDRA_MIGRATION_JOB="hydra-migration-job-${{ github.run_id }}"
           HYDRA_IMAGE=$(kubectl get deployment hydra -o jsonpath='{.spec.template.spec.containers[0].image}')
           echo "Using Hydra image: $HYDRA_IMAGE"
+
+          # Idempotent (see Kratos step): delete any leftover job from a re-run
+          # before re-creating, since a completed Job's spec is immutable.
+          kubectl delete job "$HYDRA_MIGRATION_JOB" --ignore-not-found --wait=true
 
           kubectl apply -f - <<EOF
           apiVersion: batch/v1
@@ -244,6 +253,12 @@ jobs:
         run: |
           # Define a unique job name based on the GitHub run ID
           MIGRATION_JOB_NAME="server-migration-job-${{ github.run_id }}"
+
+          # Idempotent: this job (created via --from=cronjob) has no
+          # ttlSecondsAfterFinished, so it never self-cleans — a re-run of a
+          # failed run hits `job already exists` on the create below. Delete any
+          # leftover instance first (test-suites#555).
+          kubectl delete job "$MIGRATION_JOB_NAME" --ignore-not-found --wait=true
 
           # Create the job from the cronjob
           kubectl create job --from=cronjob/server-migration $MIGRATION_JOB_NAME


### PR DESCRIPTION
Follow-up to #556. Small robustness fix for the env-reset pipeline.

## Problem

All three migration jobs (kratos / hydra / server) are named on `${{ github.run_id }}`, which is **identical across re-runs of the same run**. Re-running a failed `run-migration-and-boostrap` job therefore collides with the leftover job from the first attempt:

- The **server** migration job (created via `kubectl create job --from=cronjob/server-migration`) has **no `ttlSecondsAfterFinished`**, so it never self-cleans — a re-run fails hard with `jobs.batch "server-migration-job-<id>" already exists` **before the migration even runs**. Observed on [run 28953628696](https://github.com/alkem-io/test-suites/actions/runs/28953628696): the first attempt's migration had already succeeded; the re-run failed purely on the name clash.
- The **kratos/hydra** jobs are `ttlSecondsAfterFinished: 120` so they usually self-clean, but a re-run inside that 120 s window still collides (a completed Job's spec is immutable, so `kubectl apply` errors).

## Fix

`kubectl delete job "$NAME" --ignore-not-found --wait=true` before (re)creating each of the three. Idempotent; a fresh run (new `run_id`) is unaffected, and a re-run now cleanly replaces its own leftover.

YAML validated (`yaml.safe_load`).

Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)