### PR TITLE
test(resilience): classify + retry env failures in scenario setup

### DIFF
--- a/lib/src/scenario/TestScenarioFactory.ts
+++ b/lib/src/scenario/TestScenarioFactory.ts
@@ -19,6 +19,8 @@ import {
 } from "../core/generated/alkemio-schema";
 import { TestUser } from "../common/enums/test.user";
 import { UniqueIDGenerator } from "../utils/uniqueId";
+import { describeError, isEnvFailure } from "../utils/env-failure";
+import { delay } from "../utils/delay";
 import {
   assignPlatformRole,
   assignRoleToUser,
@@ -66,12 +68,65 @@ export class TestScenarioFactory {
   public static async createBaseScenario(
     scenarioConfig: TestScenarioConfig,
   ): Promise<OrganizationWithSpaceModel> {
-    const result = await this.createBaseScenarioPrivate(scenarioConfig);
-    // logElapsedTime('createBaseScenario', start);
-    return result;
+    return this.withEnvFailureRetry(
+      () => this.createBaseScenarioPrivate(scenarioConfig),
+      `base scenario '${scenarioConfig.name}'`,
+    );
+  }
+
+  // Env-failure signatures + backoff for core scenario setup (test-suites#563).
+  private static readonly SETUP_MAX_ATTEMPTS = 2; // one retry
+  private static readonly SETUP_RETRY_BASE_MS = 3000;
+
+  /**
+   * Retries core scenario setup ONLY on environment failures (Matrix/RPC
+   * timeout, auth endpoint mid-roll, connection reset) — never on a product
+   * error, because setup makes no assertions, so any failure here is either
+   * infra flake (retry) or a genuine setup bug (surface it). A transient
+   * Synapse/adapter blip or a brief pod roll then recovers on the retry instead
+   * of failing the whole suite. If it still fails and the cause is
+   * environmental, the error is tagged `[ENV_FAILURE]` so the report shows it
+   * as environment noise, not a product regression.
+   */
+  private static async withEnvFailureRetry<T>(
+    fn: () => Promise<T>,
+    label: string,
+  ): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= this.SETUP_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await fn();
+      } catch (e) {
+        lastError = e;
+        if (isEnvFailure(e) && attempt < this.SETUP_MAX_ATTEMPTS) {
+          const wait = this.SETUP_RETRY_BASE_MS * attempt;
+          LogManager.getLogger().warn(
+            `[ENV_FAILURE] setup of ${label} failed (attempt ${attempt}/${this.SETUP_MAX_ATTEMPTS}); retrying in ${wait}ms — ${describeError(e)}`,
+          );
+          await delay(wait);
+          continue;
+        }
+        break;
+      }
+    }
+    if (isEnvFailure(lastError)) {
+      throw new Error(
+        `[ENV_FAILURE] setup of ${label} failed after ${this.SETUP_MAX_ATTEMPTS} attempt(s) — environment, not product: ${describeError(lastError)}`,
+      );
+    }
+    throw lastError;
   }
 
   public static async createBaseScenarioOrganization(
+    scenarioConfig: TestScenarioConfig,
+  ): Promise<OrganizationWithSpaceModel> {
+    return this.withEnvFailureRetry(
+      () => this.createBaseScenarioOrganizationPrivate(scenarioConfig),
+      `organization scenario '${scenarioConfig.name}'`,
+    );
+  }
+
+  private static async createBaseScenarioOrganizationPrivate(
     scenarioConfig: TestScenarioConfig,
   ): Promise<OrganizationWithSpaceModel> {
     const baseScenario: OrganizationWithSpaceModel =

--- a/lib/src/utils/env-failure.ts
+++ b/lib/src/utils/env-failure.ts
@@ -1,0 +1,67 @@
+/**
+ * Environment-failure classification (test-suites#563).
+ *
+ * A failure is an ENVIRONMENT problem when the product code under test is not
+ * actually at fault — the API was never reached, an infra dependency (Matrix /
+ * Synapse / RabbitMQ / Kratos) was unhealthy, or the server pod was mid-roll.
+ * Tagging these distinctly is what keeps environment flakiness from
+ * masquerading as product regressions in the nightly report: green/red must
+ * mean product-correct / product-broken, not "the cluster hiccuped".
+ *
+ * These signatures are matched against thrown error text (message + cause +
+ * stack). They are deliberately used only where a match cannot be a legitimate
+ * API assertion:
+ *   - connection-level throws in the GraphQL wrapper, and
+ *   - core scenario *setup* failures (setup is never an assertion).
+ * They are NOT used to reclassify GraphQL error responses that a test asserts
+ * on.
+ */
+export const ENV_FAILURE_SIGNATURES = [
+  // Connection-level (runner <-> cluster): reset / refused / DNS / timeout.
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'EPIPE',
+  'socket hang up',
+  'fetch failed',
+  'network timeout',
+  'getaddrinfo',
+  // Matrix / RabbitMQ RPC infra (server#6258 area). An unhealthy or saturated
+  // Synapse surfaces as a 30s RPC timeout / adapter transport error during
+  // space/room setup — infrastructure, not a product assertion.
+  'Communication adapter',
+  'transport error',
+  'MATRIX_ENTITY_NOT_FOUND',
+  'Failed to receive response within timeout',
+  'communication.room',
+  // Auth endpoint unavailable / disabled — the symptom of the server pod being
+  // rolled or a feature-flag regression mid-run (the deploy-collision cascade
+  // that this issue was ultimately traced to). The non-interactive-login route
+  // 404s while the pod is down / the flag is off.
+  'non-interactive-login',
+  'feature disabled',
+  'kratos_unavailable',
+  'Unable to retrieve access token',
+];
+
+/**
+ * Renders an unknown error to the text we scan for signatures: message, any
+ * nested `cause`, and the stack (the Matrix/RPC detail often lives in a nested
+ * GraphQL error string surfaced through the stack).
+ */
+export const describeError = (err: unknown): string => {
+  if (!(err instanceof Error)) {
+    return String(err);
+  }
+  const cause = (err as Error & { cause?: unknown }).cause;
+  return [err.message, cause ? String(cause) : '', err.stack ?? '']
+    .filter(Boolean)
+    .join(' ');
+};
+
+/** True when the error text matches a known environment-failure signature. */
+export const isEnvFailure = (err: unknown): boolean => {
+  const text = describeError(err);
+  return ENV_FAILURE_SIGNATURES.some(sig => text.includes(sig));
+};

--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -3,6 +3,7 @@ import Headers from "graphql-request";
 import { TestUserManager } from "../scenario/TestUserManager";
 import { LogManager } from "../scenario/LogManager";
 import { TestUser } from "../common/enums/test.user";
+import { describeError, isEnvFailure } from "./env-failure";
 
 export type ErrorType = {
   response: {
@@ -26,38 +27,14 @@ export type GraphqlReturnWithError<TData> = Partial<
   };
 };
 
-/**
- * Connection-level failure signatures. When one of these is hit the API was
- * never (or not fully) reached — the failure is an ENVIRONMENT problem
- * (proxy reset, DNS, service down), NOT an assertion-worthy API response.
- * Tagging them distinctly keeps environment flakiness from masquerading as
- * product regressions in the reports.
- */
-const ENV_FAILURE_SIGNATURES = [
-  "ECONNRESET",
-  "ECONNREFUSED",
-  "ETIMEDOUT",
-  "EAI_AGAIN",
-  "EPIPE",
-  "socket hang up",
-  "fetch failed",
-  "network timeout",
-  "getaddrinfo",
-];
-
+// Environment-failure signatures + classifier are centralised in
+// ./env-failure so the GraphQL wrapper and core scenario-setup retry share one
+// source of truth (test-suites#563).
 const classifyNonGraphqlError = (
   err: unknown,
 ): { code: "ENV_FAILURE" | "UNKNOWN"; detail: string } => {
-  const cause =
-    err instanceof Error
-      ? (err as Error & { cause?: unknown }).cause
-      : undefined;
-  const detail =
-    err instanceof Error
-      ? `${err.message}${cause ? ` (cause: ${cause})` : ""}`
-      : String(err);
-  const isEnv = ENV_FAILURE_SIGNATURES.some((sig) => detail.includes(sig));
-  return { code: isEnv ? "ENV_FAILURE" : "UNKNOWN", detail };
+  const detail = describeError(err);
+  return { code: isEnvFailure(err) ? "ENV_FAILURE" : "UNKNOWN", detail };
 };
 
 /**


### PR DESCRIPTION
## Why

Track B of the nightly-reliability work. The real failure buckets in the last nightly were **environment, not product**:
- Matrix `getRoom` **transport error → 30s RabbitMQ RPC timeout** (`MATRIX_ENTITY_NOT_FOUND_ERROR`, routing key `communication.room.get`).
- `non-interactive-login` **404** while the server pod was rolled mid-run (the deploy-collision cascade — separately fixed by the deploy↔nightly lock, #574).

Both surfaced as red `Unable to create core scenario setup` across many files — **indistinguishable from genuine regressions** in the report. For an AI-native SDLC feedback loop, green/red must mean product-correct / product-broken, not "the cluster hiccuped".

## What

- **`lib/src/utils/env-failure.ts`** — one source of truth for environment-failure signatures: connection resets, Matrix/RPC transport+timeout, and auth-endpoint-down. Exposes `isEnvFailure` / `describeError`.
- **`graphql.wrapper.ts`** — now imports the shared classifier (drops its local duplicate); connection-level behaviour unchanged.
- **`TestScenarioFactory`** — `createBaseScenario` / `createBaseScenarioOrganization` retry **once** on an env-classified setup failure (a transient Synapse/adapter blip or brief pod roll then recovers). A persistent env failure is re-thrown tagged **`[ENV_FAILURE] … environment, not product`**.

Setup makes no assertions, so retry/reclassify here can never mask a product bug — any failure is either infra flake (retry) or a real setup defect (surfaced).

## Testing

- Lib builds clean (`tsc`).
- Classifier verified against the **actual** failing-run strings: Matrix 30s timeout, 404 feature-disabled, ECONNRESET → env; `Authorization: unable to grant …`, `BAD_USER_INPUT` → **not** env.

## Scope / follow-ups

- **Not** attempting mid-run "void the run on redeploy": the only server version signal (`platform.metadata.services[].version`) is `npm_package_version`, which doesn't change on a same-version redeploy. Reliable detection needs the server to expose boot-time/SHA in metadata — a small separate server change.
- Track C (Matrix/Synapse readiness gate + headroom) next.

Refs: test-suites#563, server#6258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when temporary environment issues occur during scenario setup.
  * Automatically retries eligible environment-related failures with increasing delays.
  * Provides clearer error details when all retry attempts fail.
  * Standardized environment-failure detection across scenario setup and GraphQL operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->