### PR TITLE
test(config): fail fast on insecure remote endpoints (guard ALKEMIO_SERVER_REST drift)

### DIFF
--- a/lib/src/config/create-config-using-envvars.ts
+++ b/lib/src/config/create-config-using-envvars.ts
@@ -48,10 +48,24 @@ export const createConfigUsingEnvVars = (): AlkemioTestConfig => {
  * `ALKEMIO_SERVER_REST` set to `http://…` instead of `https://…`). Localhost
  * over http/ws is normal for local dev and is exempt.
  */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+
 const validateEndpointSchemes = (config: AlkemioTestConfig): void => {
-  const isInsecureRemote = (url: string): boolean =>
-    /^(http|ws):\/\//i.test(url) &&
-    !/^(http|ws):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/i.test(url);
+  // Parse the URL rather than regex the raw string: a string regex both
+  // false-rejects valid local forms (`http://localhost?x=1`, `http://[::1]`) and
+  // can be fooled by userinfo (`http://localhost@evil.example`). The parsed
+  // `hostname` is the real host to compare against the loopback allowlist.
+  const isInsecureRemote = (url: string): boolean => {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return false; // unparseable — not our concern (fails elsewhere with a clearer error)
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'ws:') return false;
+    const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return !LOOPBACK_HOSTS.has(host);
+  };
 
   const named: Array<[string, string]> = [
     ['ALKEMIO_SERVER (graphql.private)', config.endPoints.graphql.private],

--- a/lib/src/config/create-config-using-envvars.ts
+++ b/lib/src/config/create-config-using-envvars.ts
@@ -33,7 +33,43 @@ export const createConfigUsingEnvVars = (): AlkemioTestConfig => {
       },
     },
   };
+  validateEndpointSchemes(config);
   return config;
+};
+
+/**
+ * Fail fast when a REMOTE endpoint is configured over an insecure scheme
+ * (`http://` / `ws://`). Every hosted environment (test/dev/…) is served over
+ * TLS behind Traefik, which 301-redirects http→https and (for wss) rejects
+ * plain ws. A client like supertest that doesn't follow redirects then sees a
+ * 301 on every request, which surfaces as a cryptic assertion failure
+ * (`expected 301 to deeply equal 200`) rather than an obvious config error —
+ * exactly the drift that broke the storage/auth suite (alkem-io/server#6257,
+ * `ALKEMIO_SERVER_REST` set to `http://…` instead of `https://…`). Localhost
+ * over http/ws is normal for local dev and is exempt.
+ */
+const validateEndpointSchemes = (config: AlkemioTestConfig): void => {
+  const isInsecureRemote = (url: string): boolean =>
+    /^(http|ws):\/\//i.test(url) &&
+    !/^(http|ws):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/i.test(url);
+
+  const named: Array<[string, string]> = [
+    ['ALKEMIO_SERVER (graphql.private)', config.endPoints.graphql.private],
+    ['ALKEMIO_BASE_URL (server)', config.endPoints.server],
+    ['ALKEMIO_SERVER_WS (ws)', config.endPoints.ws],
+    ['ALKEMIO_SERVER_REST (rest)', config.endPoints.rest],
+    ['MAIL_SLURPER_ENDPOINT (mailSlurper)', config.endPoints.mailSlurper],
+    ['KRATOS_ENDPOINT (kratos.public)', config.endPoints.kratos.public],
+    ['KRATOS_PRIVATE_API_URL (kratos.private)', config.endPoints.kratos.private],
+  ];
+
+  const offenders = named.filter(([, url]) => isInsecureRemote(url));
+  if (offenders.length > 0) {
+    const detail = offenders.map(([n, url]) => `  - ${n} = ${url}`).join('\n');
+    throw new Error(
+      `Insecure scheme on remote endpoint(s) — use https:// / wss:// (Traefik 301-redirects http→https, which non-redirect-following clients read as a failing status):\n${detail}`
+    );
+  }
 };
 
 export const stringifyConfig = (config: AlkemioTestConfig): string => {


### PR DESCRIPTION
Follow-up hardening for [alkem-io/server#6257](https://github.com/alkem-io/server/issues/6257). The actual fix was a **CI-variable correction** (below); this PR prevents the failure class from recurring silently.

## Background

The storage/auth suite (8 `*-document-auth.it-spec.ts`, ~110 assertions) failed with `expected 301 to deeply equal 200/403`. Root cause: the CI repo variable `ALKEMIO_SERVER_REST` had drifted to `http://test-alkem.io/api/private/non-interactive/rest` — **wrong protocol** (Traefik 301-redirects http→https; the supertest doc helper doesn't follow redirects) **and wrong route** (non-interactive → server, which no longer serves documents post file-service migration). The correct value, already in `server-api/.env.default`, is `https://test-alkem.io/api/private/rest` (interactive https; `…/rest/storage/*`→file-service, `…/rest/calendar/*`→server). No product code was wrong — the file-service enforces per-doc authz correctly; the request just died at the 301.

**The variable was corrected out-of-band** to `https://test-alkem.io/api/private/rest`.

## This PR

Adds `validateEndpointSchemes` to the config builder: throws a clear, itemised error at startup if any **remote** endpoint uses `http://`/`ws://` (localhost exempt). A future scheme drift now fails immediately naming the offending variable, instead of surfacing as a cryptic per-test 301.

Verified the scheme matcher against local/remote × http/https/ws/wss cases (all pass). No behavior change for correctly-configured (https/wss remote, http/ws localhost) environments.

Refs alkem-io/server#6257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect insecure remote endpoint URLs during configuration.
  * Configuration now fails early with details when non-local services use unsecured HTTP or WebSocket connections.
  * Local development endpoints, including localhost and loopback addresses, remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->