### PR TITLE
ci(test-env): probe server ClusterIP service in readiness gate, not the public URL (#555)

### DIFF
--- a/.github/workflows/cleanup-database.yml
+++ b/.github/workflows/cleanup-database.yml
@@ -282,28 +282,28 @@ jobs:
 
       # `rollout status` returning does NOT mean the API is answering: on a fresh
       # DB the server does a multi-minute bootstrap (auth reset, platform/space
-      # seeding) before it listens, and the traefik→server path can still be
-      # settling — which produced ~500 ECONNRESET test failures in run
-      # 28944454812 (test-suites#555). Gate on a real round-trip to the exact
-      # endpoint the tests use before returning.
+      # seeding) before it listens — which produced ~500 ECONNRESET test
+      # failures in run 28944454812 (test-suites#555). Gate on a real GraphQL
+      # round-trip before returning.
       #
-      # The probe runs INSIDE the cluster (via a curl pod), not from this
-      # ubuntu-latest runner: test-alkem.io is reachable from the m4 test
-      # runners and from within the cluster, but NOT from GitHub-hosted runners,
-      # so probing here directly returns HTTP 000 (false negative — observed in
-      # run 28956766280 while the server was in fact healthy and listening).
-      - name: Wait for server API readiness (end-to-end, in-cluster)
-        env:
-          ALKEMIO_SERVER: ${{ vars.ALKEMIO_SERVER }}
+      # Probe the server's in-cluster ClusterIP service directly, NOT the public
+      # test-alkem.io URL. Two reasons: (1) test-alkem.io is unreachable from
+      # this ubuntu-latest runner, and (2) even from inside the cluster, curling
+      # the public hostname resolves to the external LoadBalancer IP and must
+      # hairpin-NAT back in — which is per-node flaky and returned HTTP 000 for
+      # a whole probe window while the server was healthy and listening (run
+      # 29004235896). The internal service has no DNS/hairpin dependency and is
+      # the meaningful signal here (is the server serving GraphQL); traefik
+      # itself is always up, so the external path follows once the server is.
+      - name: Wait for server API readiness
         run: |
           set -euo pipefail
-          echo "Probing $ALKEMIO_SERVER for readiness from inside the cluster..."
+          echo "Probing alkemio-server-service:4000/graphql from inside the cluster..."
           kubectl run api-readiness-check-${{ github.run_id }}-${{ github.run_attempt }} \
-            --rm -i --restart=Never --image=curlimages/curl:8.10.1 \
-            --env="ALKEMIO_SERVER=$ALKEMIO_SERVER" -- \
+            --rm -i --restart=Never --image=curlimages/curl:8.10.1 -- \
             sh -c '
               for i in $(seq 1 60); do
-                body=$(curl -s -m 8 -w "\n%{http_code}" -X POST "$ALKEMIO_SERVER" \
+                body=$(curl -s -m 8 -w "\n%{http_code}" -X POST http://alkemio-server-service:4000/graphql \
                   -H "Content-Type: application/json" \
                   --data "{\"query\":\"{ __typename }\"}") || body="000"
                 code=$(printf "%s" "$body" | tail -n1)


### PR DESCRIPTION
Follow-up to #556/#557. Fixes the last false-negative in the reset readiness gate.

## Problem

The in-cluster readiness probe (#557) still curled the **public** `test-alkem.io` URL from the curl pod. From inside the cluster that resolves to the external LoadBalancer IP and must **hairpin-NAT** back in — which is per-node flaky. In run [29004235896](https://github.com/alkem-io/test-suites/actions/runs/29004235896) it returned `HTTP 000` for the **entire** 60-attempt window while the server was demonstrably healthy and listening (OIDC discovered 08:25:36, Nest listening 08:25:36, 0 restarts — #6241 working). My manual probes happened to land on nodes where the hairpin works, which masked it.

## Fix

Probe the **internal ClusterIP service** `http://alkemio-server-service:4000/graphql` — no DNS, no hairpin. It directly asserts the meaningful thing (the server is serving GraphQL). traefik is always up, so the external path the tests use follows once the server is serving. Also drops the now-unneeded `ALKEMIO_SERVER` env plumbing.

Verified live: `kubectl run curl ... http://alkemio-server-service:4000/graphql` returns `{"data":{"__typename":"Query"}}` / 200 reliably, whereas the public URL hairpin was intermittent.

## Why this is the last one

The substantive fixes are already proven on the live env: #6241 (OIDC retry — server now boots clean, 0 restarts) and #556 (Hydra client restoration). The remaining failures were all gate/plumbing bugs in my own #556 probe — wrong runner network (#557), then wrong target (this PR). With the probe hitting the internal service, the gate finally reflects real server health.

Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)