### PR TITLE
fix(setup): de-mask failed createSubspace in journey test setup

### DIFF
--- a/server-api/src/functional-api/journey/subspace/subspace-sorting-and-pinning.it-spec.ts
+++ b/server-api/src/functional-api/journey/subspace/subspace-sorting-and-pinning.it-spec.ts
@@ -9,6 +9,7 @@ import {
 import { SpaceSortMode } from '@alkemio/tests-lib/core/generated/alkemio-schema';
 import {
   createSubspace,
+  createSubspaceOrFail,
   getSubspacesData,
   updateSubspacePinned,
   updateSubspacesSortOrder,
@@ -59,26 +60,23 @@ describe('Subspace sorting and pinning', () => {
   let subspaceCId = '';
 
   beforeAll(async () => {
-    const resA = await createSubspace(
+    subspaceAId = await createSubspaceOrFail(
       `alpha-${uniqueId}`,
       `alpha-${uniqueId}`,
       baseScenario.space.id
     );
-    subspaceAId = resA.data?.createSubspace.id ?? '';
 
-    const resB = await createSubspace(
+    subspaceBId = await createSubspaceOrFail(
       `bravo-${uniqueId}`,
       `bravo-${uniqueId}`,
       baseScenario.space.id
     );
-    subspaceBId = resB.data?.createSubspace.id ?? '';
 
-    const resC = await createSubspace(
+    subspaceCId = await createSubspaceOrFail(
       `charlie-${uniqueId}`,
       `charlie-${uniqueId}`,
       baseScenario.space.id
     );
-    subspaceCId = resC.data?.createSubspace.id ?? '';
   });
 
   afterAll(async () => {

--- a/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
+++ b/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
@@ -62,6 +62,42 @@ export const createSubspace = async (
   return graphqlErrorWrapper(callback, userRole);
 };
 
+/**
+ * Setup-time subspace creation that surfaces failures instead of masking them.
+ *
+ * The `createSubspace(...).data?.createSubspace.id ?? ''` idiom used in test
+ * setup turns a failed create — a `graphqlErrorWrapper`-swallowed
+ * BAD_USER_INPUT / FORBIDDEN_POLICY, or an exhausted ENV_FAILURE retry — into an
+ * empty string. Later mutations/queries then reject that empty id with a
+ * misleading `UUID not valid:`, which is how the 2026-07-15 nightly produced a
+ * 12-failure cascade across subspace-sorting-and-pinning and subsubspace with no
+ * trace of the real cause. Throw the actual error at the true failure point
+ * instead (same de-masking as `createRootSpace`, test-suites#577 / #563).
+ */
+export const createSubspaceOrFail = async (
+  subspaceName: string,
+  subspaceNameId: string,
+  parentId: string,
+  userRole: TestUser = TestUser.GLOBAL_ADMIN
+): Promise<string> => {
+  const response = await createSubspace(
+    subspaceName,
+    subspaceNameId,
+    parentId,
+    userRole
+  );
+  const id = response.data?.createSubspace?.id;
+  if (!id) {
+    const detail = response.error
+      ? JSON.stringify(response.error.errors)
+      : 'server returned no createSubspace.id and no error';
+    throw new Error(
+      `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): ${detail}`
+    );
+  }
+  return id;
+};
+
 export const subspaceVariablesData = (
   displayName: string,
   nameId: string,

--- a/server-api/src/functional-api/journey/subsubspace/subsubspace.it-spec.ts
+++ b/server-api/src/functional-api/journey/subsubspace/subsubspace.it-spec.ts
@@ -2,6 +2,7 @@ import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/O
 import { deleteSpace, updateSpaceContext } from '../space/space.request.params';
 import {
   createSubspace,
+  createSubspaceOrFail,
   getSubspaceData,
 } from '../subspace/subspace.request.params';
 import {
@@ -60,8 +61,13 @@ describe('Opportunities', () => {
       subsubspaceNameId,
       baseScenario.subspace.id
     );
+    // Surface a failed create instead of letting `?? ''` mask it into an empty
+    // id that makes the comparisons below trivially pass (undefined ===
+    // undefined) — the masking that hid the 2026-07-15 nightly failure.
+    expect(responseCreateSubsubspaceOnSubspace.error).toBeUndefined();
     const createSubsubspaceData =
       responseCreateSubsubspaceOnSubspace?.data?.createSubspace;
+    expect(createSubsubspaceData?.id).toBeTruthy();
 
     subsubspaceId = createSubsubspaceData?.id ?? '';
 
@@ -87,14 +93,11 @@ describe('Opportunities', () => {
   test('should update subsubspace and query the data', async () => {
     // Arrange
     // Create Subsubspace on Subspace
-    const responseCreateSubsubspaceOnSubspace = await createSubspace(
+    subsubspaceId = await createSubspaceOrFail(
       subsubspaceName,
       subsubspaceNameId,
       baseScenario.subspace.id
     );
-
-    subsubspaceId =
-      responseCreateSubsubspaceOnSubspace?.data?.createSubspace.id ?? '';
     // Act
     // Update the created Subsubspace
     const responseUpdateSubsubspace = await updateSpaceContext(subsubspaceId);
@@ -114,13 +117,11 @@ describe('Opportunities', () => {
   test('should remove subsubspace and query the data', async () => {
     // Arrange
     // Create Subsubspace
-    const responseCreateSubsubspaceOnSubspace = await createSubspace(
+    subsubspaceId = await createSubspaceOrFail(
       subsubspaceName,
       subsubspaceNameId,
       baseScenario.subspace.id
     );
-    subsubspaceId =
-      responseCreateSubsubspaceOnSubspace?.data?.createSubspace.id ?? '';
 
     // Act
     // Remove subsubspace
@@ -140,13 +141,11 @@ describe('Opportunities', () => {
 
   test('should throw an error for creating subsubspace with same name/NameId on different subspaces', async () => {
     // Arrange
-    const responseCreateSubspaceTwo = await createSubspace(
+    additionalSubspaceId = await createSubspaceOrFail(
       `${subsubspaceName}ch`,
       `${uniqueId}ch`,
       baseScenario.space.id
     );
-    additionalSubspaceId =
-      responseCreateSubspaceTwo?.data?.createSubspace.id ?? '';
 
     // Act
     // Create Subsubspace on Challange One


### PR DESCRIPTION
## What

The 2026-07-15 nightly ([report](https://alkem-io.github.io/test-suites/server-api/2026-07-15/29378888811/#/)) failed **12 tests across 2 files** — `journey/subspace/subspace-sorting-and-pinning` (11) and `journey/subsubspace/subsubspace` (1). All 12 decode to **one masked, intermittent setup failure**, not a regression in the pin/sort feature.

## Root cause

Setup created subspaces with `createSubspace(...).data?.createSubspace.id ?? ''`. When `createSubspace` fails, the `?? ''` swallows it into an **empty string**, and every downstream `updateSubspacePinned` / `updateSubspacesSortOrder` / query / delete then rejects that empty id with a misleading `ValidationException: UUID not valid:`. `graphqlErrorWrapper` also deliberately doesn't log `BAD_USER_INPUT`/`FORBIDDEN_POLICY`, so the report showed **no trace of the real cause** — just a 12-failure UUID cascade.

**Reproduced locally:** the creates fail intermittently *only* when both files run together under the single-worker `nightly` project (`isolate:false`, shared account state under load). They pass every time in isolation and under the parallel `journey` project; a re-run passed 29/29. This is the env-instability class of #563 / server latency (alkem-io/server#6258). The pin/sort feature itself is not at fault.

## The fix

De-mask setup so a failed create surfaces at the true point with the real error — same trajectory as #577 ("stop masking createSpace failures") and #569 ("real throw"):

- **`subspace.request.params.ts`** — new `createSubspaceOrFail()` that throws `Failed to create subspace '<name>' (nameID '…', parent '…'): <real error>` instead of returning an empty id.
- **`subspace-sorting-and-pinning.it-spec.ts`** — the 3 setup creates use `createSubspaceOrFail`. The one test that legitimately asserts on `createSubspace`'s response is untouched.
- **`subsubspace.it-spec.ts`** — the arrange creates use `createSubspaceOrFail`; test 1 (which needs the created object) gets explicit `expect(...error).toBeUndefined()` / `expect(id).toBeTruthy()` guards. The duplicate-nameID tests that assert on errors are untouched.

## Scope / caveat

This is a **diagnosability fix, not a cure for the flake**. It won't stop the intermittent env failure (server-side, alkem-io/server#6258), but the next occurrence surfaces one clear `Failed to create subspace: …` at the real point instead of 12 confusing "UUID not valid" errors — and correctly clears the pin/sort feature of blame.

## Verification

- `pnpm --filter @alkemio/test-suite-server-api run lint` (typecheck + eslint) — clean
- Both specs green locally in isolation and under the `journey` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subspace test setup to fail immediately when creation fails.
  * Added clearer error reporting for unsuccessful subspace creation.
  * Prevented invalid or empty identifiers from masking setup failures in subspace and subsubspace scenarios.
  * Added validation that newly created subspaces return valid identifiers before further operations proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->