### PR TITLE
test(setup): poll committed-create recovery until half-built subspace stabilises

### DIFF
--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -106,6 +106,11 @@ jobs:
           # Deterministic Kratos provisioning (#565 Phase 2): the harness upserts
           # test identities via the in-cluster admin API, port-forwarded below.
           KRATOS_ADMIN_URL: http://localhost:4434
+          # Surface [ENV_FAILURE] retry warnings in CI stdout. The console
+          # transport defaults to error-only, which hid the silent
+          # retried-after-commit createSubspace failures behind cryptic
+          # 'nameID already taken' errors (2026-07-15 nightly, #563).
+          LOG_LEVEL: warn
         run: |
           set -uo pipefail
           # kratos-admin is ClusterIP (network-isolated); reach it via a

--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -55,6 +55,17 @@ const ENV_FAILURE_RETRY_BASE_MS = 1000;
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+// JSON.stringify throws on circular structures (axios errors carry them);
+// throwing inside the wrapper's catch handler would replace the real failure
+// with a serialization error.
+const safeStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+};
+
 export const graphqlErrorWrapper = async <TData>(
   fn: (authToken: string | undefined) => GraphQLReturnType<TData>,
   userRole?: TestUser,
@@ -89,7 +100,7 @@ export const graphqlErrorWrapper = async <TData>(
         );
         LogManager.getLogger().error("Returned error:");
         LogManager.getLogger().error(
-          err instanceof Error ? (err.stack ?? err.message) : JSON.stringify(err),
+          err instanceof Error ? (err.stack ?? err.message) : safeStringify(err),
         );
         return {
           error: {
@@ -111,7 +122,7 @@ export const graphqlErrorWrapper = async <TData>(
         // Stringify explicitly — winston's console transport renders raw
         // objects as `[object Object]`, which hid the actual GraphQL errors of
         // the failed recovery lookups in the 2026-07-15 nightly (#563).
-        LogManager.getLogger().error(JSON.stringify(badErrors));
+        LogManager.getLogger().error(safeStringify(badErrors));
         LogManager.getLogger().error(`Unable to complete call '${fn}'`);
 
         //throw new Error(`GraphQL error: ${badErrors.map(e => e.message).join(', ')}`);

--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -88,7 +88,9 @@ export const graphqlErrorWrapper = async <TData>(
           `[${code}] request failed on attempt ${attempt} (${elapsedMs}ms this attempt, ${totalMs}ms total incl. retries): '${fn}'`,
         );
         LogManager.getLogger().error("Returned error:");
-        LogManager.getLogger().error(err);
+        LogManager.getLogger().error(
+          err instanceof Error ? (err.stack ?? err.message) : JSON.stringify(err),
+        );
         return {
           error: {
             errors: [
@@ -106,7 +108,10 @@ export const graphqlErrorWrapper = async <TData>(
           e.extensions.code !== "FORBIDDEN_POLICY",
       );
       if (badErrors.length > 0) {
-        LogManager.getLogger().error(badErrors);
+        // Stringify explicitly — winston's console transport renders raw
+        // objects as `[object Object]`, which hid the actual GraphQL errors of
+        // the failed recovery lookups in the 2026-07-15 nightly (#563).
+        LogManager.getLogger().error(JSON.stringify(badErrors));
         LogManager.getLogger().error(`Unable to complete call '${fn}'`);
 
         //throw new Error(`GraphQL error: ${badErrors.map(e => e.message).join(', ')}`);

--- a/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
+++ b/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
@@ -1,4 +1,4 @@
-import { getGraphqlClient, TestUser } from '@alkemio/tests-lib';
+import { delay, getGraphqlClient, TestUser } from '@alkemio/tests-lib';
 import { UniqueIDGenerator } from '@alkemio/tests-lib';
 import { graphqlErrorWrapper } from '@alkemio/tests-lib/utils/graphql.wrapper';
 const uniqueId = UniqueIDGenerator.getID();
@@ -86,7 +86,21 @@ export const createSubspace = async (
  *    committed-then-retried create — so we look it up by nameID under the parent
  *    and return it. (This is the caveat the wrapper's retry comment calls
  *    "harmless"; for a create it is not — hence this recovery.)
+ *
+ * The recovery lookup must POLL, not fire once. createSubspace is not atomic
+ * server-side: the space row (which reserves the nameID) lands first and the
+ * children (about/collaboration/community…) keep landing for up to ~30s more
+ * (e.g. behind the Matrix 30s RPC timeout). While the space is half-built, the
+ * parent's subspaces query fails on child resolvers and non-null bubbling nulls
+ * the whole list — a single-shot lookup therefore missed a subspace that
+ * demonstrably existed (2026-07-15 nightly, test-suites#563: `alpha-35e44f` /
+ * `opio2fed` were direct children of the queried parent yet setup still threw
+ * `already taken`). We retry until the tree reads clean, and if it never does,
+ * we throw with BOTH the create error and the last lookup failure — never
+ * masking either.
  */
+const RECOVERY_LOOKUP_ATTEMPTS = 10;
+const RECOVERY_LOOKUP_DELAY_MS = 5000;
 export const createSubspaceOrFail = async (
   subspaceName: string,
   subspaceNameId: string,
@@ -109,23 +123,42 @@ export const createSubspaceOrFail = async (
       'nameID is already taken'
     )
   );
-  if (alreadyTaken) {
-    const existing = await getSubspacesData(parentId);
-    const subspaces = (existing.data?.lookup?.space?.subspaces ?? []) as Array<{
-      id: string;
-      nameID: string;
-    }>;
-    const match = subspaces.find(s => s.nameID === subspaceNameId);
-    if (match?.id) {
-      return match.id;
-    }
-  }
-
-  const detail = response.error
+  const createDetail = response.error
     ? JSON.stringify(response.error.errors)
     : 'server returned no createSubspace.id and no error';
+
+  if (alreadyTaken) {
+    let lastLookupDetail = '';
+    for (let attempt = 1; attempt <= RECOVERY_LOOKUP_ATTEMPTS; attempt++) {
+      const existing = await getSubspacesData(parentId);
+      const subspaces = existing.data?.lookup?.space?.subspaces as
+        | Array<{ id: string; nameID: string }>
+        | undefined;
+      if (existing.error || !subspaces) {
+        // Half-built space (or a transient env failure): record why and retry.
+        lastLookupDetail = `lookup failed: ${JSON.stringify(
+          existing.error?.errors ?? 'no data'
+        )}`;
+      } else {
+        const match = subspaces.find(s => s.nameID === subspaceNameId);
+        if (match?.id) {
+          return match.id;
+        }
+        lastLookupDetail = `no subspace with nameID '${subspaceNameId}' among [${subspaces
+          .map(s => s.nameID)
+          .join(', ')}]`;
+      }
+      if (attempt < RECOVERY_LOOKUP_ATTEMPTS) {
+        await delay(RECOVERY_LOOKUP_DELAY_MS);
+      }
+    }
+    throw new Error(
+      `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): create reported '${createDetail}' and the committed-create recovery did not stabilise after ${RECOVERY_LOOKUP_ATTEMPTS} lookups: ${lastLookupDetail}`
+    );
+  }
+
   throw new Error(
-    `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): ${detail}`
+    `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): ${createDetail}`
   );
 };
 


### PR DESCRIPTION
Closes the loop on the 2026-07-15 nightly's remaining subspace failures (test-suites#563), which the #580/#581 un-masking exposed.

## Diagnosis (evidence-based, from run 29407378589 + live test-env data)

The failing scenarios' "conflicting" subspaces (`alpha-35e44f`, `opio2fed`) **exist in the live trees as direct children of the exact parents the recovery queried** — with `createdDate` ~5-7s after the scenario roots, i.e. created by attempt 1 of the very call that then failed. Timeline:

1. `createSubspace` attempt 1 dies client-side (connection-level → the wrapper's `[ENV_FAILURE]` retry fires **silently**: warn-level, console transport is error-only) — but the server had already inserted the space row and kept building the space.
2. The wrapper retry hits the nameID reservation → `already taken`.
3. #581's recovery lookup runs **once**, against a **half-built** space: child resolvers throw, non-null bubbling nulls the `subspaces` list (visible in the run log as three `[object Object]` errors on `GetSubspacesData` at 10:37:09), the `?? []` masks it → no match → setup throws for a create that succeeded.

## Fixes

- **`createSubspaceOrFail`**: poll the recovery lookup (10 × 5s, covering the ~30s Matrix-bounded build window) until the tree reads clean; on exhaustion throw with **both** the create error and the last lookup failure.
- **`graphql.wrapper`**: stringify error logging — winston rendered the actual GraphQL errors as `[object Object]`.
- **nightly workflow**: `LOG_LEVEL: warn` so `[ENV_FAILURE]` retries (the trigger of this failure mode) show up in CI stdout.

## Server-side follow-up (separate)

`createSubspace` not being atomic (nameID reserved before the space is usable; a dead client leaves the build running) is a server behavior worth its own issue — this PR only makes the harness honest and resilient to it.

Refs test-suites#563, #577, #580, #581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging to avoid failed/garbled output and ensure clearer diagnostic details in non-GraphQL and filtered GraphQL error scenarios.
  * Enhanced subspace creation recovery by polling for the newly created subspace when transient race conditions occur, reducing false “already taken” failures.
  * Improved error reporting to retain both the original creation issue and any subsequent lookup/polling failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->