### PR TITLE
test(env): verify auth prerequisite before scenarios (#565 Phase 1)

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -21,6 +21,7 @@ export * from "./scenario/registration/register-in-kratos-or-fail";
 export * from "./scenario/registration/send-kratos-flow";
 export * from "./scenario/registration/verify-in-kratos-or-fail";
 export * from "./scenario/registration/register-test-user";
+export * from "./scenario/registration/verify-env-prerequisites";
 export * from "./config/test.configuration";
 export * from "./config/alkemio-test-config";
 export * from "./config/create-config-using-envvars";

--- a/lib/src/scenario/registration/verify-env-prerequisites.ts
+++ b/lib/src/scenario/registration/verify-env-prerequisites.ts
@@ -1,0 +1,65 @@
+import { TestUser } from '../../common/enums/test.user';
+import { LogManager } from '../LogManager';
+import { getUserToken } from './get-user-token';
+
+/**
+ * Env-prerequisite verification (test-suites#565, Phase 1).
+ *
+ * Runs once in global setup, AFTER user registration and BEFORE any scenario.
+ * It proves the auth prerequisite is actually met by minting a real token — the
+ * one thing that, when silently broken (e.g. a Kratos identity provisioned with
+ * a mismatched password), otherwise cascades into every scenario failing 40+
+ * minutes in with misleading downstream errors.
+ *
+ * A CRITICAL user that cannot authenticate aborts the whole run immediately with
+ * one clear, prerequisite-scoped message. REPRESENTATIVE users are probed for
+ * early signal but are non-fatal (a single role being off shouldn't mask a
+ * healthy env).
+ */
+
+// If admin can't authenticate the environment is unusable — fail fast.
+const CRITICAL_USERS: TestUser[] = [TestUser.GLOBAL_ADMIN];
+
+// A spread of roles probed for early diagnostics only (logged, non-fatal).
+const REPRESENTATIVE_USERS: TestUser[] = [
+  TestUser.SPACE_ADMIN,
+  TestUser.SPACE_MEMBER,
+  TestUser.NON_SPACE_MEMBER,
+];
+
+const emailOf = (user: TestUser): string => `${user}@alkem.io`;
+
+export const verifyEnvPrerequisites = async (): Promise<void> => {
+  const logger = LogManager.getLogger();
+
+  for (const user of CRITICAL_USERS) {
+    const email = emailOf(user);
+    try {
+      const token = await getUserToken(email);
+      if (!token) {
+        throw new Error('non-interactive-login returned an empty token');
+      }
+      logger.info?.(`[env-prereq] auth OK for critical user ${email}`);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `ENV PREREQUISITE FAILED: critical user '${email}' cannot authenticate — ${detail}. ` +
+          'The environment is not ready; aborting before scenarios run to avoid a misleading cascade. ' +
+          'Check Kratos user provisioning and AUTH_TEST_HARNESS_PASSWORD (test-suites#565).'
+      );
+    }
+  }
+
+  for (const user of REPRESENTATIVE_USERS) {
+    const email = emailOf(user);
+    try {
+      await getUserToken(email);
+      logger.info?.(`[env-prereq] auth OK for ${email}`);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      logger.warn?.(
+        `[env-prereq] auth FAILED for representative user ${email} (non-fatal) — ${detail}`
+      );
+    }
+  }
+};

--- a/server-api/src/globalTestsSetup.ts
+++ b/server-api/src/globalTestsSetup.ts
@@ -3,6 +3,7 @@ import {
   registerAllTestUsers,
   stringifyConfig,
   testConfiguration,
+  verifyEnvPrerequisites,
 } from '@alkemio/tests-lib';
 
 export default async function setup() {
@@ -19,9 +20,17 @@ export default async function setup() {
     `\nLaunching tests using configuration: ${stringifyConfig(testConfiguration)}`
   );
 
-  if (!testConfiguration.registerUsers) return;
+  if (testConfiguration.registerUsers) {
+    await registerAllTestUsers();
+  }
 
-  await registerAllTestUsers();
+  // Env-prerequisite gate (test-suites#565, Phase 1): prove the auth prerequisite
+  // is actually met by minting a real admin token BEFORE any scenario runs. A
+  // broken env (e.g. Kratos admin provisioned with a mismatched password) then
+  // aborts here with one clear message instead of cascading into every scenario
+  // failing 40+ minutes in. Runs even when registration is skipped (users are
+  // expected pre-seeded in that mode — verify they can authenticate).
+  await verifyEnvPrerequisites();
 
   // Return a teardown function so Vitest can ensure a clean exit.
   // The GraphQL client is stateless HTTP and WebSocket subscriptions are


### PR DESCRIPTION
Phase 1 of the env-prerequisites gate (#565): turn the silent-then-cascade auth failure into a fast, unambiguous abort.

## Problem
When the test Kratos admin is provisioned with a mismatched/stale password after a DB reset, the harness's per-scenario setup fails at auth (`invalid_credentials`), and because that happens in every scenario, the run cascade-fails across ~21 files 40+ minutes in with misleading downstream errors. Root cause + full catalog in #565.

## This change
`globalTestsSetup` now runs an **env-prerequisite verification** after registration and **before any scenario**:
- **Critical** (`admin`): mint a real token via the non-interactive-login path. On failure → **throw once**, aborting the whole run with `ENV PREREQUISITE FAILED: critical user 'admin@alkem.io' cannot authenticate — …` (naming Kratos provisioning / `AUTH_TEST_HARNESS_PASSWORD`).
- **Representative** (`space.admin`, `space.member`, `non.space`): probed for early diagnostics, non-fatal.
- Runs even when `SKIP_USER_REGISTRATION` is set (users pre-seeded → verify they authenticate).

Net: a broken-auth env fails in **~seconds at global setup** with one clear message, instead of a 40-min multi-file cascade. No behavior change on a healthy env (gate passes silently).

## Not in this PR
- **Phase 2** — deterministic Kratos provisioning (idempotent force-password on `already exists`), which removes the flakiness at source (design item: harness→Kratos-admin-API reachability).
- Server-side subspace latency is alkem-io/server#6258.

Refs #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment and authentication readiness checks before scenarios run.
  * Exposed the prerequisite verification functionality through the package’s public API.

* **Bug Fixes**
  * Global test setup now consistently validates required authentication access.
  * User registration runs only when explicitly enabled, while prerequisite checks always run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->