### PR TITLE
fix(ids): bound UniqueIDGenerator length so nameIDs stay <= 28

### DIFF
--- a/lib/src/utils/uniqueId.ts
+++ b/lib/src/utils/uniqueId.ts
@@ -4,11 +4,19 @@ import { randomUUID } from 'node:crypto';
  * Collision-safe short IDs for test fixtures (test-suites#569, R6).
  *
  * The previous `Math.random().toString(12).slice(-6)` was not time-based, had
- * reduced float-tail entropy, and — because 52 files capture it once at module
+ * reduced float-tail entropy, and — because files capture it once at module
  * scope under Vitest `isolate:false` — was birthday-collision-plausible across a
  * 100+ file run, producing non-deterministic nameID/displayName clashes. A
- * time-ordered prefix plus cryptographic randomness makes collisions effectively
+ * monotonic prefix plus cryptographic randomness makes collisions effectively
  * impossible while staying short and nameID-valid (lowercase alphanumeric).
+ *
+ * LENGTH MATTERS (test-suites#563): test nameIDs are built as
+ * `<scenarioName.slice(0,18)>-<id>` and the server caps a nameID at 28 chars
+ * (`NameID.MAX_LENGTH`), leaving ~9 chars for the id (18 + '-' + id <= 28). The
+ * first cut of this generator emitted a 9–11 char id, which pushed those
+ * nameIDs to 29 and made the server reject `createSpace` (BAD_USER_INPUT) —
+ * surfacing as a masked "Space ID is required" cascade. The id is kept short
+ * (seq + 4 chars) so `18 + '-' + id` stays within 28 for any realistic run.
  */
 export class UniqueIDGenerator {
   // Monotonic per-process counter guarantees uniqueness within a worker (the
@@ -18,7 +26,10 @@ export class UniqueIDGenerator {
 
   public static getID(): string {
     const seq = (UniqueIDGenerator.counter++).toString(36);
-    const rand = randomUUID().replace(/-/g, '').slice(0, 8);
+    // Fixed-width random SUFFIX: the counter is an unambiguous prefix (result
+    // minus the last 4 chars), so uniqueness is never lost to truncation. Total
+    // length is seq(<=4 for a run) + 4 = <=8, keeping nameIDs within 28.
+    const rand = randomUUID().replace(/-/g, '').slice(0, 4);
     return `${seq}${rand}`;
   }
 }


### PR DESCRIPTION
## Why

The nightly's 50-file cascade ("Space ID is required") was un-masked (#577) to its real error:

```
NameID value format is not valid: storage-auth-publi-120ba5ca5b   (29 chars)
code: BAD_USER_INPUT
```

Test nameIDs are built as `<scenarioName.slice(0,18)>-<id>`, and the server caps a nameID at **28** (`NameID.MAX_LENGTH = 25 + 3`). #573's collision-safe generator emits a **9–11 char** id, so `18 + '-' + 10 = 29 > 28` → `createSpace` rejected for every longer-named scenario. That's the #573 length regression behind the 8→50 jump.

## What

Shorten the random suffix to a **fixed 4 chars** (no total slice). The monotonic counter stays an unambiguous prefix, so uniqueness is preserved, while total length is `seq + 4 ≤ 8` → nameID ≤ 27.

## Testing
- 200,000 ids: **0 collisions**, max length **8**, all lowercase-alphanumeric, worst-case nameID length **27 ≤ 28**.
- Lib builds clean.

Refs: test-suites#563, #573, #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated ID formatting to remain within server-side name length limits.
  * Preserved collision safety while reducing the random ID suffix length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->