### PR TITLE
fix(e2e): update client-web specs for CRD UI changes

### DIFF
--- a/client-web/src/functional-e2e/default-template/default-template-per-flow-state.spec.ts
+++ b/client-web/src/functional-e2e/default-template/default-template-per-flow-state.spec.ts
@@ -23,26 +23,23 @@ const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
 
 /**
  * Helper to get the flow state menu button for the "Home" flow state.
- * CRD renders each flow state as a column whose header has an
- * "Edit column title" button (showing the flow-state name) and a sibling
- * "Column actions" button (aria-haspopup="menu") that opens the per-column
- * menu — the CRD replacement for the MUI sortable-card MoreVert button.
- * Home is the first column, so its "Column actions" is the first one.
+ * CRD renders each flow state as a column whose header shows the flow-state
+ * name as plain text and a sibling "Column actions" button
+ * (aria-haspopup="menu") that opens the per-column menu — the CRD replacement
+ * for the MUI sortable-card MoreVert button. Home is the first column, so its
+ * "Column actions" is the first one.
  */
 function getFlowStateMenuButton(page: Page) {
   return page.getByRole('button', { name: 'Column actions' }).first();
 }
 
 /**
- * Helper to get the "Set default callout template…" menu item.
- * CRD renamed the MUI "Set Default Post Template" item to a generic
- * callout-template label (with a trailing ellipsis), since the default is a
- * callout template, not specifically a post.
+ * Helper to get the default-template menu item in the column-actions menu.
+ * CRD labels this item "Post Template" (it opens the "Use a template" dialog
+ * that sets the flow state's default callout template).
  */
 function getDefaultTemplateMenuItem(page: Page) {
-  return page
-    .getByRole('menuitem')
-    .filter({ hasText: /Set default callout template/i });
+  return page.getByRole('menuitem', { name: 'Post Template', exact: true });
 }
 
 /**
@@ -96,6 +93,19 @@ async function openTemplateLibraryDialog(page: Page): Promise<void> {
   const menuItem = getDefaultTemplateMenuItem(page);
   await expect(menuItem).toBeVisible({ timeout: 5000 });
   await menuItem.click();
+
+  // CRD opens an intermediate "Post Template: <flow state>" dialog first (it
+  // shows the current default and a "Choose template…" button). Click that to
+  // open the "Use a template" picker.
+  const postTemplateDialog = page
+    .getByRole('dialog')
+    .filter({ has: page.getByRole('heading', { name: /^Post Template:/ }) })
+    .first();
+  await expect(postTemplateDialog).toBeVisible({ timeout: 5000 });
+  await postTemplateDialog
+    .getByRole('button', { name: /choose template|change template/i })
+    .first()
+    .click();
 
   const dialog = getTemplateLibraryDialog(page);
   await expect(dialog).toBeVisible({ timeout: 5000 });
@@ -203,11 +213,12 @@ test.describe('Default Template Per Flow State', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify the Home flow-state column header is visible. CRD renders each
-      // flow state as a column whose header is an "Edit column title" button
-      // showing the flow-state name.
-      const homeFlowState = page
-        .getByRole('button', { name: 'Edit column title' })
-        .filter({ hasText: 'Home' });
+      // flow state as a column whose header is now plain text (no longer an
+      // "Edit column title" button) beside the per-column "Column actions"
+      // button. The header logo link's "Home" is an accessible name on an image
+      // link (not a text node), so an exact text match targets only the column
+      // header.
+      const homeFlowState = page.getByText('Home', { exact: true }).first();
       await expect(homeFlowState).toBeVisible({ timeout: 10000 });
 
       // Open the flow-state (column actions) menu

--- a/client-web/src/functional-e2e/explore-platform/explore-platform-anonymous.spec.ts
+++ b/client-web/src/functional-e2e/explore-platform/explore-platform-anonymous.spec.ts
@@ -131,9 +131,12 @@ test.describe('Explore Alkemio Platform - Anonymous User Flow', () => {
     await expect(page.getByRole('tab', { name: 'Subspaces' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Knowledge' })).toBeVisible();
 
-    // Verify Sign in to apply button (anonymous user)
+    // Verify Sign in to apply button (anonymous user). CRD moved the apply
+    // affordance out of the dashboard and into the About dialog; open it to
+    // surface the "Sign in to apply" button.
+    await page.getByRole('button', { name: 'About this Space' }).click();
     await expect(
-      page.getByRole('button', { name: 'Sign in to apply' })
+      page.getByRole('dialog').getByRole('button', { name: 'Sign in to apply' })
     ).toBeVisible();
   });
 
@@ -290,12 +293,12 @@ test.describe('Explore Alkemio Platform - Anonymous User Flow', () => {
     // Click Template Library
     await page.getByRole('link', { name: 'Template Library' }).click();
 
-    // Verify navigation. CRD renames the page heading "Alkemio's Template
-    // Library" -> "Innovation Library".
+    // Verify navigation. The route is /innovation-library but the page heading
+    // is "Template Library".
     await expect(page).toHaveURL(/\/innovation-library/);
     await expect(
       page.getByRole('heading', {
-        name: 'Innovation Library',
+        name: 'Template Library',
         level: 1,
       })
     ).toBeVisible();
@@ -316,10 +319,10 @@ test.describe('Explore Alkemio Platform - Anonymous User Flow', () => {
   test('14. Click on Collaboration Tool Template filter', async ({ page }) => {
     await page.goto(`${baseUrl}/innovation-library`);
 
-    // Wait for page to load (CRD: "Innovation Library").
+    // Wait for page to load (heading "Template Library").
     await expect(
       page.getByRole('heading', {
-        name: 'Innovation Library',
+        name: 'Template Library',
         level: 1,
       })
     ).toBeVisible();

--- a/client-web/src/functional-e2e/explore-platform/explore-platform-authenticated.spec.ts
+++ b/client-web/src/functional-e2e/explore-platform/explore-platform-authenticated.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@alkemio/client-lib/dist/generated/graphql';
 import { createAuthenticatedSessionFixture } from '../fixtures/authenticated-session.fixture';
 import { verifyMyDashboardWelcomeElement } from '../my-dashboard/my-dashboard-page-objects';
+import { userMenuAvatar } from '../authentication/common-authentication-page-elements';
 
 const { test, setupAuthentication, teardownAuthentication } =
   createAuthenticatedSessionFixture({
@@ -151,9 +152,12 @@ test.describe('Explore Alkemio Platform - Authenticated User Flow', () => {
     await expect(page.getByRole('tab', { name: 'Subspaces' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Knowledge' })).toBeVisible();
 
-    // Authenticated user should see apply/join button (not "Sign in to apply")
+    // Authenticated user should see apply/join button (not "Sign in to apply").
+    // CRD moved the apply affordance out of the dashboard and into the About
+    // dialog; open it to surface the apply/join button.
+    await page.getByRole('button', { name: 'About this Space' }).click();
     await expect(
-      page.getByRole('button', { name: /apply|join/i })
+      page.getByRole('dialog').getByRole('button', { name: /apply|join/i })
     ).toBeVisible();
   });
 
@@ -352,11 +356,12 @@ test.describe('Explore Alkemio Platform - Authenticated User Flow', () => {
     // Click Template Library
     await page.getByRole('link', { name: 'Template Library' }).click();
 
-    // Verify navigation
+    // Verify navigation. The route is /innovation-library but the page heading
+    // is "Template Library".
     await expect(page).toHaveURL(/\/innovation-library/);
     await expect(
       page.getByRole('heading', {
-        name: 'Innovation Library',
+        name: 'Template Library',
         level: 1,
       })
     ).toBeVisible();
@@ -378,10 +383,10 @@ test.describe('Explore Alkemio Platform - Authenticated User Flow', () => {
   test('14. Click on Collaboration Tool Template filter', async ({ page }) => {
     await page.goto(`${baseUrl}/innovation-library`);
 
-    // Wait for page to load (CRD: "Innovation Library").
+    // Wait for page to load (heading "Template Library").
     await expect(
       page.getByRole('heading', {
-        name: 'Innovation Library',
+        name: 'Template Library',
         level: 1,
       })
     ).toBeVisible();
@@ -415,9 +420,12 @@ test.describe('Explore Alkemio Platform - Authenticated User Flow', () => {
     await verifyMyDashboardWelcomeElement(page);
 
     // CRD replaces the legacy avatar/"My Dashboard" affordance with a user
-    // button in the header (avatar + the "Beta" badge) that opens the account
-    // menu. Open it and verify the profile/account/logout options are present.
-    await page.getByRole('button', { name: /Beta/ }).last().click();
+    // button in the header (the avatar, keyed by the user's display name). The
+    // "Beta" badge that used to label this header button moved into the account
+    // menu it opens and is now a purely decorative badge (not exposed to the
+    // accessibility tree), so target the avatar positionally instead of by
+    // "Beta" text and verify the profile/account/logout options inside the menu.
+    await userMenuAvatar(page).click();
 
     await expect(
       page.getByRole('menuitem', { name: 'My Profile' })

--- a/client-web/src/functional-e2e/public-space/anonymous-user-access-public-space.spec.ts
+++ b/client-web/src/functional-e2e/public-space/anonymous-user-access-public-space.spec.ts
@@ -72,9 +72,12 @@ test.describe('Public Space Discovery and Access', () => {
     await expect(page.getByRole('tab', { name: 'Subspaces' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Knowledge' })).toBeVisible();
 
-    // Verify Login/Sign Up option remains available (user not logged in)
+    // Verify Login/Sign Up option remains available (user not logged in).
+    // CRD moved the apply affordance out of the dashboard and into the About
+    // dialog; open it to surface the "Sign in to apply" button.
+    await page.getByRole('button', { name: 'About this Space' }).click();
     await expect(
-      page.getByRole('button', { name: 'Sign in to apply' })
+      page.getByRole('dialog').getByRole('button', { name: 'Sign in to apply' })
     ).toBeVisible();
   });
 

--- a/client-web/src/functional-e2e/public-space/non-member-edge-cases.spec.ts
+++ b/client-web/src/functional-e2e/public-space/non-member-edge-cases.spec.ts
@@ -224,9 +224,16 @@ test.describe('Edge Cases and Error Handling', () => {
     // Try to access "Apply to Join" or similar member-only action
     await page.getByRole('tab', { name: 'Home' }).click();
 
+    // CRD moved the apply affordance out of the dashboard and into the About
+    // dialog; open it to surface the login-gated apply button.
+    await page.getByRole('button', { name: 'About this Space' }).click();
+
     // Check if "Sign in to apply" button appears (indicating login required for private actions)
     await expect(
-      page.getByRole('button', { name: /Sign in to apply|Apply/i }).first()
+      page
+        .getByRole('dialog')
+        .getByRole('button', { name: /Sign in to apply|Apply/i })
+        .first()
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Repairs client-web E2E specs that broke due to **CRD UI/requirement changes** (not test defects). Each fix re-anchors selectors to the current DOM; no product behaviour is being worked around.

### Changes

- **Apply affordance moved into the About dialog** — on the space dashboard the apply button is gone; it now lives in the "About this Space" dialog. Open the dialog and scope the `Sign in to apply` / apply-join assertion to it.
  - `public-space/anonymous-user-access-public-space.spec.ts` (1.2)
  - `public-space/non-member-edge-cases.spec.ts` (6.3)
  - `explore-platform/explore-platform-anonymous.spec.ts` (2)
  - `explore-platform/explore-platform-authenticated.spec.ts` (2)
- **Template Library heading** — the page heading is `Template Library` (route stays `/innovation-library`); the assumed "Innovation Library" rename never landed. Fixed tests 12 & 14 in both explore-platform flows.
- **"Beta" badge relocated** — it moved off the header avatar button (now keyed by the user's display name) into the account menu as a decorative, non-accessibility-tree badge. Open the menu via the shared `userMenuAvatar` helper instead of by "Beta" text and verify the profile/account/logout items (test 15).
- **Default-template-per-flow-state layout flow** — three CRD changes in one path:
  1. flow-state column title is now plain text (was an `Edit column title` button),
  2. the column-actions menu item is now `Post Template` (was "Set default callout template…"),
  3. it opens an intermediate `Post Template: <flow state>` dialog with a `Choose template…` button before the `Use a template` picker.

## Testing

All affected tests pass locally, headless (`UI_HEADLESS=true`). `default-template` 4.1 remains intentionally `test.skip` (pre-existing product persistence gap).

## Not included

Whiteboard/callout template failures seen during triage were **environment issues** (a wrong-version file service returning storage Error 14108), not test defects — those specs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated public-space access flows to show sign-in and apply actions within the “About this Space” dialog.
  - Updated template library checks to reflect the “Template Library” heading and current navigation.
  - Improved profile menu access through the user avatar.

- **Tests**
  - Updated default post-template selection flows to support the intermediate template dialog.
  - Refined end-to-end checks for current flow-state menus, filters, and page interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->