### PR TITLE
fix(harness): never auto-retry mutations on ENV_FAILURE

### DIFF
--- a/lib/src/utils/graphql.wrapper.ts
+++ b/lib/src/utils/graphql.wrapper.ts
@@ -38,23 +38,17 @@ const classifyNonGraphqlError = (
 };
 
 /**
- * Retry only ENV_FAILURE (connection-level) failures — never GraphQL errors,
- * which are legitimate API responses to assert on. These come from a ~5s
- * connection reset by a network element between the runner and the cluster when
- * a heavy request (e.g. subspace-tree creation) hasn't responded yet
- * (test-suites#563). A retry gives a fresh connection a chance to complete under
- * the cutoff. The durable fix is server-side latency (alkem-io/server#6258);
- * this is resilience until then. Caveat: for a mutation the server may have
- * committed before the reset, so a retry can hit a duplicate/conflict — for the
- * ephemeral, unique-named test data here that is harmless (it re-fails at worst,
- * never silently corrupts a real store).
+ * Shapes thrown request errors into the `{ error: { errors } }` contract the
+ * helpers/tests rely on. It does NOT retry.
+ *
+ * ENV_FAILURE (connection-level) retries live one layer deeper, in the SDK
+ * wrapper (`getGraphqlClient`), where the operation type is known — so only
+ * idempotent QUERIES are retried. Mutations must never be auto-retried: the
+ * server may have committed a create before a ~5s connection reset, and
+ * re-issuing it hits `nameID already taken`, failing a test for an entity that
+ * actually exists (the 2026-07-15 nightly cascades). By the time we catch here,
+ * any query retries have already happened; we just classify and report.
  */
-const ENV_FAILURE_MAX_ATTEMPTS = 3;
-const ENV_FAILURE_RETRY_BASE_MS = 1000;
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
 export const graphqlErrorWrapper = async <TData>(
   fn: (authToken: string | undefined) => GraphQLReturnType<TData>,
   userRole?: TestUser,
@@ -64,42 +58,31 @@ export const graphqlErrorWrapper = async <TData>(
     const userModel = TestUserManager.getUserModelByType(userRole);
     authToken = userModel.authToken;
   }
-  const wrapperStartedAt = Date.now();
-  for (let attempt = 1; ; attempt++) {
-    const startedAt = Date.now();
-    try {
-      LogManager.getLogger().info(`Executing request: ${fn}`);
-      return await fn(authToken);
-    } catch (error) {
-      const err = error as ErrorType;
-      if (!err.response || !err.response.errors) {
-        const elapsedMs = Date.now() - startedAt;
-        const { code, detail } = classifyNonGraphqlError(error);
-        if (code === "ENV_FAILURE" && attempt < ENV_FAILURE_MAX_ATTEMPTS) {
-          const delay = ENV_FAILURE_RETRY_BASE_MS * attempt;
-          LogManager.getLogger().warn(
-            `[ENV_FAILURE] request failed after ${elapsedMs}ms (attempt ${attempt}/${ENV_FAILURE_MAX_ATTEMPTS}); retrying in ${delay}ms: '${fn}'`,
-          );
-          await sleep(delay);
-          continue;
-        }
-        const totalMs = Date.now() - wrapperStartedAt;
-        LogManager.getLogger().error(
-          `[${code}] request failed on attempt ${attempt} (${elapsedMs}ms this attempt, ${totalMs}ms total incl. retries): '${fn}'`,
-        );
-        LogManager.getLogger().error("Returned error:");
-        LogManager.getLogger().error(err);
-        return {
-          error: {
-            errors: [
-              {
-                message: `[${code}] ${detail} (after ${totalMs}ms across ${attempt} attempt(s))`,
-                code,
-              },
-            ],
-          },
-        };
-      } else {
+  const startedAt = Date.now();
+  try {
+    LogManager.getLogger().info(`Executing request: ${fn}`);
+    return await fn(authToken);
+  } catch (error) {
+    const err = error as ErrorType;
+    if (!err.response || !err.response.errors) {
+      const elapsedMs = Date.now() - startedAt;
+      const { code, detail } = classifyNonGraphqlError(error);
+      LogManager.getLogger().error(
+        `[${code}] request failed (${elapsedMs}ms): '${fn}'`,
+      );
+      LogManager.getLogger().error("Returned error:");
+      LogManager.getLogger().error(err);
+      return {
+        error: {
+          errors: [
+            {
+              message: `[${code}] ${detail} (after ${elapsedMs}ms)`,
+              code,
+            },
+          ],
+        },
+      };
+    } else {
       const badErrors = err.response.errors.filter(
         (e) =>
           e.extensions.code !== "BAD_USER_INPUT" &&
@@ -120,7 +103,6 @@ export const graphqlErrorWrapper = async <TData>(
           })),
         },
       };
-      }
     }
   }
 };

--- a/lib/src/utils/graphqlClient.ts
+++ b/lib/src/utils/graphqlClient.ts
@@ -1,15 +1,65 @@
 import { testConfiguration } from '../config/test.configuration';
-import { getSdk, Sdk } from '../core/generated/graphql';
+import { getSdk, Sdk, SdkFunctionWrapper } from '../core/generated/graphql';
 import { GraphQLClient } from 'graphql-request';
+import { isEnvFailure } from './env-failure';
+import { LogManager } from '../scenario/LogManager';
 
 let graphqlSdkClient: Sdk;
+
+/**
+ * Retry only ENV_FAILURE (connection-level) failures, and ONLY for idempotent
+ * operations (queries).
+ *
+ * A ~5s connection reset by a network element between the runner and the cluster
+ * can drop a heavy request before it responds (test-suites#563; the durable fix
+ * is server latency, alkem-io/server#6258). Retrying a QUERY is safe. Retrying a
+ * MUTATION is not: the server may have committed before the reset, so re-issuing
+ * a create comes back as `nameID already taken` (BAD_USER_INPUT) and fails a test
+ * for an entity that actually exists — the root cause of the 2026-07-15 nightly
+ * cascades across subspace/subsubspace/entitlements. Mutations therefore run
+ * exactly once; a reset during a mutation surfaces as a real ENV_FAILURE rather
+ * than a duplicate.
+ *
+ * The operation type comes from the generated SDK wrapper, so this needs no
+ * per-helper changes and covers every call site uniformly.
+ */
+const ENV_FAILURE_MAX_ATTEMPTS = 3;
+const ENV_FAILURE_RETRY_BASE_MS = 1000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+const envFailureRetryWrapper: SdkFunctionWrapper = async (
+  action,
+  operationName,
+  operationType
+) => {
+  if (operationType !== 'query') {
+    return action();
+  }
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await action();
+    } catch (error) {
+      if (attempt < ENV_FAILURE_MAX_ATTEMPTS && isEnvFailure(error)) {
+        const delay = ENV_FAILURE_RETRY_BASE_MS * attempt;
+        LogManager.getLogger().warn(
+          `[ENV_FAILURE] query '${operationName}' failed (attempt ${attempt}/${ENV_FAILURE_MAX_ATTEMPTS}); retrying in ${delay}ms`
+        );
+        await sleep(delay);
+        continue;
+      }
+      throw error;
+    }
+  }
+};
 
 export const getGraphqlClient = (): Sdk => {
   if (!graphqlSdkClient) {
     const graphqlClient = new GraphQLClient(
       testConfiguration.endPoints.graphql.private
     );
-    graphqlSdkClient = getSdk(graphqlClient);
+    graphqlSdkClient = getSdk(graphqlClient, envFailureRetryWrapper);
   }
   return graphqlSdkClient;
 };

--- a/server-api/src/functional-api/journey/subspace/subspace-sorting-and-pinning.it-spec.ts
+++ b/server-api/src/functional-api/journey/subspace/subspace-sorting-and-pinning.it-spec.ts
@@ -431,8 +431,8 @@ describe('Subspace sorting and pinning', () => {
     });
 
     test('should create subspace with pinned=false by default', async () => {
-      // Act — resilient to the ENV_FAILURE retry-after-commit race (see
-      // createSubspaceOrFail); a throw here is a genuine create failure.
+      // Act — createSubspaceOrFail surfaces a genuine create failure instead of
+      // masking it into an empty id.
       newSubspaceId = await createSubspaceOrFail(
         `new-sub-${uniqueId}`,
         `new-sub-${uniqueId}`,

--- a/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
+++ b/server-api/src/functional-api/journey/subspace/subspace.request.params.ts
@@ -63,29 +63,20 @@ export const createSubspace = async (
 };
 
 /**
- * Setup-time subspace creation that is resilient to the ENV_FAILURE
- * retry-after-commit race, and surfaces genuine failures instead of masking
- * them.
+ * Setup-time subspace creation that surfaces failures instead of masking them.
  *
- * Two problems this replaces the plain
- * `createSubspace(...).data?.createSubspace.id ?? ''` idiom for:
+ * The `createSubspace(...).data?.createSubspace.id ?? ''` idiom used in test
+ * setup turns a failed create into an empty string; later mutations/queries then
+ * reject that empty id with a misleading `UUID not valid:`. That is how the
+ * 2026-07-15 nightly produced a 12-failure cascade across
+ * subspace-sorting-and-pinning and subsubspace with no trace of the real cause.
+ * Throw the actual error at the true failure point instead (same de-masking as
+ * `createRootSpace`, test-suites#577 / #563).
  *
- * 1. Masking. The `?? ''` turns a failed create into an empty string; later
- *    mutations/queries then reject that empty id with a misleading
- *    `UUID not valid:`. That is how the 2026-07-15 nightly produced a 12-failure
- *    cascade across subspace-sorting-and-pinning and subsubspace with no trace
- *    of the real cause. We throw the actual error at the true failure point
- *    instead (same de-masking as `createRootSpace`, test-suites#577 / #563).
- *
- * 2. The retry-after-commit race. On a ~5s connection reset (test-suites#563 /
- *    server#6258), `graphqlErrorWrapper` retries the mutation — but a create may
- *    have already committed server-side before the reset, so the retry comes
- *    back as `nameID already taken` (BAD_USER_INPUT). The subspace *does* exist;
- *    failing setup for a create that actually succeeded is wrong. Because the
- *    nameID is unique per run, `already taken` here reliably means our own
- *    committed-then-retried create — so we look it up by nameID under the parent
- *    and return it. (This is the caveat the wrapper's retry comment calls
- *    "harmless"; for a create it is not — hence this recovery.)
+ * Note: the earlier `nameID already taken` failures were the wrapper retrying a
+ * create that had already committed before a connection reset. That is now fixed
+ * at the source — the SDK wrapper (`getGraphqlClient`) never retries mutations —
+ * so `already taken` here again means a genuine duplicate and should surface.
  */
 export const createSubspaceOrFail = async (
   subspaceName: string,
@@ -100,33 +91,15 @@ export const createSubspaceOrFail = async (
     userRole
   );
   const id = response.data?.createSubspace?.id;
-  if (id) {
-    return id;
+  if (!id) {
+    const detail = response.error
+      ? JSON.stringify(response.error.errors)
+      : 'server returned no createSubspace.id and no error';
+    throw new Error(
+      `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): ${detail}`
+    );
   }
-
-  const alreadyTaken = response.error?.errors?.some(e =>
-    String((e as { message?: unknown }).message ?? '').includes(
-      'nameID is already taken'
-    )
-  );
-  if (alreadyTaken) {
-    const existing = await getSubspacesData(parentId);
-    const subspaces = (existing.data?.lookup?.space?.subspaces ?? []) as Array<{
-      id: string;
-      nameID: string;
-    }>;
-    const match = subspaces.find(s => s.nameID === subspaceNameId);
-    if (match?.id) {
-      return match.id;
-    }
-  }
-
-  const detail = response.error
-    ? JSON.stringify(response.error.errors)
-    : 'server returned no createSubspace.id and no error';
-  throw new Error(
-    `Failed to create subspace '${subspaceName}' (nameID '${subspaceNameId}', parent '${parentId}'): ${detail}`
-  );
+  return id;
 };
 
 export const subspaceVariablesData = (

--- a/server-api/src/functional-api/journey/subsubspace/subsubspace.it-spec.ts
+++ b/server-api/src/functional-api/journey/subsubspace/subsubspace.it-spec.ts
@@ -56,8 +56,8 @@ describe('Opportunities', () => {
 
   test('should create subsubspace and query the data', async () => {
     // Act
-    // Create Subsubspace (resilient to the ENV_FAILURE retry-after-commit race
-    // — see createSubspaceOrFail).
+    // Create Subsubspace (createSubspaceOrFail surfaces a genuine create failure
+    // instead of masking it into an empty id).
     subsubspaceId = await createSubspaceOrFail(
       subsubspaceName,
       subsubspaceNameId,


### PR DESCRIPTION
Root cause of the "nameID already taken" nightly failures (subspace, subsubspace, entitlements): graphqlErrorWrapper retried ANY request on an ENV_FAILURE connection reset. For a create, the server often commits before the ~5s reset, so the retry re-issues the same nameID and the server rejects the duplicate — failing a test for an entity that actually exists. The nightly DB is recreated per run, so this is purely a within-run retry-after-commit race, not stale data.

Fix at the source: move the ENV_FAILURE retry into the generated SDK wrapper (getGraphqlClient), where the operation type is known, and retry ONLY idempotent queries. Mutations run exactly once; a reset during a mutation now surfaces as a labelled ENV_FAILURE (environmental, server#6258) instead of a duplicate. This needs no per-helper changes and covers every suite uniformly. graphqlErrorWrapper keeps only its error-shaping role (no retry loop).

Consequently revert createSubspaceOrFail to plain de-masking: with the retry gone there is no committed-then-retried create to recover, and a genuine `already taken` should surface rather than be silently looked up. The de-masking, round-trip assertions, and tightened negatives from earlier in this PR are unchanged.

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GraphQL error handling with consistent error responses and clearer failure messages.
  - Added targeted retries for eligible query failures while avoiding retries for other operations.
  - Subspace creation failures now surface immediately instead of being masked by invalid or empty identifiers.

- **Tests**
  - Updated subspace and sub-subspace test guidance to reflect accurate failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->