### PR TITLE
test(env): deterministic Kratos identity provisioning (#565 Phase 2)

### DIFF
--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v4.0.0
+        with:
+          version: "v1.29.6"
+
+      - name: Set up Kubeconfig for Hetzner k3s
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_SECRET_HETZNER_TEST }}" > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
       - name: Run server API nightly tests
         env:
           ALKEMIO_SERVER: ${{ vars.ALKEMIO_SERVER }}
@@ -35,4 +46,21 @@ jobs:
           KRATOS_ENDPOINT: ${{ vars.KRATOS_ENDPOINT }}
           MAIL_SLURPER_ENDPOINT: ${{ vars.MAIL_SLURPER_ENDPOINT }}
           AUTH_TEST_HARNESS_PASSWORD: ${{ secrets.AUTH_TEST_HARNESS_PASSWORD }}
-        run: pnpm --filter @alkemio/test-suite-server-api run test:nightly
+          # Deterministic Kratos provisioning (#565 Phase 2): the harness upserts
+          # test identities via the in-cluster admin API, port-forwarded below.
+          KRATOS_ADMIN_URL: http://localhost:4434
+        run: |
+          set -uo pipefail
+          # kratos-admin is ClusterIP (network-isolated); reach it via a
+          # port-forward that lives for the whole test run.
+          kubectl port-forward -n default svc/kratos-admin 4434:80 > /tmp/kratos-admin-pf.log 2>&1 &
+          PF_PID=$!
+          trap 'kill $PF_PID 2>/dev/null || true' EXIT
+          for i in $(seq 1 20); do
+            grep -q "Forwarding from" /tmp/kratos-admin-pf.log && break
+            sleep 1
+          done
+          if ! grep -q "Forwarding from" /tmp/kratos-admin-pf.log; then
+            echo "kratos-admin port-forward failed"; cat /tmp/kratos-admin-pf.log; exit 1
+          fi
+          pnpm --filter @alkemio/test-suite-server-api run test:nightly

--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v4.0.0
+        with:
+          version: "v1.29.6"
+
+      - name: Set up Kubeconfig for Hetzner k3s
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_SECRET_HETZNER_TEST }}" > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
       - name: Set run folder variables
         run: |
           DATE=$(date +'%Y-%m-%d')
@@ -61,7 +72,24 @@ jobs:
           KRATOS_ENDPOINT: ${{ vars.KRATOS_ENDPOINT }}
           MAIL_SLURPER_ENDPOINT: ${{ vars.MAIL_SLURPER_ENDPOINT }}
           AUTH_TEST_HARNESS_PASSWORD: ${{ secrets.AUTH_TEST_HARNESS_PASSWORD }}
-        run: pnpm --filter @alkemio/test-suite-server-api run test:nightly
+          # Deterministic Kratos provisioning (#565 Phase 2): the harness upserts
+          # test identities via the in-cluster admin API, port-forwarded below.
+          KRATOS_ADMIN_URL: http://localhost:4434
+        run: |
+          set -uo pipefail
+          # kratos-admin is ClusterIP (network-isolated); reach it via a
+          # port-forward that lives for the whole test run.
+          kubectl port-forward -n default svc/kratos-admin 4434:80 > /tmp/kratos-admin-pf.log 2>&1 &
+          PF_PID=$!
+          trap 'kill $PF_PID 2>/dev/null || true' EXIT
+          for i in $(seq 1 20); do
+            grep -q "Forwarding from" /tmp/kratos-admin-pf.log && break
+            sleep 1
+          done
+          if ! grep -q "Forwarding from" /tmp/kratos-admin-pf.log; then
+            echo "kratos-admin port-forward failed"; cat /tmp/kratos-admin-pf.log; exit 1
+          fi
+          pnpm --filter @alkemio/test-suite-server-api run test:nightly
 
       - name: Publish report to GitHub Pages
         if: ${{ always() }}

--- a/lib/src/config/alkemio-test-config.ts
+++ b/lib/src/config/alkemio-test-config.ts
@@ -11,6 +11,10 @@ export interface AlkemioTestConfig {
     kratos: {
       public: string;
       private: string;
+      /** In-cluster Kratos ADMIN API (network-isolated). Set on CI via a
+       * port-forward for deterministic identity provisioning (#565 Phase 2);
+       * empty when unavailable (local dev falls back to self-registration). */
+      admin: string;
     };
   };
   identities: {

--- a/lib/src/config/create-config-using-envvars.ts
+++ b/lib/src/config/create-config-using-envvars.ts
@@ -24,6 +24,7 @@ export const createConfigUsingEnvVars = (): AlkemioTestConfig => {
       kratos: {
         public: process.env.KRATOS_ENDPOINT ?? 'http://localhost:4434',
         private: process.env.KRATOS_PRIVATE_API_URL ?? 'http://localhost:4434',
+        admin: process.env.KRATOS_ADMIN_URL ?? '',
       },
     },
     identities: {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -22,6 +22,7 @@ export * from "./scenario/registration/send-kratos-flow";
 export * from "./scenario/registration/verify-in-kratos-or-fail";
 export * from "./scenario/registration/register-test-user";
 export * from "./scenario/registration/verify-env-prerequisites";
+export * from "./scenario/registration/provision-test-identities";
 export * from "./config/test.configuration";
 export * from "./config/alkemio-test-config";
 export * from "./config/create-config-using-envvars";

--- a/lib/src/scenario/registration/provision-test-identities.ts
+++ b/lib/src/scenario/registration/provision-test-identities.ts
@@ -1,0 +1,101 @@
+import { Configuration, IdentityApi } from '@ory/kratos-client';
+import { testConfiguration } from '../../config/test.configuration';
+import { TestUser } from '../../common/enums/test.user';
+import { LogManager } from '../LogManager';
+
+/**
+ * Deterministic Kratos identity provisioning (test-suites#565 Phase 2).
+ *
+ * Upserts every {@link TestUser} directly via the Kratos ADMIN API with the
+ * harness password, instead of relying on self-service registration. The admin
+ * API has none of the non-determinism that made registration flaky: no password
+ * policy / breached-password (HIBP) network check, no "already exists" no-op,
+ * no swallowed failures — a `PUT`/`POST` sets the password credential outright,
+ * idempotently.
+ *
+ * Runs only when the admin endpoint is available (`endPoints.kratos.admin`,
+ * set on CI via an in-cluster port-forward). The admin API is network-isolated
+ * (ClusterIP), so no API key is required. Local dev, without admin access,
+ * keeps using self-registration.
+ *
+ * `TestUser` stays the single source of the user list — no duplicated list in
+ * the pipeline (that would reintroduce the exact drift class this hardening
+ * closes).
+ */
+
+const IDENTITY_SCHEMA_ID = 'default';
+
+// Mirror the harness's self-service name parsing (register-test-user.ts) so the
+// traits match what the rest of the suite expects.
+const parseUserName = (userName: string): [string, string] => {
+  const parts = userName.split('.');
+  const first = parts[0];
+  const last = parts.length > 1 ? parts[1] : first;
+  return [first, last];
+};
+
+export const provisionTestIdentities = async (): Promise<void> => {
+  const logger = LogManager.getLogger();
+  const adminBaseUrl = testConfiguration.endPoints.kratos.admin;
+  const password = testConfiguration.identities.admin.password;
+
+  if (!adminBaseUrl) {
+    throw new Error(
+      'provisionTestIdentities called without a Kratos admin URL (endPoints.kratos.admin / KRATOS_ADMIN_URL)'
+    );
+  }
+
+  const identityApi = new IdentityApi(
+    new Configuration({ basePath: adminBaseUrl.replace(/\/$/, '') })
+  );
+
+  let created = 0;
+  let updated = 0;
+  for (const userName of Object.values(TestUser)) {
+    const email = `${userName}@alkem.io`;
+    const [first, last] = parseUserName(userName);
+    const traits = {
+      email,
+      accepted_terms: true,
+      name: { first, last },
+    };
+    const credentials = { password: { config: { password } } };
+
+    const { data: matches } = await identityApi.listIdentities({
+      credentialsIdentifier: email,
+    });
+    const existing = matches.find(
+      identity => (identity.traits as { email?: string })?.email === email
+    );
+
+    if (existing) {
+      await identityApi.updateIdentity({
+        id: existing.id,
+        updateIdentityBody: {
+          schema_id: IDENTITY_SCHEMA_ID,
+          state: 'active',
+          traits,
+          credentials,
+        },
+      });
+      updated++;
+    } else {
+      await identityApi.createIdentity({
+        createIdentityBody: {
+          schema_id: IDENTITY_SCHEMA_ID,
+          state: 'active',
+          traits,
+          credentials,
+          verifiable_addresses: [
+            { value: email, verified: true, via: 'email', status: 'completed' },
+          ],
+        },
+      });
+      created++;
+    }
+  }
+
+  logger.info?.(
+    `[provision] Kratos test identities upserted via admin API: ${created} created, ${updated} updated (${created + updated} total)`
+  );
+};

--- a/server-api/src/globalTestsSetup.ts
+++ b/server-api/src/globalTestsSetup.ts
@@ -1,5 +1,6 @@
 import {
   LogManager,
+  provisionTestIdentities,
   registerAllTestUsers,
   stringifyConfig,
   testConfiguration,
@@ -20,7 +21,14 @@ export default async function setup() {
     `\nLaunching tests using configuration: ${stringifyConfig(testConfiguration)}`
   );
 
-  if (testConfiguration.registerUsers) {
+  // Provision test-user identities (#565 Phase 2). When the Kratos admin API is
+  // reachable (CI, via an in-cluster port-forward → KRATOS_ADMIN_URL) upsert the
+  // identities deterministically through it — no self-service policy/HIBP checks,
+  // no "already exists" no-op, always the correct password. Otherwise (local dev,
+  // no admin access) fall back to self-service registration.
+  if (testConfiguration.endPoints.kratos.admin) {
+    await provisionTestIdentities();
+  } else if (testConfiguration.registerUsers) {
     await registerAllTestUsers();
   }
 


### PR DESCRIPTION
Phase 2 of the env-prerequisites gate (#565): remove the auth flakiness at its **source** — provision test-user Kratos identities deterministically, instead of relying on flaky self-service registration.

## Why
Self-service registration (`registerTestUser`) is subject to Kratos's password policy / breached-password (HIBP) network check, no-ops on "already exists" without ensuring the password, and swallows failures — so the admin identity intermittently ends up with a wrong/absent password → `invalid_credentials` → 21-file cascade. Full root cause in #565.

## What
- **`provisionTestIdentities()`** — upserts every `TestUser` via the Kratos **admin** `IdentityApi` with the harness password + verified email. No policy/HIBP, no flow, idempotent (create-or-update). `TestUser` stays the **single source** of the list (no duplication into the pipeline — that would reintroduce the drift class we just fixed with `ALKEMIO_SERVER_REST`).
- **`globalTestsSetup` gates on `KRATOS_ADMIN_URL`**: admin reachable → provision deterministically; else (local dev) → self-registration. Phase 1's `verifyEnvPrerequisites` (#566) then confirms auth before scenarios.
- **Trigger workflows** port-forward the **ClusterIP** `kratos-admin` service (network-isolated → no API key, no public admin surface) for the test run and set `KRATOS_ADMIN_URL`. No `SKIP_USER_REGISTRATION` var needed — the endpoint's presence gates it.

## Design note (refines the #565 draft)
Provisioning runs from `globalTestsSetup` (reusing the existing Node/TS toolchain — no build/tsx/curl-JSON) with the port-forward in the `run-e2e-tests` job, rather than a standalone script in the reset pipeline (which has no Node). Same outcome; less machinery.

## Validation
Types check in CI. Runtime (admin API path/shape against the live Kratos, port-forward, verified-address handling) needs **one validation run** — the first run after merge confirms admin authenticates deterministically. If the `@ory/kratos-client` v1.3.8 admin field names differ, CI `typecheck-native` catches it first.

Refs #565, #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a Kratos admin endpoint.
  * Test identities can now be deterministically created or updated through the Kratos admin API.
  * Added verified test email identities with consistent credentials and profile details.

* **Bug Fixes**
  * Preserved automatic user registration as a fallback when the admin endpoint is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->