### PR TITLE
fix(entitlements): recover createSpace from retry-after-commit race

### DIFF
--- a/server-api/src/functional-api/entitlements/space-functional-entitlements.it-spec.ts
+++ b/server-api/src/functional-api/entitlements/space-functional-entitlements.it-spec.ts
@@ -34,6 +34,7 @@ import {
 import { getMyEntitlementsQuery } from './entitlements-request.params';
 import {
   createSpaceBasicData,
+  createSpaceBasicDataOrFail,
   deleteSpace,
 } from '@functional-api/journey/space/space.request.params';
 import { getAccountMainEntities } from '../account/account.params.request';
@@ -92,20 +93,23 @@ describe('Functional tests - Space', () => {
     });
 
     test.each`
-      spaceName               | availableEntitlements | error
-      ${`space1-${uniqueId}`} | ${allPrivileges}      | ${undefined}
-      ${`space2-${uniqueId}`} | ${allPrivileges}      | ${undefined}
-      ${`space3-${uniqueId}`} | ${allPrivileges}      | ${undefined}
+      spaceName               | availableEntitlements
+      ${`space1-${uniqueId}`} | ${allPrivileges}
+      ${`space2-${uniqueId}`} | ${allPrivileges}
+      ${`space3-${uniqueId}`} | ${allPrivileges}
     `(
       'User: VC campaign has license $availableEntitlements to creates a space with name: $spaceName',
-      async ({ spaceName, availableEntitlements, error }) => {
+      async ({ spaceName, availableEntitlements }) => {
         // Arrange
         const response = await getMyEntitlementsQuery(
           TestUser.NON_SPACE_MEMBER
         );
 
-        // Act
-        const createSpace = await createSpaceBasicData(
+        // Act — resilient to the ENV_FAILURE retry-after-commit race: a reset
+        // can make createSpace re-issue an already-committed create and come
+        // back `already taken`; createSpaceBasicDataOrFail recovers the
+        // committed space (and throws on a genuine failure).
+        const spaceId = await createSpaceBasicDataOrFail(
           spaceName,
           spaceName,
           TestUserManager.users.nonSpaceMember.accountId,
@@ -117,7 +121,7 @@ describe('Functional tests - Space', () => {
         expect(
           response?.data?.me.user?.account?.license?.availableEntitlements?.sort()
         ).toEqual(availableEntitlements);
-        expect(createSpace?.error?.errors?.[0].message).toEqual(error);
+        expect(spaceId).toBeTruthy();
       }
     );
     // Test is dependant on the above test

--- a/server-api/src/functional-api/journey/space/space.request.params.ts
+++ b/server-api/src/functional-api/journey/space/space.request.params.ts
@@ -3,7 +3,7 @@ import {
   SpacePrivacyMode,
   CommunityMembershipPolicy,
 } from '@alkemio/client-lib';
-import { getGraphqlClient, TestUser } from '@alkemio/tests-lib';
+import { delay, getGraphqlClient, TestUser } from '@alkemio/tests-lib';
 import { UniqueIDGenerator } from '@alkemio/tests-lib';
 import {
   CreateSpaceOnAccountInput,
@@ -11,6 +11,7 @@ import {
   SpaceVisibility,
 } from '@alkemio/tests-lib/core/generated/alkemio-schema';
 import { graphqlErrorWrapper } from '@alkemio/tests-lib/utils/graphql.wrapper';
+import { getAccountMainEntities } from '@functional-api/account/account.params.request';
 const uniqueId = UniqueIDGenerator.getID();
 
 export const spaceName = `testEcoName${uniqueId}`;
@@ -48,6 +49,88 @@ export const createSpaceBasicData = async (
     );
 
   return graphqlErrorWrapper(callback, userRole);
+};
+
+/**
+ * Account-space creation resilient to the ENV_FAILURE retry-after-commit race,
+ * mirroring `createSubspaceOrFail`.
+ *
+ * On a ~5s connection reset `graphqlErrorWrapper` retries the create, but the
+ * root space may already have committed (reserving the nameID), so the retry
+ * comes back as `nameID already taken` (BAD_USER_INPUT). The space *does* exist;
+ * recover it by looking it up under its owning account by nameID rather than
+ * failing a test for a create that actually succeeded (the 2026-07-15
+ * `space1-… already taken` entitlements failure, test-suites#563).
+ *
+ * The lookup POLLS: like subspaces, root-space creation is not atomic — the
+ * space row lands first and community/collaboration keep landing for ~30s, and
+ * while the space is half-built the `account.spaces` query nulls via non-null
+ * bubbling on a failing child resolver. We retry until it reads clean and, if it
+ * never does, throw with both the create error and the last lookup failure.
+ */
+const RECOVERY_LOOKUP_ATTEMPTS = 10;
+const RECOVERY_LOOKUP_DELAY_MS = 5000;
+export const createSpaceBasicDataOrFail = async (
+  spaceName: string,
+  spaceNameId: string,
+  accountID: string,
+  addTutorialCallouts = true,
+  userRole: TestUser = TestUser.GLOBAL_ADMIN
+): Promise<string> => {
+  const response = await createSpaceBasicData(
+    spaceName,
+    spaceNameId,
+    accountID,
+    addTutorialCallouts,
+    userRole
+  );
+  const id = response.data?.createSpace?.id;
+  if (id) {
+    return id;
+  }
+
+  const alreadyTaken = response.error?.errors?.some(e =>
+    String((e as { message?: unknown }).message ?? '').includes(
+      'nameID is already taken'
+    )
+  );
+  const createDetail = response.error
+    ? JSON.stringify(response.error.errors)
+    : 'server returned no createSpace.id and no error';
+
+  if (alreadyTaken) {
+    let lastLookupDetail = '';
+    for (let attempt = 1; attempt <= RECOVERY_LOOKUP_ATTEMPTS; attempt++) {
+      const existing = await getAccountMainEntities(accountID, userRole);
+      const spaces = existing.data?.lookup?.account?.spaces as
+        | Array<{ id: string; nameID: string }>
+        | undefined;
+      if (existing.error || !spaces) {
+        // Half-built space (or a transient env failure): record why and retry.
+        lastLookupDetail = `lookup failed: ${JSON.stringify(
+          existing.error?.errors ?? 'no data'
+        )}`;
+      } else {
+        const match = spaces.find(s => s.nameID === spaceNameId);
+        if (match?.id) {
+          return match.id;
+        }
+        lastLookupDetail = `no space with nameID '${spaceNameId}' among [${spaces
+          .map(s => s.nameID)
+          .join(', ')}]`;
+      }
+      if (attempt < RECOVERY_LOOKUP_ATTEMPTS) {
+        await delay(RECOVERY_LOOKUP_DELAY_MS);
+      }
+    }
+    throw new Error(
+      `Failed to create space '${spaceName}' (nameID '${spaceNameId}', account '${accountID}'): create reported '${createDetail}' and the committed-create recovery did not stabilise after ${RECOVERY_LOOKUP_ATTEMPTS} lookups: ${lastLookupDetail}`
+    );
+  }
+
+  throw new Error(
+    `Failed to create space '${spaceName}' (nameID '${spaceNameId}', account '${accountID}'): ${createDetail}`
+  );
 };
 
 export const createSpaceAndGetData = async (

--- a/server-api/src/functional-api/journey/space/space.request.params.ts
+++ b/server-api/src/functional-api/journey/space/space.request.params.ts
@@ -62,6 +62,10 @@ export const createSpaceBasicData = async (
  * failing a test for a create that actually succeeded (the 2026-07-15
  * `space1-… already taken` entitlements failure, test-suites#563).
  *
+ * A preflight lookup establishes provenance: we reject a nameID that already
+ * exists *before* creating, so the recovery only ever returns a space this call
+ * committed — never a pre-existing one, which would hide a genuine duplicate.
+ *
  * The lookup POLLS: like subspaces, root-space creation is not atomic — the
  * space row lands first and community/collaboration keep landing for ~30s, and
  * while the space is half-built the `account.spaces` query nulls via non-null
@@ -77,6 +81,24 @@ export const createSpaceBasicDataOrFail = async (
   addTutorialCallouts = true,
   userRole: TestUser = TestUser.GLOBAL_ADMIN
 ): Promise<string> => {
+  // Preflight for provenance: if the nameID is already on the account BEFORE we
+  // create, a later `already taken` is a GENUINE duplicate — not our own
+  // retry-after-commit — and the recovery below would wrongly return that
+  // pre-existing space, hiding the failure. Reject it up front so the recovery
+  // can trust that any `already taken` is our own committed-then-retried create.
+  // (Belt-and-suspenders for the nightly: nameIDs are run-unique on a per-run
+  // fresh DB and the single worker has no concurrent creator; a lookup that
+  // errors/half-reads fails open, since it cannot prove pre-existence.)
+  const preflight = await getAccountMainEntities(accountID, userRole);
+  const preflightSpaces = preflight.data?.lookup?.account?.spaces as
+    | Array<{ id: string; nameID: string }>
+    | undefined;
+  if (preflightSpaces?.some(s => s.nameID === spaceNameId)) {
+    throw new Error(
+      `Refusing to create space '${spaceName}': nameID '${spaceNameId}' already exists on account '${accountID}' before creation — genuine duplicate, not a retry-after-commit`
+    );
+  }
+
   const response = await createSpaceBasicData(
     spaceName,
     spaceNameId,


### PR DESCRIPTION
Fixes the one remaining nightly failure ([29420789814](https://alkem-io.github.io/test-suites/server-api/2026-07-15/29420789814/)): `space-functional-entitlements` → `space1-… already taken or restricted`.

## Cause

The same ENV_FAILURE **retry-after-commit** race that #583 fixed for subspaces, on the `createSpace` path. The DB is recreated per run, so this is within-run: on a ~5s connection reset `graphqlErrorWrapper` retries the create, but the root space already committed (reserving the nameID), so the retry returns `nameID already taken` — failing the VC-campaign create test for a space that actually exists.

## Fix

Mirror #583's subspace recovery for account spaces:

- New `createSpaceBasicDataOrFail` (in `space.request.params.ts`) — on `already taken`, **polls** the owning account's spaces (`GetAccountMainEntities`) by nameID and returns the committed space; throws on a genuine failure with both the create error and the last lookup detail. It polls (10×5s) for the same reason #583 does: root-space creation is non-atomic — community/collaboration land over ~30s, and while the space is half-built the `account.spaces` query nulls via non-null bubbling on a failing child resolver.
- The three VC-campaign create rows (`space1/2/3`, all expected to succeed) use the helper; the assertion becomes "helper returned an id" (it throws on real failure). The **over-limit** and **post-delete** tests keep plain `createSpaceBasicData` — their create outcome is the assertion target and must not be recovered.

## Verification

- `server-api` typecheck + lint clean.
- `entitlements/space-functional-entitlements` — 5/5 green locally (healthy server: creates succeed, no recovery needed; the path mirrors #583's validated pattern).

## Context

Companion to #583 (subspace recovery) and #581 (de-masking + test-assertion hardening). Supersedes the closed #584 (never-retry-mutations), which would have regressed heavy subspace creates. `develop`'s chosen direction is *recover, not prevent*; this extends it to the last create path the nightly exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating spaces during automated flows, including recovery from temporary commit and race-condition failures.
  * Space creation now confirms success with a valid space identifier before continuing with entitlement checks.
  * Enhanced error handling when a created space cannot be recovered or located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->