### PR TITLE
fix(auth): mint test-user tokens once per run, not per file

### DIFF
--- a/lib/src/scenario/TestUserManager.ts
+++ b/lib/src/scenario/TestUserManager.ts
@@ -7,10 +7,25 @@ import { getGraphqlClient } from "../utils/graphqlClient";
 export class TestUserManager {
   private static userModelMapEmail: Map<string, UserModel>;
   private static userModelMapType: Map<string, UserModel>;
+  private static populated = false;
 
   public static users: TestUserModels;
 
+  /**
+   * Mints each core test user's token ONCE per run and caches it (the class is a
+   * module singleton under Vitest `isolate:false`). It used to re-mint every
+   * user on every scenario setup — a full Kratos native login flow per user per
+   * file (~users × files ≈ hundreds of logins). Under that load Kratos
+   * rate-limits (429), which the server maps to `invalid_credentials`, failing
+   * setups intermittently mid-run (test-suites#563). Non-interactive-login
+   * tokens live 4h — far longer than a run — so a single mint per user is safe.
+   * The `populated` flag flips only after a full pass, so a partial failure
+   * (e.g. an early rate-limit) is retried in full rather than left incomplete.
+   */
   public static async populateUserModelMap() {
+    if (this.populated) {
+      return;
+    }
     this.userModelMapEmail = new Map<string, UserModel>();
     this.userModelMapType = new Map<string, UserModel>();
 
@@ -31,6 +46,9 @@ export class TestUserManager {
     }
     // Finally ensure the exposed users field is populated
     this.populateUsers();
+
+    // Cache is complete — subsequent scenario setups reuse these tokens.
+    this.populated = true;
 
     // logElapsedTime('populateUserModels', start);
   }


### PR DESCRIPTION
## Why

~8 files failed the last nightly with (now un-masked, retried, and tagged by Track B):
```
[ENV_FAILURE] ... Unable to retrieve access token for user admin@alkem.io:
invalid_credentials — Kratos rejected the test-harness credentials
```

It is **not** a wrong password — it's **Kratos rate-limiting (429)** under load, which the server maps to `invalid_credentials` (`status >= 400 && status < 500` → `InvalidCredentialsError`). The harness generates that load itself: `populateUserModelMap` re-created its maps and **re-minted every core test user's token on every scenario setup** — a full Kratos native login flow (`createNativeLoginFlow` + `updateLoginFlow`) per user per file, ≈ users × files ≈ **hundreds of logins per run**.

## What

Mint each core test user's token **once per run** and cache it:
- The class is a module singleton (Vitest `isolate:false`).
- Non-interactive-login tokens live **4h** (`token_ttl_s` default 14400) — far longer than a ~70-min run.
- The core test users are stable fixtures.

A `populated` flag (set only after a full pass) collapses hundreds of login flows to one set, removing the rate-limit storm. A partial failure (early rate-limit) leaves the flag false so it retries in full.

## Follow-up (server, minor)
The server maps *any* Kratos 4xx to `invalid_credentials`, so a 429 rate-limit is misreported as a bad password. Worth mapping 429 → a distinct rate-limit error for diagnosability — separate change.

Refs: test-suites#563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved scenario setup speed by caching completed test-user initialization.
  * Prevented redundant authentication and user data setup on subsequent scenario runs.
  * Added retry handling when initialization is only partially completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->