### PR TITLE
test(nightly): retry root-space creation on nameID collision

### DIFF
--- a/lib/src/scenario/TestScenarioFactory.ts
+++ b/lib/src/scenario/TestScenarioFactory.ts
@@ -908,30 +908,58 @@ export class TestScenarioFactory {
     scenarioName: string,
     addTutorialCallouts: boolean,
   ): Promise<SpaceModel> {
-    const uniqueId = UniqueIDGenerator.getID();
     const truncatedScenarioName = scenarioName.slice(0, 18);
-    const spaceName = `${truncatedScenarioName}-${uniqueId}`;
-    const spaceNameId = this.validateAndClean(`${spaceName.toLowerCase()}`);
-    if (!spaceNameId) {
-      throw new Error(`Unable to create space: Invalid nameId: ${spaceNameId}`);
+
+    // Create the root space, retrying a nameID collision with a fresh id.
+    // Under Vitest `pool: threads` the per-process UniqueIDGenerator counter can
+    // reset across files, so two files whose scenario names share the
+    // truncated-18 prefix (e.g. several `storage-auth-public…` scenarios) can
+    // draw the same short id and collide (test-suites#563). Any other failure is
+    // surfaced verbatim rather than masked (test-suites#577).
+    const createOnce = async () => {
+      const uniqueId = UniqueIDGenerator.getID();
+      const spaceName = `${truncatedScenarioName}-${uniqueId}`;
+      const spaceNameId = this.validateAndClean(spaceName.toLowerCase());
+      if (!spaceNameId) {
+        throw new Error(
+          `Unable to create space: Invalid nameId: ${spaceNameId}`,
+        );
+      }
+      const res = await this.createSpaceAndGetData(
+        "l0-" + spaceName,
+        spaceNameId,
+        accountID,
+        addTutorialCallouts,
+      );
+      return { spaceName, res };
+    };
+
+    // createSpaceAndGetData throws on a failed create (its de-masking throw,
+    // test-suites#577) with the GraphQL error detail in the message — so the
+    // collision arrives as a thrown Error, not as `res.error`. Catch it, retry
+    // with a fresh id, and rethrow anything else verbatim.
+    let attempt: Awaited<ReturnType<typeof createOnce>> | undefined;
+    for (let i = 0; i < 3; i++) {
+      try {
+        attempt = await createOnce();
+        break;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        if (i === 2 || !message.includes("already taken or restricted")) {
+          throw e;
+        }
+      }
     }
 
-    const responseRootSpace = await this.createSpaceAndGetData(
-      "l0-" + spaceName,
-      spaceNameId,
-      accountID,
-      addTutorialCallouts,
-    );
-
-    if (!responseRootSpace.data?.lookup?.space) {
+    if (!attempt || !attempt.res.data?.lookup?.space) {
       throw new Error(
-        `Failed to create root space: ${JSON.stringify(
-          responseRootSpace.error,
+        `Failed to create root space '${attempt?.spaceName ?? truncatedScenarioName}' (account '${accountID}'): ${JSON.stringify(
+          attempt?.res.error ?? {},
         )}`,
       );
     }
 
-    const spaceData = responseRootSpace.data?.lookup?.space;
+    const spaceData = attempt.res.data.lookup.space;
     spaceModel.id = spaceData?.id ?? "";
     spaceModel.nameId = spaceData?.nameID ?? "";
     spaceModel.about = {


### PR DESCRIPTION
Follow-up to #577/#578 — fixes the `storage-auth-publi-5fafa` root-space nameID collision from the 2026-07-15 nightly (test-suites#563).

## What

Under Vitest `pool: threads` the per-process `UniqueIDGenerator` counter can reset across worker files, so scenarios whose names share the same truncated-18 prefix (the three `storage-auth-public…` scenarios) can draw the same short id and collide on the space nameID → `already taken or restricted`.

`createSpaceAndGetData` throws on a failed create (the #577 de-masking), so the collision surfaces as a thrown Error carrying the GraphQL detail. `createRootSpace` now catches that specific error and retries with a freshly generated id (up to 3 attempts). Every other failure is rethrown verbatim — no re-masking.

## Scope note

This branch originally also un-masked `createSubspace` setup in `subspace-sorting-and-pinning` / `subsubspace`; that landed on develop separately via #580/#581 (`createSubspaceOrFail`) and was dropped here in rebase.

## Deliberately NOT touched

- `space.entitlements` (`availableEntitlements [4] != [5]`) — real product entitlement-consumption behavior (a free-space entitlement is consumed as spaces are created). Flagged for product confirmation rather than silenced.

Refs test-suites#563, #577, #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)