### PR TITLE
ci(nightly): allow manual workflow_dispatch

### DIFF
--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -3,6 +3,9 @@ name: Nightly Clean Up Environment and Trigger Tests
 on:
   schedule:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
+  # Allow on-demand runs (verify a fix, reproduce a failure) — same pipeline,
+  # including the shared test-cluster deploy lock.
+  workflow_dispatch:
 
 jobs:
   deploy-all-services:


### PR DESCRIPTION
Enables on-demand runs of the full nightly pipeline (deploy-all-services → acquire-lock → cleanup-db → e2e → release-lock) to verify a fix or reproduce a failure without waiting for the 00:00 UTC schedule. Same jobs, including the shared test-cluster deploy lock (#574).

🤖 Generated with [Claude Code](https://claude.com/claude-code)