### PR TITLE
test(resilience): retry ENV_FAILURE requests in the graphql wrapper (#563)

### DIFF
--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -87,6 +87,7 @@ export const graphqlErrorWrapper = async <TData>(
     const userModel = TestUserManager.getUserModelByType(userRole);
     authToken = userModel.authToken;
   }
+  const wrapperStartedAt = Date.now();
   for (let attempt = 1; ; attempt++) {
     const startedAt = Date.now();
     try {
@@ -105,8 +106,9 @@ export const graphqlErrorWrapper = async <TData>(
           await sleep(delay);
           continue;
         }
+        const totalMs = Date.now() - wrapperStartedAt;
         LogManager.getLogger().error(
-          `[${code}] request failed after ${elapsedMs}ms on attempt ${attempt}: '${fn}'`,
+          `[${code}] request failed on attempt ${attempt} (${elapsedMs}ms this attempt, ${totalMs}ms total incl. retries): '${fn}'`,
         );
         LogManager.getLogger().error("Returned error:");
         LogManager.getLogger().error(err);
@@ -114,7 +116,7 @@ export const graphqlErrorWrapper = async <TData>(
           error: {
             errors: [
               {
-                message: `[${code}] ${detail} (after ${elapsedMs}ms)`,
+                message: `[${code}] ${detail} (after ${totalMs}ms across ${attempt} attempt(s))`,
                 code,
               },
             ],

--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -60,6 +60,24 @@ const classifyNonGraphqlError = (
   return { code: isEnv ? "ENV_FAILURE" : "UNKNOWN", detail };
 };
 
+/**
+ * Retry only ENV_FAILURE (connection-level) failures — never GraphQL errors,
+ * which are legitimate API responses to assert on. These come from a ~5s
+ * connection reset by a network element between the runner and the cluster when
+ * a heavy request (e.g. subspace-tree creation) hasn't responded yet
+ * (test-suites#563). A retry gives a fresh connection a chance to complete under
+ * the cutoff. The durable fix is server-side latency (alkem-io/server#6258);
+ * this is resilience until then. Caveat: for a mutation the server may have
+ * committed before the reset, so a retry can hit a duplicate/conflict — for the
+ * ephemeral, unique-named test data here that is harmless (it re-fails at worst,
+ * never silently corrupts a real store).
+ */
+const ENV_FAILURE_MAX_ATTEMPTS = 3;
+const ENV_FAILURE_RETRY_BASE_MS = 1000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export const graphqlErrorWrapper = async <TData>(
   fn: (authToken: string | undefined) => GraphQLReturnType<TData>,
   userRole?: TestUser,
@@ -69,31 +87,40 @@ export const graphqlErrorWrapper = async <TData>(
     const userModel = TestUserManager.getUserModelByType(userRole);
     authToken = userModel.authToken;
   }
-  const startedAt = Date.now();
-  try {
-    LogManager.getLogger().info(`Executing request: ${fn}`);
-    return await fn(authToken);
-  } catch (error) {
-    const err = error as ErrorType;
-    if (!err.response || !err.response.errors) {
-      const elapsedMs = Date.now() - startedAt;
-      const { code, detail } = classifyNonGraphqlError(error);
-      LogManager.getLogger().error(
-        `[${code}] request failed after ${elapsedMs}ms: '${fn}'`,
-      );
-      LogManager.getLogger().error("Returned error:");
-      LogManager.getLogger().error(err);
-      return {
-        error: {
-          errors: [
-            {
-              message: `[${code}] ${detail} (after ${elapsedMs}ms)`,
-              code,
-            },
-          ],
-        },
-      };
-    } else {
+  for (let attempt = 1; ; attempt++) {
+    const startedAt = Date.now();
+    try {
+      LogManager.getLogger().info(`Executing request: ${fn}`);
+      return await fn(authToken);
+    } catch (error) {
+      const err = error as ErrorType;
+      if (!err.response || !err.response.errors) {
+        const elapsedMs = Date.now() - startedAt;
+        const { code, detail } = classifyNonGraphqlError(error);
+        if (code === "ENV_FAILURE" && attempt < ENV_FAILURE_MAX_ATTEMPTS) {
+          const delay = ENV_FAILURE_RETRY_BASE_MS * attempt;
+          LogManager.getLogger().warn(
+            `[ENV_FAILURE] request failed after ${elapsedMs}ms (attempt ${attempt}/${ENV_FAILURE_MAX_ATTEMPTS}); retrying in ${delay}ms: '${fn}'`,
+          );
+          await sleep(delay);
+          continue;
+        }
+        LogManager.getLogger().error(
+          `[${code}] request failed after ${elapsedMs}ms on attempt ${attempt}: '${fn}'`,
+        );
+        LogManager.getLogger().error("Returned error:");
+        LogManager.getLogger().error(err);
+        return {
+          error: {
+            errors: [
+              {
+                message: `[${code}] ${detail} (after ${elapsedMs}ms)`,
+                code,
+              },
+            ],
+          },
+        };
+      } else {
       const badErrors = err.response.errors.filter(
         (e) =>
           e.extensions.code !== "BAD_USER_INPUT" &&
@@ -114,6 +141,7 @@ export const graphqlErrorWrapper = async <TData>(
           })),
         },
       };
+      }
     }
   }
 };


### PR DESCRIPTION
Client-side resilience stopgap for #563. The durable fix is server-side latency ([alkem-io/server#6258](https://github.com/alkem-io/server/issues/6258)); this keeps the nightly green until that lands.

## Why

Heavy requests (subspace-tree creation) whose server response hasn't arrived by ~5s get their connection reset. Investigation traced it precisely:
- **Not test-suites** — no timeout in the harness; graphql-request 6 + Node 20.9 undici default is 300s.
- **Not traefik** — it logs the failures as `499 Client Closed Request` at ~5002ms with the upstream server still processing (i.e. it's the victim of a downstream close, not the cause). v2.9.6, no timeout args.
- **Not the Scaleway runner network** — live check via the Scaleway API: the runner (`62.210.193.163`, the exact IP traefik logs closing) is `vpc_disabled`, direct public IP, **no VPC / Public Gateway / NAT / security group**; the only firewall is inbound-SSH pf. Nothing to configure.

So the ~5s is a host/edge default with no IaC knob. The two owners of the real problem:
- **server#6258** — subspace-tree setup creates Matrix rooms serially (~1s each) → response >5s. Fixing that (parallel/async) makes the cut irrelevant.
- **this PR** — retry so a fresh connection can complete under the cutoff meanwhile.

## What

`graphqlErrorWrapper` now retries `ENV_FAILURE`-classified failures (connection-level: ECONNRESET, socket hang up, …) up to 3 attempts with 1s/2s backoff. **GraphQL errors are never retried** — they're legitimate API responses to assert on. Mutation caveat (server may have committed before the reset) is documented inline and harmless for the ephemeral, unique-named test data.

Refs #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary connection failures by automatically retrying eligible requests up to three times.
  * Added increasing delays between retry attempts to improve request reliability.
  * Enhanced error reporting when retries are exhausted or when non-retryable failures occur.
  * Preserved existing handling for GraphQL-reported errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->