### PR TITLE
test(conversion): cross-service coverage for moveSpaceL2ToSpaceL1 (workspace#030-move-subspace-parent)

### DIFF
--- a/lib/src/core/generated/alkemio-schema.ts
+++ b/lib/src/core/generated/alkemio-schema.ts
@@ -1205,6 +1205,15 @@ export type CalloutContributionsCountOutput = {
   whiteboard: Scalars["Float"]["output"];
 };
 
+export type CalloutContributorsSettings = {
+  /** The contributor types included in this contributor-collection callout. At least one. */
+  contributorTypes: Array<ActorType>;
+  /** The contributor type shown first (the segmented switch opens on it). One of contributorTypes. */
+  defaultContributorType: ActorType;
+  /** The default display mode (list or map). */
+  defaultView: ContributorCollectionView;
+};
+
 export enum CalloutDescriptionDisplayMode {
   Collapsed = "COLLAPSED",
   Expanded = "EXPANDED",
@@ -1215,6 +1224,10 @@ export type CalloutFraming = {
   authorization?: Maybe<Authorization>;
   /** The Collabora document attached to this Callout Framing, if any. Present when framing.type = COLLABORA_DOCUMENT. */
   collaboraDocument?: Maybe<CollaboraDocument>;
+  /** Per-type counts (users, organizations, virtual contributors) of the total eligible set for a CONTRIBUTORS framing, after type-selection and user-information visibility filtering. Zeroed for non-CONTRIBUTORS framings. */
+  contributorCounts: ContributorCollectionCounts;
+  /** The full authorized set of contributors of the given type for a CONTRIBUTORS framing, ordered leads/admins first then alphabetically. No server-side pagination or search: the client paginates (list) and name-searches client-side over this set. Empty for non-CONTRIBUTORS framings or deselected types. */
+  contributors: Array<ContributorCollectionItem>;
   /** The date at which the entity was created. */
   createdDate: Scalars["DateTime"]["output"];
   /** The ID of the entity */
@@ -1229,6 +1242,8 @@ export type CalloutFraming = {
   poll?: Maybe<Poll>;
   /** The Profile for framing the associated Callout. */
   profile: Profile;
+  /** The host space's subspaces for a SPACES framing, ordered pinned-first then the space's sortOrder/displayName. Returns the existing Space type (no new item type). No server-side pagination/search: the client name-searches and paginates client-side over this set. Empty for non-SPACES framings, for a callout not attached to a space, or for a host with no subspaces. */
+  subspaces: Array<Space>;
   /** The type of the Callout Framing, the additional content attached to this callout */
   type: CalloutFramingType;
   /** The date at which the entity was last updated. */
@@ -1237,13 +1252,19 @@ export type CalloutFraming = {
   whiteboard?: Maybe<Whiteboard>;
 };
 
+export type CalloutFramingContributorsArgs = {
+  type: ActorType;
+};
+
 export enum CalloutFramingType {
   CollaboraDocument = "COLLABORA_DOCUMENT",
+  Contributors = "CONTRIBUTORS",
   Link = "LINK",
   MediaGallery = "MEDIA_GALLERY",
   Memo = "MEMO",
   None = "NONE",
   Poll = "POLL",
+  Spaces = "SPACES",
   Whiteboard = "WHITEBOARD",
 }
 
@@ -1256,6 +1277,19 @@ export type CalloutPostCreated = {
   post: Post;
   /** The sorting order for this Contribution. */
   sortOrder: Scalars["Float"]["output"];
+};
+
+/** The selection mode for a collection callout (Contributors or Subspaces). AUTO (default) returns the full computed set; CUSTOM restricts to the admin-curated selectedIds list. */
+export enum CalloutSelectionMode {
+  Auto = "AUTO",
+  Custom = "CUSTOM",
+}
+
+export type CalloutSelectionSettings = {
+  /** The selection mode: AUTO (full computed set) or CUSTOM (admin-curated subset). */
+  mode: CalloutSelectionMode;
+  /** The selected actor/space IDs in CUSTOM mode (0–500 entries). Ignored when mode is AUTO. */
+  selectedIds: Array<Scalars["ID"]["output"]>;
 };
 
 export type CalloutSettings = {
@@ -1281,6 +1315,10 @@ export type CalloutSettingsContribution = {
 export type CalloutSettingsFraming = {
   /** Can comment to callout framing. */
   commentsEnabled: Scalars["Boolean"]["output"];
+  /** Configuration for a contributor-collection callout. Present only when framing.type = CONTRIBUTORS. */
+  contributors?: Maybe<CalloutContributorsSettings>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Absent / null ⇒ AUTO (full computed set). */
+  selection?: Maybe<CalloutSelectionSettings>;
 };
 
 export enum CalloutVisibility {
@@ -1377,7 +1415,7 @@ export enum CollaboraDocumentType {
 }
 
 export type CollaboraEditorUrlResult = {
-  /** The time-to-live of the access token in seconds. */
+  /** When the access token expires, as an absolute Unix timestamp in milliseconds (the WOPI access_token_ttl passed through from the WOPI host); 0 means it does not expire. */
   accessTokenTTL: Scalars["Float"]["output"];
   /** The URL to open the document in the Collabora editor. */
   editorUrl: Scalars["String"]["output"];
@@ -1661,9 +1699,42 @@ export type ContributionsFilterInput = {
   types?: InputMaybe<Array<CalloutContributionType>>;
 };
 
+export type ContributorCollectionCounts = {
+  organizations: Scalars["Int"]["output"];
+  users: Scalars["Int"]["output"];
+  virtualContributors: Scalars["Int"]["output"];
+};
+
+export type ContributorCollectionItem = {
+  avatarUrl?: Maybe<Scalars["String"]["output"]>;
+  displayName: Scalars["String"]["output"];
+  id: Scalars["UUID"]["output"];
+  /** Location of the contributor; null for Virtual Contributors or when not readable. */
+  location?: Maybe<ContributorLocation>;
+  /** The role label for this contributor (lead/admin/member). */
+  roleLabel?: Maybe<Scalars["String"]["output"]>;
+  type: ActorType;
+  url?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** The default display mode for a contributor-collection callout framing. */
+export enum ContributorCollectionView {
+  List = "LIST",
+  Map = "MAP",
+}
+
 export type ContributorFilterInput = {
   displayName?: InputMaybe<Scalars["String"]["input"]>;
   nameID?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ContributorLocation = {
+  city?: Maybe<Scalars["String"]["output"]>;
+  country?: Maybe<Scalars["String"]["output"]>;
+  /** Whether the location has valid stored coordinates (geoLocation.isValid). City/country alone is false. */
+  hasValidCoordinates: Scalars["Boolean"]["output"];
+  latitude?: Maybe<Scalars["Float"]["output"]>;
+  longitude?: Maybe<Scalars["Float"]["output"]>;
 };
 
 export type Conversation = {
@@ -1874,6 +1945,24 @@ export type CreateCalloutContributionInput = {
   whiteboard?: InputMaybe<CreateWhiteboardInput>;
 };
 
+export type CreateCalloutContributorsSettingsData = {
+  /** The contributor types to include. At least one type is required. */
+  contributorTypes: Array<ActorType>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: Maybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: Maybe<ContributorCollectionView>;
+};
+
+export type CreateCalloutContributorsSettingsInput = {
+  /** The contributor types to include. At least one type is required. */
+  contributorTypes: Array<ActorType>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: InputMaybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: InputMaybe<ContributorCollectionView>;
+};
+
 export type CreateCalloutData = {
   classification?: Maybe<CreateClassificationData>;
   contributionDefaults?: Maybe<CreateCalloutContributionDefaultsData>;
@@ -1948,6 +2037,20 @@ export type CreateCalloutOnCalloutsSetInput = {
   sortOrder?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
+export type CreateCalloutSelectionSettingsData = {
+  /** The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted. */
+  mode?: Maybe<CalloutSelectionMode>;
+  /** The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server. */
+  selectedIds?: Maybe<Array<Scalars["ID"]["output"]>>;
+};
+
+export type CreateCalloutSelectionSettingsInput = {
+  /** The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted. */
+  mode?: InputMaybe<CalloutSelectionMode>;
+  /** The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server. */
+  selectedIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+};
+
 export type CreateCalloutSettingsContributionData = {
   /** Allowed Contribution types. */
   allowedTypes?: Maybe<Array<CalloutContributionType>>;
@@ -1980,11 +2083,19 @@ export type CreateCalloutSettingsData = {
 export type CreateCalloutSettingsFramingData = {
   /** Can comment to callout framing. */
   commentsEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: Maybe<CreateCalloutContributorsSettingsData>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: Maybe<CreateCalloutSelectionSettingsData>;
 };
 
 export type CreateCalloutSettingsFramingInput = {
   /** Can comment to callout framing. */
   commentsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: InputMaybe<CreateCalloutContributorsSettingsInput>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: InputMaybe<CreateCalloutSelectionSettingsInput>;
 };
 
 export type CreateCalloutSettingsInput = {
@@ -2115,6 +2226,10 @@ export type CreateInnovationFlowStateInput = {
 export type CreateInnovationFlowStateSettingsData = {
   /** The flag to set. */
   allowNewCallouts: Scalars["Boolean"]["output"];
+  /** Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted. */
+  descriptionDisplayMode?: Maybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted. */
+  showPublishDetails?: Maybe<Scalars["Boolean"]["output"]>;
   /** Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted. */
   visible?: Maybe<Scalars["Boolean"]["output"]>;
 };
@@ -2122,6 +2237,10 @@ export type CreateInnovationFlowStateSettingsData = {
 export type CreateInnovationFlowStateSettingsInput = {
   /** The flag to set. */
   allowNewCallouts: Scalars["Boolean"]["input"];
+  /** Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted. */
+  descriptionDisplayMode?: InputMaybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted. */
+  showPublishDetails?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted. */
   visible?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
@@ -2129,6 +2248,8 @@ export type CreateInnovationFlowStateSettingsInput = {
 export type CreateInnovationHubOnAccountInput = {
   /** The Account where the InnovationHub is to be created. */
   accountID: Scalars["UUID"]["input"];
+  /** The Innovation Packs curated for this Innovation Hub. When omitted, the Innovation Hub is created with no Innovation Packs. */
+  innovationPackListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars["NameID"]["input"]>;
   profileData: CreateProfileInput;
@@ -2140,6 +2261,8 @@ export type CreateInnovationHubOnAccountInput = {
   subdomain: Scalars["String"]["input"];
   /** The type of Innovation Hub. */
   type: InnovationHubType;
+  /** The Virtual Contributors curated for this Innovation Hub. When omitted, the Innovation Hub is created with no Virtual Contributors. */
+  virtualContributorListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
 };
 
 export type CreateInnovationPackOnAccountInput = {
@@ -2387,6 +2510,8 @@ export type CreateSpaceSettingsPrivacyInput = {
   /** Flag to control if Platform Support has admin rights. */
   allowPlatformSupportAsAdmin?: InputMaybe<Scalars["Boolean"]["input"]>;
   mode?: InputMaybe<SpacePrivacyMode>;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. */
+  userInformationVisibility?: InputMaybe<UserInformationVisibility>;
 };
 
 export type CreateStateOnInnovationFlowInput = {
@@ -3356,6 +3481,10 @@ export type InnovationFlowState = {
 export type InnovationFlowStateSettings = {
   /** Whether new callouts can be added to this State. */
   allowNewCallouts: Scalars["Boolean"]["output"];
+  /** How Post descriptions in this State are displayed in the feed: expanded or collapsed. Default expanded. */
+  descriptionDisplayMode: CalloutDescriptionDisplayMode;
+  /** Whether Posts in this State show publish details (publisher, publish date, avatar) in the feed. Presentation only — does not restrict access to publisher data. Default true. */
+  showPublishDetails: Scalars["Boolean"]["output"];
   /** Whether this State/phase is shown in the member-facing navigation. Default true. UI-affordance only: it does NOT gate access to the phase content. */
   visible: Scalars["Boolean"]["output"];
 };
@@ -3369,6 +3498,8 @@ export type InnovationHub = {
   createdDate: Scalars["DateTime"]["output"];
   /** The ID of the entity */
   id: Scalars["UUID"]["output"];
+  /** The Innovation Packs curated for this Innovation Hub, in stored (curated) order, filtered to those the requesting agent may read. */
+  innovationPackListFilter?: Maybe<Array<InnovationPack>>;
   /** Flag to control if this InnovationHub is listed in the platform store. */
   listedInStore: Scalars["Boolean"]["output"];
   /** A name identifier of the entity, unique within a given scope. */
@@ -3388,6 +3519,8 @@ export type InnovationHub = {
   type: InnovationHubType;
   /** The date at which the entity was last updated. */
   updatedDate: Scalars["DateTime"]["output"];
+  /** The Virtual Contributors curated for this Innovation Hub, in stored (curated) order, filtered to those the requesting agent may read. */
+  virtualContributorListFilter?: Maybe<Array<VirtualContributor>>;
 };
 
 export enum InnovationHubType {
@@ -4524,6 +4657,17 @@ export type MoveSpaceL1ToSpaceL2Input = {
   targetSpaceL1ID: Scalars["UUID"]["input"];
 };
 
+export type MoveSpaceL2ToSpaceL1Input = {
+  /** Send invitations to former community members who are also in the target L0 community. */
+  autoInvite?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Custom invitation message. Used only when autoInvite is true. */
+  invitationMessage?: InputMaybe<Scalars["String"]["input"]>;
+  /** The L2 subspace to move (stays L2). */
+  spaceL2ID: Scalars["UUID"]["input"];
+  /** The target L1 subspace in a different L0 (new parent for the moved L2). */
+  targetSpaceL1ID: Scalars["UUID"]["input"];
+};
+
 export type Mutation = {
   /** Adds an Iframe Allowed URL to the Platform Settings */
   addIframeAllowedURL: Array<Scalars["String"]["output"]>;
@@ -4759,6 +4903,8 @@ export type Mutation = {
   moveSpaceL1ToSpaceL0: Space;
   /** Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges. */
   moveSpaceL1ToSpaceL2: Space;
+  /** Move an L2 sub-subspace to become an L2 subspace under a target L1 in a different L0 space.       The subspace stays at level 2 but changes both its parent L1 and its top-level L0.       All community roles (including admins) are cleared and pending invitations dropped.       Platform access rules are recomputed from the new parent hierarchy.       Requires platform admin privileges. */
+  moveSpaceL2ToSpaceL1: Space;
   /** Refresh the Bodies of Knowledge on All VCs */
   refreshAllBodiesOfKnowledge: Scalars["Boolean"]["output"];
   /** Triggers a request to the backing AI Service to refresh the knowledge that is available to it. */
@@ -4795,6 +4941,8 @@ export type Mutation = {
   removeUserFromGroup: UserGroup;
   /** Reorder Poll options. Requires UPDATE privilege. The provided list must contain exactly the same option IDs as the current poll options. */
   reorderPollOptions: Poll;
+  /** Replace the backing file of an existing CollaboraDocument in place, preserving its identity. Requires UPDATE on the document. The replacement must be an allowed OfficeDocs format, within the size cap, and the SAME document type as the current file. Refused while the document is being edited. */
+  replaceCollaboraDocument: CollaboraDocument;
   /** Resets the interaction with the VC by recreating the room. */
   resetConversationVc: Conversation;
   /** Reset all license plans on Accounts */
@@ -5387,6 +5535,10 @@ export type MutationMoveSpaceL1ToSpaceL2Args = {
   moveData: MoveSpaceL1ToSpaceL2Input;
 };
 
+export type MutationMoveSpaceL2ToSpaceL1Args = {
+  moveData: MoveSpaceL2ToSpaceL1Input;
+};
+
 export type MutationRefreshVirtualContributorBodyOfKnowledgeArgs = {
   refreshData: RefreshVirtualContributorBodyOfKnowledgeInput;
 };
@@ -5453,6 +5605,11 @@ export type MutationRemoveUserFromGroupArgs = {
 
 export type MutationReorderPollOptionsArgs = {
   optionData: ReorderPollOptionsInput;
+};
+
+export type MutationReplaceCollaboraDocumentArgs = {
+  file: Scalars["Upload"]["input"];
+  replaceData: ReplaceCollaboraDocumentInput;
 };
 
 export type MutationResetConversationVcArgs = {
@@ -6775,6 +6932,8 @@ export type Query = {
   aiServer: AiServer;
   /** Retrieves the editor URL for the specified CollaboraDocument. */
   collaboraEditorUrl: CollaboraEditorUrlResult;
+  /** Whether the WOPI save service backing this CollaboraDocument is currently reachable. A side-effect-free health check — unlike collaboraEditorUrl it issues no access token and records no analytics — used to surface a save-path outage in the editor. */
+  collaboraServiceAvailable: Scalars["Boolean"]["output"];
   /** Active Spaces only, order by most active in the past X days. */
   exploreSpaces: Array<Space>;
   /** Allow creation of inputs based on existing entities in the domain model */
@@ -6863,6 +7022,10 @@ export type QueryActorsWithCredentialArgs = {
 };
 
 export type QueryCollaboraEditorUrlArgs = {
+  collaboraDocumentID: Scalars["UUID"]["input"];
+};
+
+export type QueryCollaboraServiceAvailableArgs = {
   collaboraDocumentID: Scalars["UUID"]["input"];
 };
 
@@ -7152,6 +7315,13 @@ export type RemoveUserGroupMemberInput = {
 export type ReorderPollOptionsInput = {
   optionIDs: Array<Scalars["UUID"]["input"]>;
   pollID: Scalars["UUID"]["input"];
+};
+
+export type ReplaceCollaboraDocumentInput = {
+  /** The ID of the CollaboraDocument whose backing file is being replaced. */
+  ID: Scalars["UUID"]["input"];
+  /** Optional title chosen in the replace dialog (defaults to the incoming file title). When supplied it is persisted as the CollaboraDocument display name (the same entity), propagating to the editor title and the download filename. Omit to leave the current name unchanged. */
+  displayName?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RevokeAuthorizationCredentialInput = {
@@ -7647,6 +7817,25 @@ export type SearchResultCallout = SearchResult & {
   type: SearchResultType;
 };
 
+export type SearchResultCollaboraDocument = SearchResult & {
+  /** The Callout of the Collabora document. */
+  callout: Callout;
+  /** The Collabora document that was found. */
+  collaboraDocument: CollaboraDocument;
+  /** The identifier of the search result. Does not represent the entity in Alkemio. */
+  id: Scalars["UUID"]["output"];
+  /** Whether the Collabora document is a contribution (response) or part of the framing. */
+  isContribution: Scalars["Boolean"]["output"];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars["Float"]["output"];
+  /** The Space of the Collabora document. */
+  space: Space;
+  /** The terms that were matched for this result */
+  terms: Array<Scalars["String"]["output"]>;
+  /** The type of returned result for this search. */
+  type: SearchResultType;
+};
+
 export type SearchResultMemo = SearchResult & {
   /** The Callout of the Memo. */
   callout: Callout;
@@ -7714,6 +7903,7 @@ export type SearchResultSpace = SearchResult & {
 /** The different types of available search results. */
 export enum SearchResultType {
   Callout = "CALLOUT",
+  CollaboraDocument = "COLLABORA_DOCUMENT",
   Memo = "MEMO",
   Organization = "ORGANIZATION",
   Post = "POST",
@@ -7977,7 +8167,10 @@ export type SpaceSettingsCollaboration = {
 };
 
 export type SpaceSettingsLayout = {
-  /** The default display mode for callout descriptions in this Space. */
+  /**
+   * The default display mode for callout descriptions in this Space.
+   * @deprecated REMOVE_AFTER=2026-10-31 | superseded by InnovationFlowStateSettings.descriptionDisplayMode
+   */
   calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode;
 };
 
@@ -7995,6 +8188,8 @@ export type SpaceSettingsPrivacy = {
   allowPlatformSupportAsAdmin: Scalars["Boolean"]["output"];
   /** The privacy mode for this Space */
   mode: SpacePrivacyMode;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. Absent is treated as follow-space-visibility. */
+  userInformationVisibility?: Maybe<UserInformationVisibility>;
 };
 
 export enum SpaceSortMode {
@@ -8536,6 +8731,15 @@ export type UpdateCalloutContributionDefaultsInput = {
   whiteboardContent?: InputMaybe<Scalars["WhiteboardContent"]["input"]>;
 };
 
+export type UpdateCalloutContributorsSettingsInput = {
+  /** When provided, replaces the selected contributor types (at least one). */
+  contributorTypes?: InputMaybe<Array<ActorType>>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: InputMaybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: InputMaybe<ContributorCollectionView>;
+};
+
 export type UpdateCalloutEntityInput = {
   ID: Scalars["UUID"]["input"];
   classification?: InputMaybe<UpdateClassificationInput>;
@@ -8577,6 +8781,13 @@ export type UpdateCalloutPublishInfoInput = {
   publisherID?: InputMaybe<Scalars["UUID"]["input"]>;
 };
 
+export type UpdateCalloutSelectionSettingsInput = {
+  /** The selection mode (AUTO or CUSTOM). When omitted, the stored mode is unchanged. */
+  mode?: InputMaybe<CalloutSelectionMode>;
+  /** Replaces the curated selection in full (CUSTOM mode). At most 500 entries. Deduplicated by the server. When omitted, the stored list is unchanged. */
+  selectedIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+};
+
 export type UpdateCalloutSettingsContributionInput = {
   /** Indicate who can add more contributions to the callout. */
   canAddContributions?: InputMaybe<CalloutAllowedActors>;
@@ -8589,6 +8800,10 @@ export type UpdateCalloutSettingsContributionInput = {
 export type UpdateCalloutSettingsFramingInput = {
   /** Can comment to callout framing. */
   commentsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: InputMaybe<UpdateCalloutContributorsSettingsInput>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: InputMaybe<UpdateCalloutSelectionSettingsInput>;
 };
 
 export type UpdateCalloutSettingsInput = {
@@ -8713,10 +8928,10 @@ export type UpdateInnovationFlowInput = {
 };
 
 export type UpdateInnovationFlowStateInput = {
-  /** The explanation text to clarify the State. */
+  /** Optional. The explanation text to clarify the State; omission leaves the stored value unchanged. */
   description?: InputMaybe<Scalars["Markdown"]["input"]>;
-  /** The display name for the State */
-  displayName: Scalars["String"]["input"];
+  /** Optional. The display name for the State; omission leaves the stored value unchanged. */
+  displayName?: InputMaybe<Scalars["String"]["input"]>;
   /** ID of the Innovation Flow */
   innovationFlowStateID: Scalars["UUID"]["input"];
   settings?: InputMaybe<UpdateInnovationFlowStateSettingsInput>;
@@ -8725,6 +8940,10 @@ export type UpdateInnovationFlowStateInput = {
 export type UpdateInnovationFlowStateSettingsInput = {
   /** Optional. Sets whether new callouts can be added to this State; omission leaves the stored value unchanged. */
   allowNewCallouts?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Optional. Sets how Post descriptions in this State are displayed in the feed; omission leaves the stored value unchanged. */
+  descriptionDisplayMode?: InputMaybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Sets whether Posts in this State show publish details (publisher, publish date, avatar) in the feed; omission leaves the stored value unchanged. */
+  showPublishDetails?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged. */
   visible?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
@@ -8737,6 +8956,8 @@ export type UpdateInnovationFlowStatesSortOrderInput = {
 
 export type UpdateInnovationHubInput = {
   ID: Scalars["UUID"]["input"];
+  /** The Innovation Packs curated for this Innovation Hub; full replace. An empty list is allowed and hides the section. Omit to leave unchanged. */
+  innovationPackListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** Flag to control the visibility of the InnovationHub in the platform store. */
   listedInStore?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
@@ -8745,10 +8966,12 @@ export type UpdateInnovationHubInput = {
   profileData?: InputMaybe<UpdateProfileInput>;
   /** Visibility of the InnovationHub in searches. */
   searchVisibility?: InputMaybe<SearchVisibility>;
-  /** A list of Spaces to include in this Innovation Hub. Only valid when type 'list' is used. */
+  /** A list of Spaces to include in this Innovation Hub; full replace. An empty list is allowed and hides the Spaces listing. Only valid when type 'list' is used. */
   spaceListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** Spaces with which visibility this Innovation Hub will display. Only valid when type 'visibility' is used. */
   spaceVisibilityFilter?: InputMaybe<SpaceVisibility>;
+  /** The Virtual Contributors curated for this Innovation Hub; full replace. An empty list is allowed and hides the section. Omit to leave unchanged. */
+  virtualContributorListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
 };
 
 export type UpdateInnovationPackInput = {
@@ -9009,6 +9232,8 @@ export type UpdateSpaceSettingsPrivacyInput = {
   /** Flag to control if Platform Support has admin rights. */
   allowPlatformSupportAsAdmin?: InputMaybe<Scalars["Boolean"]["input"]>;
   mode?: InputMaybe<SpacePrivacyMode>;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. */
+  userInformationVisibility?: InputMaybe<UserInformationVisibility>;
 };
 
 export type UpdateSubspacePinnedInput = {
@@ -9139,6 +9364,8 @@ export type UpdateUserSettingsNotificationInput = {
   organization?: InputMaybe<UpdateUserSettingsNotificationOrganizationInput>;
   /** Settings related to Platform Notifications. */
   platform?: InputMaybe<UpdateUserSettingsNotificationPlatformInput>;
+  /** Settings related to notification sound playback. */
+  sound?: InputMaybe<UpdateUserSettingsNotificationSoundInput>;
   /** Settings related to Space Notifications. */
   space?: InputMaybe<UpdateUserSettingsNotificationSpaceInput>;
   /** Settings related to User Notifications. */
@@ -9174,6 +9401,13 @@ export type UpdateUserSettingsNotificationPlatformInput = {
   forumDiscussionComment?: InputMaybe<NotificationSettingInput>;
   /** Receive a notification when a new Discussion is created in the Forum */
   forumDiscussionCreated?: InputMaybe<NotificationSettingInput>;
+};
+
+export type UpdateUserSettingsNotificationSoundInput = {
+  /** Play a sound when a chat message is received. Default true. */
+  chatMessage?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Play a sound when a non-chat in-app notification is received. Default true. */
+  inAppNotification?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type UpdateUserSettingsNotificationSpaceAdminInput = {
@@ -9585,6 +9819,12 @@ export type UserGroup = {
   updatedDate: Scalars["DateTime"]["output"];
 };
 
+/** Controls who may read member-user information in a Space. Follows space visibility by default, or restricts user info to members only. */
+export enum UserInformationVisibility {
+  FollowSpaceVisibility = "FOLLOW_SPACE_VISIBILITY",
+  MembersOnly = "MEMBERS_ONLY",
+}
+
 /** Minimal user-profile summary identifying a user without exposing PII beyond id + displayName. */
 export type UserProfileSummary = {
   displayName: Scalars["String"]["output"];
@@ -9638,6 +9878,8 @@ export type UserSettingsNotification = {
   organization: UserSettingsNotificationOrganization;
   /** The notifications settings for Platform events for this User */
   platform: UserSettingsNotificationPlatform;
+  /** The sound playback settings for this User. */
+  sound: UserSettingsNotificationSound;
   /** The notifications settings for Space events for this User */
   space: UserSettingsNotificationSpace;
   /** The notifications settings for User events for this User */
@@ -9682,6 +9924,13 @@ export type UserSettingsNotificationPlatformAdmin = {
   userProfileCreated: UserSettingsNotificationChannels;
   /** Receive a notification when a user profile is removed */
   userProfileRemoved: UserSettingsNotificationChannels;
+};
+
+export type UserSettingsNotificationSound = {
+  /** Play a sound when a chat message is received. Default true. */
+  chatMessage: Scalars["Boolean"]["output"];
+  /** Play a sound when a non-chat in-app notification is received. Default true. */
+  inAppNotification: Scalars["Boolean"]["output"];
 };
 
 export type UserSettingsNotificationSpace = {
@@ -10198,36 +10447,68 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
         })
       | (Omit<
           ActivityLogEntryCalloutDiscussionComment,
-          "space" | "triggeredBy"
-        > & { space?: Maybe<_RefType["Space"]>; triggeredBy: _RefType["User"] })
-      | (Omit<ActivityLogEntryCalloutLinkCreated, "space" | "triggeredBy"> & {
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
           space?: Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
-      | (Omit<ActivityLogEntryCalloutMemoCreated, "space" | "triggeredBy"> & {
+      | (Omit<
+          ActivityLogEntryCalloutLinkCreated,
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
           space?: Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
-      | (Omit<ActivityLogEntryCalloutPostComment, "space" | "triggeredBy"> & {
+      | (Omit<
+          ActivityLogEntryCalloutMemoCreated,
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
           space?: Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
-      | (Omit<ActivityLogEntryCalloutPostCreated, "space" | "triggeredBy"> & {
+      | (Omit<
+          ActivityLogEntryCalloutPostComment,
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
           space?: Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
-      | (Omit<ActivityLogEntryCalloutPublished, "space" | "triggeredBy"> & {
+      | (Omit<
+          ActivityLogEntryCalloutPostCreated,
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
+          space?: Maybe<_RefType["Space"]>;
+          triggeredBy: _RefType["User"];
+        })
+      | (Omit<
+          ActivityLogEntryCalloutPublished,
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
           space?: Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           ActivityLogEntryCalloutWhiteboardContentModified,
-          "space" | "triggeredBy"
-        > & { space?: Maybe<_RefType["Space"]>; triggeredBy: _RefType["User"] })
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
+          space?: Maybe<_RefType["Space"]>;
+          triggeredBy: _RefType["User"];
+        })
       | (Omit<
           ActivityLogEntryCalloutWhiteboardCreated,
-          "space" | "triggeredBy"
-        > & { space?: Maybe<_RefType["Space"]>; triggeredBy: _RefType["User"] })
+          "callout" | "space" | "triggeredBy"
+        > & {
+          callout: _RefType["Callout"];
+          space?: Maybe<_RefType["Space"]>;
+          triggeredBy: _RefType["User"];
+        })
       | (Omit<
           ActivityLogEntryMemberJoined,
           "actor" | "community" | "space" | "triggeredBy"
@@ -10300,7 +10581,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           | "profile"
           | "subspaceByNameID"
           | "subspaces"
-          | "templatesManager"
         > & {
           about: _RefType["SpaceAbout"];
           account: _RefType["Account"];
@@ -10312,7 +10592,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           profile?: Maybe<_RefType["Profile"]>;
           subspaceByNameID: _RefType["Space"];
           subspaces: Array<_RefType["Space"]>;
-          templatesManager?: Maybe<_RefType["TemplatesManager"]>;
         })
       | (Omit<
           Space,
@@ -10326,7 +10605,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           | "profile"
           | "subspaceByNameID"
           | "subspaces"
-          | "templatesManager"
         > & {
           about: _RefType["SpaceAbout"];
           account: _RefType["Account"];
@@ -10338,7 +10616,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           profile?: Maybe<_RefType["Profile"]>;
           subspaceByNameID: _RefType["Space"];
           subspaces: Array<_RefType["Space"]>;
-          templatesManager?: Maybe<_RefType["TemplatesManager"]>;
         })
       | (Omit<User, "account" | "actor" | "credentials" | "profile"> & {
           account?: Maybe<_RefType["Account"]>;
@@ -10412,20 +10689,22 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
       | (Omit<InAppNotificationPayloadSpace, "space"> & {
           space: _RefType["Space"];
         })
-      | (Omit<InAppNotificationPayloadSpaceCollaborationCallout, "space"> & {
-          space: _RefType["Space"];
-        })
+      | (Omit<
+          InAppNotificationPayloadSpaceCollaborationCallout,
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           InAppNotificationPayloadSpaceCollaborationCalloutComment,
-          "space"
-        > & { space: _RefType["Space"] })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-          "space"
-        > & { space: _RefType["Space"] })
-      | (Omit<InAppNotificationPayloadSpaceCollaborationPoll, "space"> & {
-          space: _RefType["Space"];
-        })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
+      | (Omit<
+          InAppNotificationPayloadSpaceCollaborationPoll,
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           InAppNotificationPayloadSpaceCommunicationMessageDirect,
           "space"
@@ -10468,18 +10747,34 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           space: _RefType["Space"];
         });
     SearchResult:
-      | (Omit<SearchResultCallout, "space"> & { space: _RefType["Space"] })
-      | (Omit<SearchResultMemo, "space"> & { space: _RefType["Space"] })
+      | (Omit<SearchResultCallout, "callout" | "space"> & {
+          callout: _RefType["Callout"];
+          space: _RefType["Space"];
+        })
+      | (Omit<SearchResultCollaboraDocument, "callout" | "space"> & {
+          callout: _RefType["Callout"];
+          space: _RefType["Space"];
+        })
+      | (Omit<SearchResultMemo, "callout" | "space"> & {
+          callout: _RefType["Callout"];
+          space: _RefType["Space"];
+        })
       | (Omit<SearchResultOrganization, "organization"> & {
           organization: _RefType["Organization"];
         })
-      | (Omit<SearchResultPost, "space"> & { space: _RefType["Space"] })
+      | (Omit<SearchResultPost, "callout" | "space"> & {
+          callout: _RefType["Callout"];
+          space: _RefType["Space"];
+        })
       | (Omit<SearchResultSpace, "parentSpace" | "space"> & {
           parentSpace?: Maybe<_RefType["Space"]>;
           space: _RefType["Space"];
         })
       | (Omit<SearchResultUser, "user"> & { user: _RefType["User"] })
-      | (Omit<SearchResultWhiteboard, "space"> & { space: _RefType["Space"] });
+      | (Omit<SearchResultWhiteboard, "callout" | "space"> & {
+          callout: _RefType["Callout"];
+          space: _RefType["Space"];
+        });
   };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -10542,37 +10837,61 @@ export type ResolversTypes = {
     }
   >;
   ActivityLogEntryCalloutDiscussionComment: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutDiscussionComment, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutDiscussionComment,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutLinkCreated: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutLinkCreated, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutLinkCreated,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutMemoCreated: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutMemoCreated, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutMemoCreated,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutPostComment: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutPostComment, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutPostComment,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutPostCreated: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutPostCreated, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutPostCreated,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutPublished: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutPublished, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutPublished,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10580,14 +10899,19 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutWhiteboardContentModified: ResolverTypeWrapper<
     Omit<
       ActivityLogEntryCalloutWhiteboardContentModified,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
   >;
   ActivityLogEntryCalloutWhiteboardCreated: ResolverTypeWrapper<
-    Omit<ActivityLogEntryCalloutWhiteboardCreated, "space" | "triggeredBy"> & {
+    Omit<
+      ActivityLogEntryCalloutWhiteboardCreated,
+      "callout" | "space" | "triggeredBy"
+    > & {
+      callout: ResolversTypes["Callout"];
       space?: Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10691,8 +11015,13 @@ export type ResolversTypes = {
   >;
   CalendarEventType: CalendarEventType;
   Callout: ResolverTypeWrapper<
-    Omit<Callout, "createdBy" | "publishedBy"> & {
+    Omit<
+      Callout,
+      "contributionDefaults" | "createdBy" | "framing" | "publishedBy"
+    > & {
+      contributionDefaults: ResolversTypes["CalloutContributionDefaults"];
       createdBy?: Maybe<ResolversTypes["User"]>;
+      framing: ResolversTypes["CalloutFraming"];
       publishedBy?: Maybe<ResolversTypes["User"]>;
     }
   >;
@@ -10705,17 +11034,28 @@ export type ResolversTypes = {
   CalloutContributionDefaults: ResolverTypeWrapper<CalloutContributionDefaults>;
   CalloutContributionType: CalloutContributionType;
   CalloutContributionsCountOutput: ResolverTypeWrapper<CalloutContributionsCountOutput>;
+  CalloutContributorsSettings: ResolverTypeWrapper<CalloutContributorsSettings>;
   CalloutDescriptionDisplayMode: CalloutDescriptionDisplayMode;
   CalloutFraming: ResolverTypeWrapper<
-    Omit<CalloutFraming, "profile"> & { profile: ResolversTypes["Profile"] }
+    Omit<CalloutFraming, "contributorCounts" | "profile" | "subspaces"> & {
+      contributorCounts: ResolversTypes["ContributorCollectionCounts"];
+      profile: ResolversTypes["Profile"];
+      subspaces: Array<ResolversTypes["Space"]>;
+    }
   >;
   CalloutFramingType: CalloutFramingType;
   CalloutPostCreated: ResolverTypeWrapper<CalloutPostCreated>;
+  CalloutSelectionMode: CalloutSelectionMode;
+  CalloutSelectionSettings: ResolverTypeWrapper<CalloutSelectionSettings>;
   CalloutSettings: ResolverTypeWrapper<CalloutSettings>;
   CalloutSettingsContribution: ResolverTypeWrapper<CalloutSettingsContribution>;
   CalloutSettingsFraming: ResolverTypeWrapper<CalloutSettingsFraming>;
   CalloutVisibility: CalloutVisibility;
-  CalloutsSet: ResolverTypeWrapper<CalloutsSet>;
+  CalloutsSet: ResolverTypeWrapper<
+    Omit<CalloutsSet, "callouts"> & {
+      callouts: Array<ResolversTypes["Callout"]>;
+    }
+  >;
   CalloutsSetType: CalloutsSetType;
   CastPollVoteInput: CastPollVoteInput;
   Classification: ResolverTypeWrapper<Classification>;
@@ -10728,10 +11068,7 @@ export type ResolversTypes = {
   CollaboraDocumentType: CollaboraDocumentType;
   CollaboraEditorUrlResult: ResolverTypeWrapper<CollaboraEditorUrlResult>;
   Collaboration: ResolverTypeWrapper<
-    Omit<Collaboration, "innovationFlow" | "timeline"> & {
-      innovationFlow: ResolversTypes["InnovationFlow"];
-      timeline: ResolversTypes["Timeline"];
-    }
+    Omit<Collaboration, "timeline"> & { timeline: ResolversTypes["Timeline"] }
   >;
   Communication: ResolverTypeWrapper<Communication>;
   CommunicationAdminEnsureAccessInput: CommunicationAdminEnsureAccessInput;
@@ -10790,7 +11127,11 @@ export type ResolversTypes = {
   >;
   ContentUpdatePolicy: ContentUpdatePolicy;
   ContributionsFilterInput: ContributionsFilterInput;
+  ContributorCollectionCounts: ResolverTypeWrapper<ContributorCollectionCounts>;
+  ContributorCollectionItem: ResolverTypeWrapper<ContributorCollectionItem>;
+  ContributorCollectionView: ContributorCollectionView;
   ContributorFilterInput: ContributorFilterInput;
+  ContributorLocation: ResolverTypeWrapper<ContributorLocation>;
   Conversation: ResolverTypeWrapper<
     Omit<Conversation, "members"> & { members: Array<ResolversTypes["Actor"]> }
   >;
@@ -10846,11 +11187,15 @@ export type ResolversTypes = {
   CreateCalloutContributionDefaultsData: ResolverTypeWrapper<CreateCalloutContributionDefaultsData>;
   CreateCalloutContributionDefaultsInput: CreateCalloutContributionDefaultsInput;
   CreateCalloutContributionInput: CreateCalloutContributionInput;
+  CreateCalloutContributorsSettingsData: ResolverTypeWrapper<CreateCalloutContributorsSettingsData>;
+  CreateCalloutContributorsSettingsInput: CreateCalloutContributorsSettingsInput;
   CreateCalloutData: ResolverTypeWrapper<CreateCalloutData>;
   CreateCalloutFramingData: ResolverTypeWrapper<CreateCalloutFramingData>;
   CreateCalloutFramingInput: CreateCalloutFramingInput;
   CreateCalloutInput: CreateCalloutInput;
   CreateCalloutOnCalloutsSetInput: CreateCalloutOnCalloutsSetInput;
+  CreateCalloutSelectionSettingsData: ResolverTypeWrapper<CreateCalloutSelectionSettingsData>;
+  CreateCalloutSelectionSettingsInput: CreateCalloutSelectionSettingsInput;
   CreateCalloutSettingsContributionData: ResolverTypeWrapper<CreateCalloutSettingsContributionData>;
   CreateCalloutSettingsContributionInput: CreateCalloutSettingsContributionInput;
   CreateCalloutSettingsData: ResolverTypeWrapper<CreateCalloutSettingsData>;
@@ -10995,6 +11340,7 @@ export type ResolversTypes = {
   Groupable: ResolverTypeWrapper<
     ResolversInterfaceTypes<ResolversTypes>["Groupable"]
   >;
+  ID: ResolverTypeWrapper<Scalars["ID"]["output"]>;
   ISearchCategoryResult: ResolverTypeWrapper<
     Omit<ISearchCategoryResult, "results"> & {
       results: Array<ResolversTypes["SearchResult"]>;
@@ -11057,25 +11403,28 @@ export type ResolversTypes = {
     }
   >;
   InAppNotificationPayloadSpaceCollaborationCallout: ResolverTypeWrapper<
-    Omit<InAppNotificationPayloadSpaceCollaborationCallout, "space"> & {
-      space: ResolversTypes["Space"];
-    }
+    Omit<
+      InAppNotificationPayloadSpaceCollaborationCallout,
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationCalloutComment: ResolverTypeWrapper<
-    Omit<InAppNotificationPayloadSpaceCollaborationCalloutComment, "space"> & {
-      space: ResolversTypes["Space"];
-    }
+    Omit<
+      InAppNotificationPayloadSpaceCollaborationCalloutComment,
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationCalloutPostComment: ResolverTypeWrapper<
     Omit<
       InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-      "space"
-    > & { space: ResolversTypes["Space"] }
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationPoll: ResolverTypeWrapper<
-    Omit<InAppNotificationPayloadSpaceCollaborationPoll, "space"> & {
-      space: ResolversTypes["Space"];
-    }
+    Omit<
+      InAppNotificationPayloadSpaceCollaborationPoll,
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCommunicationMessageDirect: ResolverTypeWrapper<
     Omit<InAppNotificationPayloadSpaceCommunicationMessageDirect, "space"> & {
@@ -11137,11 +11486,7 @@ export type ResolversTypes = {
     }
   >;
   InnovationFlow: ResolverTypeWrapper<
-    Omit<InnovationFlow, "currentState" | "profile" | "states"> & {
-      currentState?: Maybe<ResolversTypes["InnovationFlowState"]>;
-      profile: ResolversTypes["Profile"];
-      states: Array<ResolversTypes["InnovationFlowState"]>;
-    }
+    Omit<InnovationFlow, "profile"> & { profile: ResolversTypes["Profile"] }
   >;
   InnovationFlowSettings: ResolverTypeWrapper<InnovationFlowSettings>;
   InnovationFlowState: ResolverTypeWrapper<
@@ -11153,9 +11498,14 @@ export type ResolversTypes = {
   InnovationHub: ResolverTypeWrapper<
     Omit<
       InnovationHub,
-      "account" | "profile" | "provider" | "spaceListFilter"
+      | "account"
+      | "innovationPackListFilter"
+      | "profile"
+      | "provider"
+      | "spaceListFilter"
     > & {
       account: ResolversTypes["Account"];
+      innovationPackListFilter?: Maybe<Array<ResolversTypes["InnovationPack"]>>;
       profile: ResolversTypes["Profile"];
       provider: ResolversTypes["Actor"];
       spaceListFilter?: Maybe<Array<ResolversTypes["Space"]>>;
@@ -11240,12 +11590,12 @@ export type ResolversTypes = {
       | "account"
       | "calendar"
       | "calendarEvent"
+      | "callout"
       | "collaboration"
       | "community"
       | "communityGuidelines"
       | "conversation"
       | "document"
-      | "innovationFlow"
       | "innovationHub"
       | "innovationPack"
       | "invitation"
@@ -11256,7 +11606,6 @@ export type ResolversTypes = {
       | "storageBucket"
       | "template"
       | "templateContentSpace"
-      | "templatesManager"
       | "templatesSet"
       | "user"
     > & {
@@ -11264,12 +11613,12 @@ export type ResolversTypes = {
       account?: Maybe<ResolversTypes["Account"]>;
       calendar?: Maybe<ResolversTypes["Calendar"]>;
       calendarEvent?: Maybe<ResolversTypes["CalendarEvent"]>;
+      callout?: Maybe<ResolversTypes["Callout"]>;
       collaboration?: Maybe<ResolversTypes["Collaboration"]>;
       community?: Maybe<ResolversTypes["Community"]>;
       communityGuidelines?: Maybe<ResolversTypes["CommunityGuidelines"]>;
       conversation?: Maybe<ResolversTypes["Conversation"]>;
       document?: Maybe<ResolversTypes["Document"]>;
-      innovationFlow?: Maybe<ResolversTypes["InnovationFlow"]>;
       innovationHub?: Maybe<ResolversTypes["InnovationHub"]>;
       innovationPack?: Maybe<ResolversTypes["InnovationPack"]>;
       invitation?: Maybe<ResolversTypes["Invitation"]>;
@@ -11280,7 +11629,6 @@ export type ResolversTypes = {
       storageBucket?: Maybe<ResolversTypes["StorageBucket"]>;
       template?: Maybe<ResolversTypes["Template"]>;
       templateContentSpace?: Maybe<ResolversTypes["TemplateContentSpace"]>;
-      templatesManager?: Maybe<ResolversTypes["TemplatesManager"]>;
       templatesSet?: Maybe<ResolversTypes["TemplatesSet"]>;
       user?: Maybe<ResolversTypes["User"]>;
     }
@@ -11344,6 +11692,7 @@ export type ResolversTypes = {
   MoveCalloutContributionInput: MoveCalloutContributionInput;
   MoveSpaceL1ToSpaceL0Input: MoveSpaceL1ToSpaceL0Input;
   MoveSpaceL1ToSpaceL2Input: MoveSpaceL1ToSpaceL2Input;
+  MoveSpaceL2ToSpaceL1Input: MoveSpaceL2ToSpaceL1Input;
   Mutation: ResolverTypeWrapper<{}>;
   MutationType: MutationType;
   MySpaceResults: ResolverTypeWrapper<
@@ -11439,19 +11788,13 @@ export type ResolversTypes = {
   Platform: ResolverTypeWrapper<
     Omit<
       Platform,
-      | "configuration"
-      | "forum"
-      | "innovationHub"
-      | "library"
-      | "roleSet"
-      | "templatesManager"
+      "configuration" | "forum" | "innovationHub" | "library" | "roleSet"
     > & {
       configuration: ResolversTypes["Config"];
       forum: ResolversTypes["Forum"];
       innovationHub?: Maybe<ResolversTypes["InnovationHub"]>;
       library: ResolversTypes["Library"];
       roleSet: ResolversTypes["RoleSet"];
-      templatesManager?: Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   PlatformAccessRole: ResolverTypeWrapper<PlatformAccessRole>;
@@ -11555,7 +11898,6 @@ export type ResolversTypes = {
       | "profile"
       | "subspaceByNameID"
       | "subspaces"
-      | "templatesManager"
     > & {
       about: ResolversTypes["SpaceAbout"];
       account: ResolversTypes["Account"];
@@ -11567,7 +11909,6 @@ export type ResolversTypes = {
       profile?: Maybe<ResolversTypes["Profile"]>;
       subspaceByNameID: ResolversTypes["Space"];
       subspaces: Array<ResolversTypes["Space"]>;
-      templatesManager?: Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   RelayPaginatedSpaceEdge: ResolverTypeWrapper<
@@ -11585,6 +11926,7 @@ export type ResolversTypes = {
   RemoveRoleOnRoleSetInput: RemoveRoleOnRoleSetInput;
   RemoveUserGroupMemberInput: RemoveUserGroupMemberInput;
   ReorderPollOptionsInput: ReorderPollOptionsInput;
+  ReplaceCollaboraDocumentInput: ReplaceCollaboraDocumentInput;
   RevokeAuthorizationCredentialInput: RevokeAuthorizationCredentialInput;
   RevokeLicensePlanFromAccount: RevokeLicensePlanFromAccount;
   RevokeLicensePlanFromSpace: RevokeLicensePlanFromSpace;
@@ -11641,10 +11983,22 @@ export type ResolversTypes = {
     ResolversInterfaceTypes<ResolversTypes>["SearchResult"]
   >;
   SearchResultCallout: ResolverTypeWrapper<
-    Omit<SearchResultCallout, "space"> & { space: ResolversTypes["Space"] }
+    Omit<SearchResultCallout, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
+  >;
+  SearchResultCollaboraDocument: ResolverTypeWrapper<
+    Omit<SearchResultCollaboraDocument, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
   >;
   SearchResultMemo: ResolverTypeWrapper<
-    Omit<SearchResultMemo, "space"> & { space: ResolversTypes["Space"] }
+    Omit<SearchResultMemo, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
   >;
   SearchResultOrganization: ResolverTypeWrapper<
     Omit<SearchResultOrganization, "organization"> & {
@@ -11652,7 +12006,10 @@ export type ResolversTypes = {
     }
   >;
   SearchResultPost: ResolverTypeWrapper<
-    Omit<SearchResultPost, "space"> & { space: ResolversTypes["Space"] }
+    Omit<SearchResultPost, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
   >;
   SearchResultSpace: ResolverTypeWrapper<
     Omit<SearchResultSpace, "parentSpace" | "space"> & {
@@ -11665,7 +12022,10 @@ export type ResolversTypes = {
     Omit<SearchResultUser, "user"> & { user: ResolversTypes["User"] }
   >;
   SearchResultWhiteboard: ResolverTypeWrapper<
-    Omit<SearchResultWhiteboard, "space"> & { space: ResolversTypes["Space"] }
+    Omit<SearchResultWhiteboard, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
   >;
   SearchVisibility: SearchVisibility;
   SendDirectMessageToUsersInput: SendDirectMessageToUsersInput;
@@ -11686,7 +12046,6 @@ export type ResolversTypes = {
       | "profile"
       | "subspaceByNameID"
       | "subspaces"
-      | "templatesManager"
     > & {
       about: ResolversTypes["SpaceAbout"];
       account: ResolversTypes["Account"];
@@ -11698,7 +12057,6 @@ export type ResolversTypes = {
       profile?: Maybe<ResolversTypes["Profile"]>;
       subspaceByNameID: ResolversTypes["Space"];
       subspaces: Array<ResolversTypes["Space"]>;
-      templatesManager?: Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   SpaceAbout: ResolverTypeWrapper<
@@ -11766,7 +12124,11 @@ export type ResolversTypes = {
   Task: ResolverTypeWrapper<Task>;
   TaskStatus: TaskStatus;
   Template: ResolverTypeWrapper<
-    Omit<Template, "communityGuidelines" | "contentSpace" | "profile"> & {
+    Omit<
+      Template,
+      "callout" | "communityGuidelines" | "contentSpace" | "profile"
+    > & {
+      callout?: Maybe<ResolversTypes["Callout"]>;
       communityGuidelines?: Maybe<ResolversTypes["CommunityGuidelines"]>;
       contentSpace?: Maybe<ResolversTypes["TemplateContentSpace"]>;
       profile: ResolversTypes["Profile"];
@@ -11793,8 +12155,7 @@ export type ResolversTypes = {
   >;
   TemplateType: TemplateType;
   TemplatesManager: ResolverTypeWrapper<
-    Omit<TemplatesManager, "templateDefaults" | "templatesSet"> & {
-      templateDefaults: Array<ResolversTypes["TemplateDefault"]>;
+    Omit<TemplatesManager, "templatesSet"> & {
       templatesSet?: Maybe<ResolversTypes["TemplatesSet"]>;
     }
   >;
@@ -11831,9 +12192,11 @@ export type ResolversTypes = {
   UpdateBaselineLicensePlanOnAccount: UpdateBaselineLicensePlanOnAccount;
   UpdateCalendarEventInput: UpdateCalendarEventInput;
   UpdateCalloutContributionDefaultsInput: UpdateCalloutContributionDefaultsInput;
+  UpdateCalloutContributorsSettingsInput: UpdateCalloutContributorsSettingsInput;
   UpdateCalloutEntityInput: UpdateCalloutEntityInput;
   UpdateCalloutFramingInput: UpdateCalloutFramingInput;
   UpdateCalloutPublishInfoInput: UpdateCalloutPublishInfoInput;
+  UpdateCalloutSelectionSettingsInput: UpdateCalloutSelectionSettingsInput;
   UpdateCalloutSettingsContributionInput: UpdateCalloutSettingsContributionInput;
   UpdateCalloutSettingsFramingInput: UpdateCalloutSettingsFramingInput;
   UpdateCalloutSettingsInput: UpdateCalloutSettingsInput;
@@ -11907,6 +12270,7 @@ export type ResolversTypes = {
   UpdateUserSettingsNotificationOrganizationInput: UpdateUserSettingsNotificationOrganizationInput;
   UpdateUserSettingsNotificationPlatformAdminInput: UpdateUserSettingsNotificationPlatformAdminInput;
   UpdateUserSettingsNotificationPlatformInput: UpdateUserSettingsNotificationPlatformInput;
+  UpdateUserSettingsNotificationSoundInput: UpdateUserSettingsNotificationSoundInput;
   UpdateUserSettingsNotificationSpaceAdminInput: UpdateUserSettingsNotificationSpaceAdminInput;
   UpdateUserSettingsNotificationSpaceInput: UpdateUserSettingsNotificationSpaceInput;
   UpdateUserSettingsNotificationUserInput: UpdateUserSettingsNotificationUserInput;
@@ -11960,6 +12324,7 @@ export type ResolversTypes = {
       profile?: Maybe<ResolversTypes["Profile"]>;
     }
   >;
+  UserInformationVisibility: UserInformationVisibility;
   UserProfileSummary: ResolverTypeWrapper<UserProfileSummary>;
   UserSettings: ResolverTypeWrapper<UserSettings>;
   UserSettingsAssistant: ResolverTypeWrapper<UserSettingsAssistant>;
@@ -11970,6 +12335,7 @@ export type ResolversTypes = {
   UserSettingsNotificationOrganization: ResolverTypeWrapper<UserSettingsNotificationOrganization>;
   UserSettingsNotificationPlatform: ResolverTypeWrapper<UserSettingsNotificationPlatform>;
   UserSettingsNotificationPlatformAdmin: ResolverTypeWrapper<UserSettingsNotificationPlatformAdmin>;
+  UserSettingsNotificationSound: ResolverTypeWrapper<UserSettingsNotificationSound>;
   UserSettingsNotificationSpace: ResolverTypeWrapper<UserSettingsNotificationSpace>;
   UserSettingsNotificationSpaceAdmin: ResolverTypeWrapper<UserSettingsNotificationSpaceAdmin>;
   UserSettingsNotificationUser: ResolverTypeWrapper<UserSettingsNotificationUser>;
@@ -12090,57 +12456,65 @@ export type ResolversParentTypes = {
   };
   ActivityLogEntryCalloutDiscussionComment: Omit<
     ActivityLogEntryCalloutDiscussionComment,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutLinkCreated: Omit<
     ActivityLogEntryCalloutLinkCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutMemoCreated: Omit<
     ActivityLogEntryCalloutMemoCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPostComment: Omit<
     ActivityLogEntryCalloutPostComment,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPostCreated: Omit<
     ActivityLogEntryCalloutPostCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPublished: Omit<
     ActivityLogEntryCalloutPublished,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutWhiteboardContentModified: Omit<
     ActivityLogEntryCalloutWhiteboardContentModified,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutWhiteboardCreated: Omit<
     ActivityLogEntryCalloutWhiteboardCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
@@ -12217,8 +12591,13 @@ export type ResolversParentTypes = {
     profile: ResolversParentTypes["Profile"];
     subspace?: Maybe<ResolversParentTypes["Space"]>;
   };
-  Callout: Omit<Callout, "createdBy" | "publishedBy"> & {
+  Callout: Omit<
+    Callout,
+    "contributionDefaults" | "createdBy" | "framing" | "publishedBy"
+  > & {
+    contributionDefaults: ResolversParentTypes["CalloutContributionDefaults"];
     createdBy?: Maybe<ResolversParentTypes["User"]>;
+    framing: ResolversParentTypes["CalloutFraming"];
     publishedBy?: Maybe<ResolversParentTypes["User"]>;
   };
   CalloutContribution: Omit<CalloutContribution, "createdBy"> & {
@@ -12226,14 +12605,23 @@ export type ResolversParentTypes = {
   };
   CalloutContributionDefaults: CalloutContributionDefaults;
   CalloutContributionsCountOutput: CalloutContributionsCountOutput;
-  CalloutFraming: Omit<CalloutFraming, "profile"> & {
+  CalloutContributorsSettings: CalloutContributorsSettings;
+  CalloutFraming: Omit<
+    CalloutFraming,
+    "contributorCounts" | "profile" | "subspaces"
+  > & {
+    contributorCounts: ResolversParentTypes["ContributorCollectionCounts"];
     profile: ResolversParentTypes["Profile"];
+    subspaces: Array<ResolversParentTypes["Space"]>;
   };
   CalloutPostCreated: CalloutPostCreated;
+  CalloutSelectionSettings: CalloutSelectionSettings;
   CalloutSettings: CalloutSettings;
   CalloutSettingsContribution: CalloutSettingsContribution;
   CalloutSettingsFraming: CalloutSettingsFraming;
-  CalloutsSet: CalloutsSet;
+  CalloutsSet: Omit<CalloutsSet, "callouts"> & {
+    callouts: Array<ResolversParentTypes["Callout"]>;
+  };
   CastPollVoteInput: CastPollVoteInput;
   Classification: Classification;
   CollaboraDocument: Omit<CollaboraDocument, "createdBy" | "profile"> & {
@@ -12241,8 +12629,7 @@ export type ResolversParentTypes = {
     profile: ResolversParentTypes["Profile"];
   };
   CollaboraEditorUrlResult: CollaboraEditorUrlResult;
-  Collaboration: Omit<Collaboration, "innovationFlow" | "timeline"> & {
-    innovationFlow: ResolversParentTypes["InnovationFlow"];
+  Collaboration: Omit<Collaboration, "timeline"> & {
     timeline: ResolversParentTypes["Timeline"];
   };
   Communication: Communication;
@@ -12296,7 +12683,10 @@ export type ResolversParentTypes = {
     authentication: ResolversParentTypes["AuthenticationConfig"];
   };
   ContributionsFilterInput: ContributionsFilterInput;
+  ContributorCollectionCounts: ContributorCollectionCounts;
+  ContributorCollectionItem: ContributorCollectionItem;
   ContributorFilterInput: ContributorFilterInput;
+  ContributorLocation: ContributorLocation;
   Conversation: Omit<Conversation, "members"> & {
     members: Array<ResolversParentTypes["Actor"]>;
   };
@@ -12350,11 +12740,15 @@ export type ResolversParentTypes = {
   CreateCalloutContributionDefaultsData: CreateCalloutContributionDefaultsData;
   CreateCalloutContributionDefaultsInput: CreateCalloutContributionDefaultsInput;
   CreateCalloutContributionInput: CreateCalloutContributionInput;
+  CreateCalloutContributorsSettingsData: CreateCalloutContributorsSettingsData;
+  CreateCalloutContributorsSettingsInput: CreateCalloutContributorsSettingsInput;
   CreateCalloutData: CreateCalloutData;
   CreateCalloutFramingData: CreateCalloutFramingData;
   CreateCalloutFramingInput: CreateCalloutFramingInput;
   CreateCalloutInput: CreateCalloutInput;
   CreateCalloutOnCalloutsSetInput: CreateCalloutOnCalloutsSetInput;
+  CreateCalloutSelectionSettingsData: CreateCalloutSelectionSettingsData;
+  CreateCalloutSelectionSettingsInput: CreateCalloutSelectionSettingsInput;
   CreateCalloutSettingsContributionData: CreateCalloutSettingsContributionData;
   CreateCalloutSettingsContributionInput: CreateCalloutSettingsContributionInput;
   CreateCalloutSettingsData: CreateCalloutSettingsData;
@@ -12493,6 +12887,7 @@ export type ResolversParentTypes = {
   GrantAuthorizationCredentialInput: GrantAuthorizationCredentialInput;
   GrantOrganizationAuthorizationCredentialInput: GrantOrganizationAuthorizationCredentialInput;
   Groupable: ResolversInterfaceTypes<ResolversParentTypes>["Groupable"];
+  ID: Scalars["ID"]["output"];
   ISearchCategoryResult: Omit<ISearchCategoryResult, "results"> & {
     results: Array<ResolversParentTypes["SearchResult"]>;
   };
@@ -12545,20 +12940,32 @@ export type ResolversParentTypes = {
   > & { space: ResolversParentTypes["Space"] };
   InAppNotificationPayloadSpaceCollaborationCallout: Omit<
     InAppNotificationPayloadSpaceCollaborationCallout,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationCalloutComment: Omit<
     InAppNotificationPayloadSpaceCollaborationCalloutComment,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationCalloutPostComment: Omit<
     InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationPoll: Omit<
     InAppNotificationPayloadSpaceCollaborationPoll,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCommunicationMessageDirect: Omit<
     InAppNotificationPayloadSpaceCommunicationMessageDirect,
     "space"
@@ -12608,13 +13015,8 @@ export type ResolversParentTypes = {
     InAppNotificationPayloadVirtualContributor,
     "space"
   > & { space: ResolversParentTypes["Space"] };
-  InnovationFlow: Omit<
-    InnovationFlow,
-    "currentState" | "profile" | "states"
-  > & {
-    currentState?: Maybe<ResolversParentTypes["InnovationFlowState"]>;
+  InnovationFlow: Omit<InnovationFlow, "profile"> & {
     profile: ResolversParentTypes["Profile"];
-    states: Array<ResolversParentTypes["InnovationFlowState"]>;
   };
   InnovationFlowSettings: InnovationFlowSettings;
   InnovationFlowState: Omit<InnovationFlowState, "defaultCalloutTemplate"> & {
@@ -12623,9 +13025,16 @@ export type ResolversParentTypes = {
   InnovationFlowStateSettings: InnovationFlowStateSettings;
   InnovationHub: Omit<
     InnovationHub,
-    "account" | "profile" | "provider" | "spaceListFilter"
+    | "account"
+    | "innovationPackListFilter"
+    | "profile"
+    | "provider"
+    | "spaceListFilter"
   > & {
     account: ResolversParentTypes["Account"];
+    innovationPackListFilter?: Maybe<
+      Array<ResolversParentTypes["InnovationPack"]>
+    >;
     profile: ResolversParentTypes["Profile"];
     provider: ResolversParentTypes["Actor"];
     spaceListFilter?: Maybe<Array<ResolversParentTypes["Space"]>>;
@@ -12692,12 +13101,12 @@ export type ResolversParentTypes = {
     | "account"
     | "calendar"
     | "calendarEvent"
+    | "callout"
     | "collaboration"
     | "community"
     | "communityGuidelines"
     | "conversation"
     | "document"
-    | "innovationFlow"
     | "innovationHub"
     | "innovationPack"
     | "invitation"
@@ -12708,7 +13117,6 @@ export type ResolversParentTypes = {
     | "storageBucket"
     | "template"
     | "templateContentSpace"
-    | "templatesManager"
     | "templatesSet"
     | "user"
   > & {
@@ -12716,12 +13124,12 @@ export type ResolversParentTypes = {
     account?: Maybe<ResolversParentTypes["Account"]>;
     calendar?: Maybe<ResolversParentTypes["Calendar"]>;
     calendarEvent?: Maybe<ResolversParentTypes["CalendarEvent"]>;
+    callout?: Maybe<ResolversParentTypes["Callout"]>;
     collaboration?: Maybe<ResolversParentTypes["Collaboration"]>;
     community?: Maybe<ResolversParentTypes["Community"]>;
     communityGuidelines?: Maybe<ResolversParentTypes["CommunityGuidelines"]>;
     conversation?: Maybe<ResolversParentTypes["Conversation"]>;
     document?: Maybe<ResolversParentTypes["Document"]>;
-    innovationFlow?: Maybe<ResolversParentTypes["InnovationFlow"]>;
     innovationHub?: Maybe<ResolversParentTypes["InnovationHub"]>;
     innovationPack?: Maybe<ResolversParentTypes["InnovationPack"]>;
     invitation?: Maybe<ResolversParentTypes["Invitation"]>;
@@ -12732,7 +13140,6 @@ export type ResolversParentTypes = {
     storageBucket?: Maybe<ResolversParentTypes["StorageBucket"]>;
     template?: Maybe<ResolversParentTypes["Template"]>;
     templateContentSpace?: Maybe<ResolversParentTypes["TemplateContentSpace"]>;
-    templatesManager?: Maybe<ResolversParentTypes["TemplatesManager"]>;
     templatesSet?: Maybe<ResolversParentTypes["TemplatesSet"]>;
     user?: Maybe<ResolversParentTypes["User"]>;
   };
@@ -12790,6 +13197,7 @@ export type ResolversParentTypes = {
   MoveCalloutContributionInput: MoveCalloutContributionInput;
   MoveSpaceL1ToSpaceL0Input: MoveSpaceL1ToSpaceL0Input;
   MoveSpaceL1ToSpaceL2Input: MoveSpaceL1ToSpaceL2Input;
+  MoveSpaceL2ToSpaceL1Input: MoveSpaceL2ToSpaceL1Input;
   Mutation: {};
   MySpaceResults: Omit<MySpaceResults, "latestActivity" | "space"> & {
     latestActivity?: Maybe<ResolversParentTypes["ActivityLogEntry"]>;
@@ -12865,19 +13273,13 @@ export type ResolversParentTypes = {
   PaginatedVirtualContributor: PaginatedVirtualContributor;
   Platform: Omit<
     Platform,
-    | "configuration"
-    | "forum"
-    | "innovationHub"
-    | "library"
-    | "roleSet"
-    | "templatesManager"
+    "configuration" | "forum" | "innovationHub" | "library" | "roleSet"
   > & {
     configuration: ResolversParentTypes["Config"];
     forum: ResolversParentTypes["Forum"];
     innovationHub?: Maybe<ResolversParentTypes["InnovationHub"]>;
     library: ResolversParentTypes["Library"];
     roleSet: ResolversParentTypes["RoleSet"];
-    templatesManager?: Maybe<ResolversParentTypes["TemplatesManager"]>;
   };
   PlatformAccessRole: PlatformAccessRole;
   PlatformAdminCommunicationQueryResults: PlatformAdminCommunicationQueryResults;
@@ -12962,7 +13364,6 @@ export type ResolversParentTypes = {
     | "profile"
     | "subspaceByNameID"
     | "subspaces"
-    | "templatesManager"
   > & {
     about: ResolversParentTypes["SpaceAbout"];
     account: ResolversParentTypes["Account"];
@@ -12974,7 +13375,6 @@ export type ResolversParentTypes = {
     profile?: Maybe<ResolversParentTypes["Profile"]>;
     subspaceByNameID: ResolversParentTypes["Space"];
     subspaces: Array<ResolversParentTypes["Space"]>;
-    templatesManager?: Maybe<ResolversParentTypes["TemplatesManager"]>;
   };
   RelayPaginatedSpaceEdge: Omit<RelayPaginatedSpaceEdge, "node"> & {
     node: ResolversParentTypes["RelayPaginatedSpace"];
@@ -12989,6 +13389,7 @@ export type ResolversParentTypes = {
   RemoveRoleOnRoleSetInput: RemoveRoleOnRoleSetInput;
   RemoveUserGroupMemberInput: RemoveUserGroupMemberInput;
   ReorderPollOptionsInput: ReorderPollOptionsInput;
+  ReplaceCollaboraDocumentInput: ReplaceCollaboraDocumentInput;
   RevokeAuthorizationCredentialInput: RevokeAuthorizationCredentialInput;
   RevokeLicensePlanFromAccount: RevokeLicensePlanFromAccount;
   RevokeLicensePlanFromSpace: RevokeLicensePlanFromSpace;
@@ -13032,16 +13433,26 @@ export type ResolversParentTypes = {
   SearchFilterInput: SearchFilterInput;
   SearchInput: SearchInput;
   SearchResult: ResolversInterfaceTypes<ResolversParentTypes>["SearchResult"];
-  SearchResultCallout: Omit<SearchResultCallout, "space"> & {
+  SearchResultCallout: Omit<SearchResultCallout, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
-  SearchResultMemo: Omit<SearchResultMemo, "space"> & {
+  SearchResultCollaboraDocument: Omit<
+    SearchResultCollaboraDocument,
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
+  SearchResultMemo: Omit<SearchResultMemo, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SearchResultOrganization: Omit<SearchResultOrganization, "organization"> & {
     organization: ResolversParentTypes["Organization"];
   };
-  SearchResultPost: Omit<SearchResultPost, "space"> & {
+  SearchResultPost: Omit<SearchResultPost, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SearchResultSpace: Omit<SearchResultSpace, "parentSpace" | "space"> & {
@@ -13051,7 +13462,8 @@ export type ResolversParentTypes = {
   SearchResultUser: Omit<SearchResultUser, "user"> & {
     user: ResolversParentTypes["User"];
   };
-  SearchResultWhiteboard: Omit<SearchResultWhiteboard, "space"> & {
+  SearchResultWhiteboard: Omit<SearchResultWhiteboard, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SendDirectMessageToUsersInput: SendDirectMessageToUsersInput;
@@ -13071,7 +13483,6 @@ export type ResolversParentTypes = {
     | "profile"
     | "subspaceByNameID"
     | "subspaces"
-    | "templatesManager"
   > & {
     about: ResolversParentTypes["SpaceAbout"];
     account: ResolversParentTypes["Account"];
@@ -13083,7 +13494,6 @@ export type ResolversParentTypes = {
     profile?: Maybe<ResolversParentTypes["Profile"]>;
     subspaceByNameID: ResolversParentTypes["Space"];
     subspaces: Array<ResolversParentTypes["Space"]>;
-    templatesManager?: Maybe<ResolversParentTypes["TemplatesManager"]>;
   };
   SpaceAbout: Omit<
     SpaceAbout,
@@ -13145,8 +13555,9 @@ export type ResolversParentTypes = {
   Task: Task;
   Template: Omit<
     Template,
-    "communityGuidelines" | "contentSpace" | "profile"
+    "callout" | "communityGuidelines" | "contentSpace" | "profile"
   > & {
+    callout?: Maybe<ResolversParentTypes["Callout"]>;
     communityGuidelines?: Maybe<ResolversParentTypes["CommunityGuidelines"]>;
     contentSpace?: Maybe<ResolversParentTypes["TemplateContentSpace"]>;
     profile: ResolversParentTypes["Profile"];
@@ -13166,11 +13577,7 @@ export type ResolversParentTypes = {
     innovationPack: ResolversParentTypes["InnovationPack"];
     template: ResolversParentTypes["Template"];
   };
-  TemplatesManager: Omit<
-    TemplatesManager,
-    "templateDefaults" | "templatesSet"
-  > & {
-    templateDefaults: Array<ResolversParentTypes["TemplateDefault"]>;
+  TemplatesManager: Omit<TemplatesManager, "templatesSet"> & {
     templatesSet?: Maybe<ResolversParentTypes["TemplatesSet"]>;
   };
   TemplatesSet: Omit<
@@ -13204,9 +13611,11 @@ export type ResolversParentTypes = {
   UpdateBaselineLicensePlanOnAccount: UpdateBaselineLicensePlanOnAccount;
   UpdateCalendarEventInput: UpdateCalendarEventInput;
   UpdateCalloutContributionDefaultsInput: UpdateCalloutContributionDefaultsInput;
+  UpdateCalloutContributorsSettingsInput: UpdateCalloutContributorsSettingsInput;
   UpdateCalloutEntityInput: UpdateCalloutEntityInput;
   UpdateCalloutFramingInput: UpdateCalloutFramingInput;
   UpdateCalloutPublishInfoInput: UpdateCalloutPublishInfoInput;
+  UpdateCalloutSelectionSettingsInput: UpdateCalloutSelectionSettingsInput;
   UpdateCalloutSettingsContributionInput: UpdateCalloutSettingsContributionInput;
   UpdateCalloutSettingsFramingInput: UpdateCalloutSettingsFramingInput;
   UpdateCalloutSettingsInput: UpdateCalloutSettingsInput;
@@ -13280,6 +13689,7 @@ export type ResolversParentTypes = {
   UpdateUserSettingsNotificationOrganizationInput: UpdateUserSettingsNotificationOrganizationInput;
   UpdateUserSettingsNotificationPlatformAdminInput: UpdateUserSettingsNotificationPlatformAdminInput;
   UpdateUserSettingsNotificationPlatformInput: UpdateUserSettingsNotificationPlatformInput;
+  UpdateUserSettingsNotificationSoundInput: UpdateUserSettingsNotificationSoundInput;
   UpdateUserSettingsNotificationSpaceAdminInput: UpdateUserSettingsNotificationSpaceAdminInput;
   UpdateUserSettingsNotificationSpaceInput: UpdateUserSettingsNotificationSpaceInput;
   UpdateUserSettingsNotificationUserInput: UpdateUserSettingsNotificationUserInput;
@@ -13335,6 +13745,7 @@ export type ResolversParentTypes = {
   UserSettingsNotificationOrganization: UserSettingsNotificationOrganization;
   UserSettingsNotificationPlatform: UserSettingsNotificationPlatform;
   UserSettingsNotificationPlatformAdmin: UserSettingsNotificationPlatformAdmin;
+  UserSettingsNotificationSound: UserSettingsNotificationSound;
   UserSettingsNotificationSpace: UserSettingsNotificationSpace;
   UserSettingsNotificationSpaceAdmin: UserSettingsNotificationSpaceAdmin;
   UserSettingsNotificationUser: UserSettingsNotificationUser;
@@ -14356,6 +14767,28 @@ export type CalloutContributionsCountOutputResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CalloutContributorsSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CalloutContributorsSettings"] = ResolversParentTypes["CalloutContributorsSettings"]
+> = {
+  contributorTypes?: Resolver<
+    Array<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultContributorType?: Resolver<
+    ResolversTypes["ActorType"],
+    ParentType,
+    ContextType
+  >;
+  defaultView?: Resolver<
+    ResolversTypes["ContributorCollectionView"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CalloutFramingResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CalloutFraming"] = ResolversParentTypes["CalloutFraming"]
@@ -14370,6 +14803,17 @@ export type CalloutFramingResolvers<
     ParentType,
     ContextType
   >;
+  contributorCounts?: Resolver<
+    ResolversTypes["ContributorCollectionCounts"],
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    Array<ResolversTypes["ContributorCollectionItem"]>,
+    ParentType,
+    ContextType,
+    RequireFields<CalloutFramingContributorsArgs, "type">
+  >;
   createdDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
   link?: Resolver<Maybe<ResolversTypes["Link"]>, ParentType, ContextType>;
@@ -14381,6 +14825,7 @@ export type CalloutFramingResolvers<
   memo?: Resolver<Maybe<ResolversTypes["Memo"]>, ParentType, ContextType>;
   poll?: Resolver<Maybe<ResolversTypes["Poll"]>, ParentType, ContextType>;
   profile?: Resolver<ResolversTypes["Profile"], ParentType, ContextType>;
+  subspaces?: Resolver<Array<ResolversTypes["Space"]>, ParentType, ContextType>;
   type?: Resolver<
     ResolversTypes["CalloutFramingType"],
     ParentType,
@@ -14403,6 +14848,19 @@ export type CalloutPostCreatedResolvers<
   contributionID?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   post?: Resolver<ResolversTypes["Post"], ParentType, ContextType>;
   sortOrder?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CalloutSelectionSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CalloutSelectionSettings"] = ResolversParentTypes["CalloutSelectionSettings"]
+> = {
+  mode?: Resolver<
+    ResolversTypes["CalloutSelectionMode"],
+    ParentType,
+    ContextType
+  >;
+  selectedIds?: Resolver<Array<ResolversTypes["ID"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -14457,6 +14915,16 @@ export type CalloutSettingsFramingResolvers<
 > = {
   commentsEnabled?: Resolver<
     ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    Maybe<ResolversTypes["CalloutContributorsSettings"]>,
+    ParentType,
+    ContextType
+  >;
+  selection?: Resolver<
+    Maybe<ResolversTypes["CalloutSelectionSettings"]>,
     ParentType,
     ContextType
   >;
@@ -14828,6 +15296,62 @@ export type ConfigResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ContributorCollectionCountsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorCollectionCounts"] = ResolversParentTypes["ContributorCollectionCounts"]
+> = {
+  organizations?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  users?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  virtualContributors?: Resolver<
+    ResolversTypes["Int"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ContributorCollectionItemResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorCollectionItem"] = ResolversParentTypes["ContributorCollectionItem"]
+> = {
+  avatarUrl?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  displayName?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  location?: Resolver<
+    Maybe<ResolversTypes["ContributorLocation"]>,
+    ParentType,
+    ContextType
+  >;
+  roleLabel?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  type?: Resolver<ResolversTypes["ActorType"], ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ContributorLocationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorLocation"] = ResolversParentTypes["ContributorLocation"]
+> = {
+  city?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  country?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  hasValidCoordinates?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  latitude?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  longitude?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ConversationResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["Conversation"] = ResolversParentTypes["Conversation"]
@@ -15048,6 +15572,28 @@ export type CreateCalloutContributionDefaultsDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CreateCalloutContributorsSettingsDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CreateCalloutContributorsSettingsData"] = ResolversParentTypes["CreateCalloutContributorsSettingsData"]
+> = {
+  contributorTypes?: Resolver<
+    Array<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultContributorType?: Resolver<
+    Maybe<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultView?: Resolver<
+    Maybe<ResolversTypes["ContributorCollectionView"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CreateCalloutDataResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CreateCalloutData"] = ResolversParentTypes["CreateCalloutData"]
@@ -15134,6 +15680,23 @@ export type CreateCalloutFramingDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CreateCalloutSelectionSettingsDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CreateCalloutSelectionSettingsData"] = ResolversParentTypes["CreateCalloutSelectionSettingsData"]
+> = {
+  mode?: Resolver<
+    Maybe<ResolversTypes["CalloutSelectionMode"]>,
+    ParentType,
+    ContextType
+  >;
+  selectedIds?: Resolver<
+    Maybe<Array<ResolversTypes["ID"]>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CreateCalloutSettingsContributionDataResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CreateCalloutSettingsContributionData"] = ResolversParentTypes["CreateCalloutSettingsContributionData"]
@@ -15185,6 +15748,16 @@ export type CreateCalloutSettingsFramingDataResolvers<
 > = {
   commentsEnabled?: Resolver<
     Maybe<ResolversTypes["Boolean"]>,
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    Maybe<ResolversTypes["CreateCalloutContributorsSettingsData"]>,
+    ParentType,
+    ContextType
+  >;
+  selection?: Resolver<
+    Maybe<ResolversTypes["CreateCalloutSelectionSettingsData"]>,
     ParentType,
     ContextType
   >;
@@ -15303,6 +15876,16 @@ export type CreateInnovationFlowStateSettingsDataResolvers<
 > = {
   allowNewCallouts?: Resolver<
     ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  descriptionDisplayMode?: Resolver<
+    Maybe<ResolversTypes["CalloutDescriptionDisplayMode"]>,
+    ParentType,
+    ContextType
+  >;
+  showPublishDetails?: Resolver<
+    Maybe<ResolversTypes["Boolean"]>,
     ParentType,
     ContextType
   >;
@@ -16333,6 +16916,16 @@ export type InnovationFlowStateSettingsResolvers<
     ParentType,
     ContextType
   >;
+  descriptionDisplayMode?: Resolver<
+    ResolversTypes["CalloutDescriptionDisplayMode"],
+    ParentType,
+    ContextType
+  >;
+  showPublishDetails?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
   visible?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -16349,6 +16942,11 @@ export type InnovationHubResolvers<
   >;
   createdDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  innovationPackListFilter?: Resolver<
+    Maybe<Array<ResolversTypes["InnovationPack"]>>,
+    ParentType,
+    ContextType
+  >;
   listedInStore?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   nameID?: Resolver<ResolversTypes["NameID"], ParentType, ContextType>;
   profile?: Resolver<ResolversTypes["Profile"], ParentType, ContextType>;
@@ -16371,6 +16969,11 @@ export type InnovationHubResolvers<
   subdomain?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   type?: Resolver<ResolversTypes["InnovationHubType"], ParentType, ContextType>;
   updatedDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  virtualContributorListFilter?: Resolver<
+    Maybe<Array<ResolversTypes["VirtualContributor"]>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -18320,6 +18923,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationMoveSpaceL1ToSpaceL2Args, "moveData">
   >;
+  moveSpaceL2ToSpaceL1?: Resolver<
+    ResolversTypes["Space"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationMoveSpaceL2ToSpaceL1Args, "moveData">
+  >;
   refreshAllBodiesOfKnowledge?: Resolver<
     ResolversTypes["Boolean"],
     ParentType,
@@ -18435,6 +19044,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationReorderPollOptionsArgs, "optionData">
+  >;
+  replaceCollaboraDocument?: Resolver<
+    ResolversTypes["CollaboraDocument"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationReplaceCollaboraDocumentArgs, "file" | "replaceData">
   >;
   resetConversationVc?: Resolver<
     ResolversTypes["Conversation"],
@@ -20158,6 +20773,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryCollaboraEditorUrlArgs, "collaboraDocumentID">
   >;
+  collaboraServiceAvailable?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType,
+    RequireFields<QueryCollaboraServiceAvailableArgs, "collaboraDocumentID">
+  >;
   exploreSpaces?: Resolver<
     Array<ResolversTypes["Space"]>,
     ParentType,
@@ -20887,6 +21508,7 @@ export type SearchResultResolvers<
 > = {
   __resolveType: TypeResolveFn<
     | "SearchResultCallout"
+    | "SearchResultCollaboraDocument"
     | "SearchResultMemo"
     | "SearchResultOrganization"
     | "SearchResultPost"
@@ -20908,6 +21530,25 @@ export type SearchResultCalloutResolvers<
 > = {
   callout?: Resolver<ResolversTypes["Callout"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  score?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  space?: Resolver<ResolversTypes["Space"], ParentType, ContextType>;
+  terms?: Resolver<Array<ResolversTypes["String"]>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes["SearchResultType"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type SearchResultCollaboraDocumentResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["SearchResultCollaboraDocument"] = ResolversParentTypes["SearchResultCollaboraDocument"]
+> = {
+  callout?: Resolver<ResolversTypes["Callout"], ParentType, ContextType>;
+  collaboraDocument?: Resolver<
+    ResolversTypes["CollaboraDocument"],
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  isContribution?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   score?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   space?: Resolver<ResolversTypes["Space"], ParentType, ContextType>;
   terms?: Resolver<Array<ResolversTypes["String"]>, ParentType, ContextType>;
@@ -21309,6 +21950,11 @@ export type SpaceSettingsPrivacyResolvers<
     ContextType
   >;
   mode?: Resolver<ResolversTypes["SpacePrivacyMode"], ParentType, ContextType>;
+  userInformationVisibility?: Resolver<
+    Maybe<ResolversTypes["UserInformationVisibility"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -22354,6 +23000,11 @@ export type UserSettingsNotificationResolvers<
     ParentType,
     ContextType
   >;
+  sound?: Resolver<
+    ResolversTypes["UserSettingsNotificationSound"],
+    ParentType,
+    ContextType
+  >;
   space?: Resolver<
     ResolversTypes["UserSettingsNotificationSpace"],
     ParentType,
@@ -22447,6 +23098,19 @@ export type UserSettingsNotificationPlatformAdminResolvers<
   >;
   userProfileRemoved?: Resolver<
     ResolversTypes["UserSettingsNotificationChannels"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserSettingsNotificationSoundResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["UserSettingsNotificationSound"] = ResolversParentTypes["UserSettingsNotificationSound"]
+> = {
+  chatMessage?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  inAppNotification?: Resolver<
+    ResolversTypes["Boolean"],
     ParentType,
     ContextType
   >;
@@ -23043,8 +23707,10 @@ export type Resolvers<ContextType = any> = {
   CalloutContribution?: CalloutContributionResolvers<ContextType>;
   CalloutContributionDefaults?: CalloutContributionDefaultsResolvers<ContextType>;
   CalloutContributionsCountOutput?: CalloutContributionsCountOutputResolvers<ContextType>;
+  CalloutContributorsSettings?: CalloutContributorsSettingsResolvers<ContextType>;
   CalloutFraming?: CalloutFramingResolvers<ContextType>;
   CalloutPostCreated?: CalloutPostCreatedResolvers<ContextType>;
+  CalloutSelectionSettings?: CalloutSelectionSettingsResolvers<ContextType>;
   CalloutSettings?: CalloutSettingsResolvers<ContextType>;
   CalloutSettingsContribution?: CalloutSettingsContributionResolvers<ContextType>;
   CalloutSettingsFraming?: CalloutSettingsFramingResolvers<ContextType>;
@@ -23067,6 +23733,9 @@ export type Resolvers<ContextType = any> = {
   CommunityInvitationResult?: CommunityInvitationResultResolvers<ContextType>;
   CommunityMembershipResult?: CommunityMembershipResultResolvers<ContextType>;
   Config?: ConfigResolvers<ContextType>;
+  ContributorCollectionCounts?: ContributorCollectionCountsResolvers<ContextType>;
+  ContributorCollectionItem?: ContributorCollectionItemResolvers<ContextType>;
+  ContributorLocation?: ContributorLocationResolvers<ContextType>;
   Conversation?: ConversationResolvers<ContextType>;
   ConversationCreatedEvent?: ConversationCreatedEventResolvers<ContextType>;
   ConversationDeletedEvent?: ConversationDeletedEventResolvers<ContextType>;
@@ -23079,8 +23748,10 @@ export type Resolvers<ContextType = any> = {
   ConversationUpdatedEvent?: ConversationUpdatedEventResolvers<ContextType>;
   CreateCalloutContributionData?: CreateCalloutContributionDataResolvers<ContextType>;
   CreateCalloutContributionDefaultsData?: CreateCalloutContributionDefaultsDataResolvers<ContextType>;
+  CreateCalloutContributorsSettingsData?: CreateCalloutContributorsSettingsDataResolvers<ContextType>;
   CreateCalloutData?: CreateCalloutDataResolvers<ContextType>;
   CreateCalloutFramingData?: CreateCalloutFramingDataResolvers<ContextType>;
+  CreateCalloutSelectionSettingsData?: CreateCalloutSelectionSettingsDataResolvers<ContextType>;
   CreateCalloutSettingsContributionData?: CreateCalloutSettingsContributionDataResolvers<ContextType>;
   CreateCalloutSettingsData?: CreateCalloutSettingsDataResolvers<ContextType>;
   CreateCalloutSettingsFramingData?: CreateCalloutSettingsFramingDataResolvers<ContextType>;
@@ -23264,6 +23935,7 @@ export type Resolvers<ContextType = any> = {
   SearchCursor?: GraphQLScalarType;
   SearchResult?: SearchResultResolvers<ContextType>;
   SearchResultCallout?: SearchResultCalloutResolvers<ContextType>;
+  SearchResultCollaboraDocument?: SearchResultCollaboraDocumentResolvers<ContextType>;
   SearchResultMemo?: SearchResultMemoResolvers<ContextType>;
   SearchResultOrganization?: SearchResultOrganizationResolvers<ContextType>;
   SearchResultPost?: SearchResultPostResolvers<ContextType>;
@@ -23329,6 +24001,7 @@ export type Resolvers<ContextType = any> = {
   UserSettingsNotificationOrganization?: UserSettingsNotificationOrganizationResolvers<ContextType>;
   UserSettingsNotificationPlatform?: UserSettingsNotificationPlatformResolvers<ContextType>;
   UserSettingsNotificationPlatformAdmin?: UserSettingsNotificationPlatformAdminResolvers<ContextType>;
+  UserSettingsNotificationSound?: UserSettingsNotificationSoundResolvers<ContextType>;
   UserSettingsNotificationSpace?: UserSettingsNotificationSpaceResolvers<ContextType>;
   UserSettingsNotificationSpaceAdmin?: UserSettingsNotificationSpaceAdminResolvers<ContextType>;
   UserSettingsNotificationUser?: UserSettingsNotificationUserResolvers<ContextType>;
@@ -63000,6 +63673,4114 @@ export type MoveSpaceL1ToSpaceL2Mutation = {
   };
 };
 
+export type MoveSpaceL2ToSpaceL1MutationVariables = Exact<{
+  moveData: MoveSpaceL2ToSpaceL1Input;
+}>;
+
+export type MoveSpaceL2ToSpaceL1Mutation = {
+  moveSpaceL2ToSpaceL1: {
+    id: string;
+    nameID: string;
+    visibility: SpaceVisibility;
+    level: SpaceLevel;
+    account: {
+      id: string;
+      spaces: Array<{ id: string }>;
+      authorization?:
+        | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+      host?:
+        | {
+            id: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  url: string;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  storageBucket: {
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    parentEntity?:
+                      | { displayName: string; type: ProfileType }
+                      | undefined;
+                    documents: Array<{
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>;
+                  };
+                }
+              | undefined;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }
+        | undefined;
+    };
+    authorization?:
+      | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+      | undefined;
+    about: {
+      id: string;
+      why?: any | undefined;
+      who?: any | undefined;
+      authorization?:
+        | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+      profile: {
+        id: string;
+        displayName: string;
+        description?: any | undefined;
+        url: string;
+        tagline?: string | undefined;
+        references?:
+          | Array<{
+              id: string;
+              name: string;
+              uri: string;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>
+          | undefined;
+        tagsets?:
+          | Array<{
+              id: string;
+              name: string;
+              tags: Array<string>;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>
+          | undefined;
+        location?:
+          | { country?: string | undefined; city?: string | undefined }
+          | undefined;
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+        storageBucket: {
+          id: string;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          parentEntity?: { displayName: string; type: ProfileType } | undefined;
+          documents: Array<{
+            id: string;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+        };
+      };
+      metrics?: Array<{ id: string; name: string; value: string }> | undefined;
+      provider?: { id: string } | undefined;
+    };
+    community: {
+      id: string;
+      authorization?:
+        | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+      groups: Array<{
+        id: string;
+        members?:
+          | Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>
+          | undefined;
+        profile?:
+          | {
+              id: string;
+              displayName: string;
+              description?: any | undefined;
+              url: string;
+              tagline?: string | undefined;
+              references?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              tagsets?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    tags: Array<string>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              location?:
+                | { country?: string | undefined; city?: string | undefined }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              storageBucket: {
+                id: string;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                parentEntity?:
+                  | { displayName: string; type: ProfileType }
+                  | undefined;
+                documents: Array<{
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+              };
+            }
+          | undefined;
+      }>;
+      roleSet: {
+        id: string;
+        applications: Array<{
+          id: string;
+          state: string;
+          nextEvents: Array<string>;
+          isFinalized: boolean;
+          lifecycle: { id: string };
+          questions: Array<{ id: string }>;
+          actor: {
+            id: string;
+            profile?: { id: string; displayName: string } | undefined;
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        memberUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        leadUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        adminUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        memberOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | { displayName: string; type: ProfileType }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        leadOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | { displayName: string; type: ProfileType }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+        adminOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | { displayName: string; type: ProfileType }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        }>;
+      };
+      communication: {
+        id: string;
+        updates: {
+          id: string;
+          messages: Array<{
+            __typename: "Message";
+            id: any;
+            message: any;
+            threadID?: any | undefined;
+            reactions: Array<{
+              __typename: "Reaction";
+              id: any;
+              emoji: any;
+              sender?:
+                | {
+                    __typename: "User";
+                    id: string;
+                    profile?:
+                      | {
+                          __typename: "Profile";
+                          id: string;
+                          displayName: string;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+            sender?:
+              | {
+                  __typename: "Actor";
+                  id: string;
+                  profile?:
+                    | {
+                        __typename: "Profile";
+                        id: string;
+                        displayName: string;
+                        url: string;
+                        description?: any | undefined;
+                        tagsets?:
+                          | Array<{
+                              __typename: "Tagset";
+                              id: string;
+                              name: string;
+                              tags: Array<string>;
+                              allowedValues: Array<string>;
+                              type: TagsetType;
+                            }>
+                          | undefined;
+                        location?:
+                          | {
+                              __typename: "Location";
+                              id: string;
+                              country?: string | undefined;
+                              city?: string | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        };
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+      };
+    };
+    collaboration: {
+      id: string;
+      calloutsSet: {
+        id: string;
+        callouts: Array<{
+          id: string;
+          activity: number;
+          nameID: string;
+          publishedDate?: Date | undefined;
+          sortOrder: number;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          comments?:
+            | {
+                id: string;
+                messagesCount: number;
+                messages: Array<{ message: any }>;
+              }
+            | undefined;
+          contributions: Array<{
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            createdBy?: { email: string } | undefined;
+            link?:
+              | {
+                  id: string;
+                  uri: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                }
+              | undefined;
+            post?:
+              | {
+                  id: string;
+                  nameID: string;
+                  createdDate: Date;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                  comments: {
+                    id: string;
+                    messagesCount: number;
+                    messages: Array<{
+                      id: any;
+                      message: any;
+                      sender?: { id: string } | undefined;
+                    }>;
+                  };
+                  createdBy?: { email: string } | undefined;
+                }
+              | undefined;
+            whiteboard?:
+              | {
+                  id: string;
+                  nameID: string;
+                  content: any;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                }
+              | undefined;
+          }>;
+          createdBy?: { email: string } | undefined;
+          framing: {
+            id: string;
+            profile: {
+              id: string;
+              displayName: string;
+              description?: any | undefined;
+              url: string;
+              tagline?: string | undefined;
+              references?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              tagsets?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    tags: Array<string>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              location?:
+                | { country?: string | undefined; city?: string | undefined }
+                | undefined;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              storageBucket: {
+                id: string;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                parentEntity?:
+                  | { displayName: string; type: ProfileType }
+                  | undefined;
+                documents: Array<{
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+              };
+            };
+            whiteboard?:
+              | {
+                  id: string;
+                  nameID: string;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                }
+              | undefined;
+          };
+          publishedBy?: { email: string } | undefined;
+          settings: {
+            visibility: CalloutVisibility;
+            framing: { commentsEnabled: boolean };
+            contribution: {
+              enabled: boolean;
+              canAddContributions: CalloutAllowedActors;
+              commentsEnabled: boolean;
+            };
+          };
+        }>;
+      };
+      authorization?:
+        | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+      innovationFlow: {
+        id: string;
+        profile: {
+          id: string;
+          displayName: string;
+          description?: any | undefined;
+          url: string;
+          tagline?: string | undefined;
+          references?:
+            | Array<{
+                id: string;
+                name: string;
+                uri: string;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>
+            | undefined;
+          tagsets?:
+            | Array<{
+                id: string;
+                name: string;
+                tags: Array<string>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>
+            | undefined;
+          location?:
+            | { country?: string | undefined; city?: string | undefined }
+            | undefined;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          storageBucket: {
+            id: string;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            parentEntity?:
+              | { displayName: string; type: ProfileType }
+              | undefined;
+            documents: Array<{
+              id: string;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>;
+          };
+        };
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+        currentState?:
+          | { description?: any | undefined; displayName: string }
+          | undefined;
+        states: Array<{ description?: any | undefined; displayName: string }>;
+      };
+    };
+    subspaces: Array<{
+      id: string;
+      nameID: string;
+      pinned: boolean;
+      sortOrder: number;
+      about: {
+        id: string;
+        why?: any | undefined;
+        who?: any | undefined;
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+        profile: {
+          id: string;
+          displayName: string;
+          description?: any | undefined;
+          url: string;
+          tagline?: string | undefined;
+          references?:
+            | Array<{
+                id: string;
+                name: string;
+                uri: string;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>
+            | undefined;
+          tagsets?:
+            | Array<{
+                id: string;
+                name: string;
+                tags: Array<string>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>
+            | undefined;
+          location?:
+            | { country?: string | undefined; city?: string | undefined }
+            | undefined;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          storageBucket: {
+            id: string;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            parentEntity?:
+              | { displayName: string; type: ProfileType }
+              | undefined;
+            documents: Array<{
+              id: string;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+            }>;
+          };
+        };
+        metrics?:
+          | Array<{ id: string; name: string; value: string }>
+          | undefined;
+        provider?: { id: string } | undefined;
+      };
+      collaboration: {
+        id: string;
+        calloutsSet: {
+          id: string;
+          callouts: Array<{
+            id: string;
+            activity: number;
+            nameID: string;
+            publishedDate?: Date | undefined;
+            sortOrder: number;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            comments?:
+              | {
+                  id: string;
+                  messagesCount: number;
+                  messages: Array<{ message: any }>;
+                }
+              | undefined;
+            contributions: Array<{
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              createdBy?: { email: string } | undefined;
+              link?:
+                | {
+                    id: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | { displayName: string; type: ProfileType }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                    };
+                  }
+                | undefined;
+              post?:
+                | {
+                    id: string;
+                    nameID: string;
+                    createdDate: Date;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | { displayName: string; type: ProfileType }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                    comments: {
+                      id: string;
+                      messagesCount: number;
+                      messages: Array<{
+                        id: any;
+                        message: any;
+                        sender?: { id: string } | undefined;
+                      }>;
+                    };
+                    createdBy?: { email: string } | undefined;
+                  }
+                | undefined;
+              whiteboard?:
+                | {
+                    id: string;
+                    nameID: string;
+                    content: any;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | { displayName: string; type: ProfileType }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                  }
+                | undefined;
+            }>;
+            createdBy?: { email: string } | undefined;
+            framing: {
+              id: string;
+              profile: {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                url: string;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                storageBucket: {
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  parentEntity?:
+                    | { displayName: string; type: ProfileType }
+                    | undefined;
+                  documents: Array<{
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>;
+                };
+              };
+              whiteboard?:
+                | {
+                    id: string;
+                    nameID: string;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | { displayName: string; type: ProfileType }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                  }
+                | undefined;
+            };
+            publishedBy?: { email: string } | undefined;
+            settings: {
+              visibility: CalloutVisibility;
+              framing: { commentsEnabled: boolean };
+              contribution: {
+                enabled: boolean;
+                canAddContributions: CalloutAllowedActors;
+                commentsEnabled: boolean;
+              };
+            };
+          }>;
+        };
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+        innovationFlow: {
+          id: string;
+          profile: {
+            id: string;
+            displayName: string;
+            description?: any | undefined;
+            url: string;
+            tagline?: string | undefined;
+            references?:
+              | Array<{
+                  id: string;
+                  name: string;
+                  uri: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>
+              | undefined;
+            tagsets?:
+              | Array<{
+                  id: string;
+                  name: string;
+                  tags: Array<string>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>
+              | undefined;
+            location?:
+              | { country?: string | undefined; city?: string | undefined }
+              | undefined;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+            storageBucket: {
+              id: string;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              parentEntity?:
+                | { displayName: string; type: ProfileType }
+                | undefined;
+              documents: Array<{
+                id: string;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>;
+            };
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          currentState?:
+            | { description?: any | undefined; displayName: string }
+            | undefined;
+          states: Array<{ description?: any | undefined; displayName: string }>;
+        };
+      };
+      authorization?:
+        | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+        | undefined;
+      community: {
+        id: string;
+        authorization?:
+          | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+          | undefined;
+        groups: Array<{
+          id: string;
+          members?:
+            | Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>
+            | undefined;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                url: string;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+                storageBucket: {
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  parentEntity?:
+                    | { displayName: string; type: ProfileType }
+                    | undefined;
+                  documents: Array<{
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>;
+                };
+              }
+            | undefined;
+        }>;
+        roleSet: {
+          id: string;
+          applications: Array<{
+            id: string;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            lifecycle: { id: string };
+            questions: Array<{ id: string }>;
+            actor: {
+              id: string;
+              profile?: { id: string; displayName: string } | undefined;
+            };
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          memberUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          leadUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          adminUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          memberOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | { displayName: string; type: ProfileType }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          leadOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | { displayName: string; type: ProfileType }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+          adminOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | { displayName: string; type: ProfileType }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{ id: string; name: VisualType; uri: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          }>;
+        };
+        communication: {
+          id: string;
+          updates: {
+            id: string;
+            messages: Array<{
+              __typename: "Message";
+              id: any;
+              message: any;
+              threadID?: any | undefined;
+              reactions: Array<{
+                __typename: "Reaction";
+                id: any;
+                emoji: any;
+                sender?:
+                  | {
+                      __typename: "User";
+                      id: string;
+                      profile?:
+                        | {
+                            __typename: "Profile";
+                            id: string;
+                            displayName: string;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+              sender?:
+                | {
+                    __typename: "Actor";
+                    id: string;
+                    profile?:
+                      | {
+                          __typename: "Profile";
+                          id: string;
+                          displayName: string;
+                          url: string;
+                          description?: any | undefined;
+                          tagsets?:
+                            | Array<{
+                                __typename: "Tagset";
+                                id: string;
+                                name: string;
+                                tags: Array<string>;
+                                allowedValues: Array<string>;
+                                type: TagsetType;
+                              }>
+                            | undefined;
+                          location?:
+                            | {
+                                __typename: "Location";
+                                id: string;
+                                country?: string | undefined;
+                                city?: string | undefined;
+                              }
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+            authorization?:
+              | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+              | undefined;
+          };
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+        };
+      };
+    }>;
+    settings: {
+      sortMode: SpaceSortMode;
+      privacy: { mode: SpacePrivacyMode; allowPlatformSupportAsAdmin: boolean };
+      membership: {
+        allowSubspaceAdminsToInviteMembers: boolean;
+        policy: CommunityMembershipPolicy;
+        trustedOrganizations: Array<string>;
+      };
+      collaboration: {
+        allowMembersToCreateCallouts: boolean;
+        allowMembersToCreateSubspaces: boolean;
+        inheritMembershipRights: boolean;
+        allowEventsFromSubspaces: boolean;
+        allowMembersToVideoCall: boolean;
+      };
+    };
+    templatesManager?:
+      | {
+          id: string;
+          authorization?:
+            | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+            | undefined;
+          templatesSet?:
+            | {
+                id: string;
+                spaceTemplates: Array<{
+                  id: string;
+                  type: TemplateType;
+                  profile: {
+                    displayName: string;
+                    description?: any | undefined;
+                    id: string;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                postTemplates: Array<{
+                  id: string;
+                  type: TemplateType;
+                  postDefaultDescription?: any | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                whiteboardTemplates: Array<{
+                  id: string;
+                  type: TemplateType;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  whiteboard?:
+                    | {
+                        id: string;
+                        content: any;
+                        profile: {
+                          id: string;
+                          displayName: string;
+                          description?: any | undefined;
+                          url: string;
+                          tagline?: string | undefined;
+                          references?:
+                            | Array<{
+                                id: string;
+                                name: string;
+                                uri: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>
+                            | undefined;
+                          tagsets?:
+                            | Array<{
+                                id: string;
+                                name: string;
+                                tags: Array<string>;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>
+                            | undefined;
+                          location?:
+                            | {
+                                country?: string | undefined;
+                                city?: string | undefined;
+                              }
+                            | undefined;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                          storageBucket: {
+                            id: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            parentEntity?:
+                              | { displayName: string; type: ProfileType }
+                              | undefined;
+                            documents: Array<{
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                            }>;
+                          };
+                        };
+                      }
+                    | undefined;
+                }>;
+                communityGuidelinesTemplates: Array<{
+                  id: string;
+                  type: TemplateType;
+                  profile: {
+                    displayName: string;
+                    description?: any | undefined;
+                    id: string;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                calloutTemplates: Array<{
+                  id: string;
+                  type: TemplateType;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  callout?:
+                    | {
+                        id: string;
+                        framing: {
+                          profile: {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | { displayName: string; type: ProfileType }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          };
+                        };
+                      }
+                    | undefined;
+                }>;
+                authorization?:
+                  | { myPrivileges?: Array<AuthorizationPrivilege> | undefined }
+                  | undefined;
+              }
+            | undefined;
+          templateDefaults: Array<{ id: string }>;
+        }
+      | undefined;
+  };
+};
+
 export type DeleteDocumentMutationVariables = Exact<{
   deleteData: DeleteDocumentInput;
 }>;
@@ -84203,6 +88984,7 @@ export type SearchQuery = {
         | { type: SearchResultType }
         | { type: SearchResultType }
         | { type: SearchResultType }
+        | { type: SearchResultType }
         | {
             type: SearchResultType;
             parentSpace?:
@@ -84244,6 +89026,7 @@ export type SearchQuery = {
         | { type: SearchResultType }
         | { type: SearchResultType }
         | { type: SearchResultType }
+        | { type: SearchResultType }
       >;
     };
     contributionResults: {
@@ -84268,6 +89051,7 @@ export type SearchQuery = {
           }
         | { type: SearchResultType }
         | { type: SearchResultType }
+        | { type: SearchResultType }
         | {
             type: SearchResultType;
             post: { id: string; profile: { displayName: string } };
@@ -84288,6 +89072,7 @@ export type SearchQuery = {
     };
     actorResults: {
       results: Array<
+        | { type: SearchResultType }
         | { type: SearchResultType }
         | { type: SearchResultType }
         | {

--- a/lib/src/core/generated/graphql.ts
+++ b/lib/src/core/generated/graphql.ts
@@ -1211,6 +1211,15 @@ export type CalloutContributionsCountOutput = {
   whiteboard: Scalars["Float"]["output"];
 };
 
+export type CalloutContributorsSettings = {
+  /** The contributor types included in this contributor-collection callout. At least one. */
+  contributorTypes: Array<ActorType>;
+  /** The contributor type shown first (the segmented switch opens on it). One of contributorTypes. */
+  defaultContributorType: ActorType;
+  /** The default display mode (list or map). */
+  defaultView: ContributorCollectionView;
+};
+
 export enum CalloutDescriptionDisplayMode {
   Collapsed = "COLLAPSED",
   Expanded = "EXPANDED",
@@ -1221,6 +1230,10 @@ export type CalloutFraming = {
   authorization?: Maybe<Authorization>;
   /** The Collabora document attached to this Callout Framing, if any. Present when framing.type = COLLABORA_DOCUMENT. */
   collaboraDocument?: Maybe<CollaboraDocument>;
+  /** Per-type counts (users, organizations, virtual contributors) of the total eligible set for a CONTRIBUTORS framing, after type-selection and user-information visibility filtering. Zeroed for non-CONTRIBUTORS framings. */
+  contributorCounts: ContributorCollectionCounts;
+  /** The full authorized set of contributors of the given type for a CONTRIBUTORS framing, ordered leads/admins first then alphabetically. No server-side pagination or search: the client paginates (list) and name-searches client-side over this set. Empty for non-CONTRIBUTORS framings or deselected types. */
+  contributors: Array<ContributorCollectionItem>;
   /** The date at which the entity was created. */
   createdDate: Scalars["DateTime"]["output"];
   /** The ID of the entity */
@@ -1235,6 +1248,8 @@ export type CalloutFraming = {
   poll?: Maybe<Poll>;
   /** The Profile for framing the associated Callout. */
   profile: Profile;
+  /** The host space's subspaces for a SPACES framing, ordered pinned-first then the space's sortOrder/displayName. Returns the existing Space type (no new item type). No server-side pagination/search: the client name-searches and paginates client-side over this set. Empty for non-SPACES framings, for a callout not attached to a space, or for a host with no subspaces. */
+  subspaces: Array<Space>;
   /** The type of the Callout Framing, the additional content attached to this callout */
   type: CalloutFramingType;
   /** The date at which the entity was last updated. */
@@ -1243,13 +1258,19 @@ export type CalloutFraming = {
   whiteboard?: Maybe<Whiteboard>;
 };
 
+export type CalloutFramingContributorsArgs = {
+  type: ActorType;
+};
+
 export enum CalloutFramingType {
   CollaboraDocument = "COLLABORA_DOCUMENT",
+  Contributors = "CONTRIBUTORS",
   Link = "LINK",
   MediaGallery = "MEDIA_GALLERY",
   Memo = "MEMO",
   None = "NONE",
   Poll = "POLL",
+  Spaces = "SPACES",
   Whiteboard = "WHITEBOARD",
 }
 
@@ -1262,6 +1283,19 @@ export type CalloutPostCreated = {
   post: Post;
   /** The sorting order for this Contribution. */
   sortOrder: Scalars["Float"]["output"];
+};
+
+/** The selection mode for a collection callout (Contributors or Subspaces). AUTO (default) returns the full computed set; CUSTOM restricts to the admin-curated selectedIds list. */
+export enum CalloutSelectionMode {
+  Auto = "AUTO",
+  Custom = "CUSTOM",
+}
+
+export type CalloutSelectionSettings = {
+  /** The selection mode: AUTO (full computed set) or CUSTOM (admin-curated subset). */
+  mode: CalloutSelectionMode;
+  /** The selected actor/space IDs in CUSTOM mode (0–500 entries). Ignored when mode is AUTO. */
+  selectedIds: Array<Scalars["ID"]["output"]>;
 };
 
 export type CalloutSettings = {
@@ -1287,6 +1321,10 @@ export type CalloutSettingsContribution = {
 export type CalloutSettingsFraming = {
   /** Can comment to callout framing. */
   commentsEnabled: Scalars["Boolean"]["output"];
+  /** Configuration for a contributor-collection callout. Present only when framing.type = CONTRIBUTORS. */
+  contributors?: Maybe<CalloutContributorsSettings>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Absent / null ⇒ AUTO (full computed set). */
+  selection?: Maybe<CalloutSelectionSettings>;
 };
 
 export enum CalloutVisibility {
@@ -1383,7 +1421,7 @@ export enum CollaboraDocumentType {
 }
 
 export type CollaboraEditorUrlResult = {
-  /** The time-to-live of the access token in seconds. */
+  /** When the access token expires, as an absolute Unix timestamp in milliseconds (the WOPI access_token_ttl passed through from the WOPI host); 0 means it does not expire. */
   accessTokenTTL: Scalars["Float"]["output"];
   /** The URL to open the document in the Collabora editor. */
   editorUrl: Scalars["String"]["output"];
@@ -1667,9 +1705,42 @@ export type ContributionsFilterInput = {
   types?: InputMaybe<Array<CalloutContributionType>>;
 };
 
+export type ContributorCollectionCounts = {
+  organizations: Scalars["Int"]["output"];
+  users: Scalars["Int"]["output"];
+  virtualContributors: Scalars["Int"]["output"];
+};
+
+export type ContributorCollectionItem = {
+  avatarUrl?: Maybe<Scalars["String"]["output"]>;
+  displayName: Scalars["String"]["output"];
+  id: Scalars["UUID"]["output"];
+  /** Location of the contributor; null for Virtual Contributors or when not readable. */
+  location?: Maybe<ContributorLocation>;
+  /** The role label for this contributor (lead/admin/member). */
+  roleLabel?: Maybe<Scalars["String"]["output"]>;
+  type: ActorType;
+  url?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** The default display mode for a contributor-collection callout framing. */
+export enum ContributorCollectionView {
+  List = "LIST",
+  Map = "MAP",
+}
+
 export type ContributorFilterInput = {
   displayName?: InputMaybe<Scalars["String"]["input"]>;
   nameID?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ContributorLocation = {
+  city?: Maybe<Scalars["String"]["output"]>;
+  country?: Maybe<Scalars["String"]["output"]>;
+  /** Whether the location has valid stored coordinates (geoLocation.isValid). City/country alone is false. */
+  hasValidCoordinates: Scalars["Boolean"]["output"];
+  latitude?: Maybe<Scalars["Float"]["output"]>;
+  longitude?: Maybe<Scalars["Float"]["output"]>;
 };
 
 export type Conversation = {
@@ -1880,6 +1951,24 @@ export type CreateCalloutContributionInput = {
   whiteboard?: InputMaybe<CreateWhiteboardInput>;
 };
 
+export type CreateCalloutContributorsSettingsData = {
+  /** The contributor types to include. At least one type is required. */
+  contributorTypes: Array<ActorType>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: Maybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: Maybe<ContributorCollectionView>;
+};
+
+export type CreateCalloutContributorsSettingsInput = {
+  /** The contributor types to include. At least one type is required. */
+  contributorTypes: Array<ActorType>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: InputMaybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: InputMaybe<ContributorCollectionView>;
+};
+
 export type CreateCalloutData = {
   classification?: Maybe<CreateClassificationData>;
   contributionDefaults?: Maybe<CreateCalloutContributionDefaultsData>;
@@ -1954,6 +2043,20 @@ export type CreateCalloutOnCalloutsSetInput = {
   sortOrder?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
+export type CreateCalloutSelectionSettingsData = {
+  /** The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted. */
+  mode?: Maybe<CalloutSelectionMode>;
+  /** The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server. */
+  selectedIds?: Maybe<Array<Scalars["ID"]["output"]>>;
+};
+
+export type CreateCalloutSelectionSettingsInput = {
+  /** The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted. */
+  mode?: InputMaybe<CalloutSelectionMode>;
+  /** The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server. */
+  selectedIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+};
+
 export type CreateCalloutSettingsContributionData = {
   /** Allowed Contribution types. */
   allowedTypes?: Maybe<Array<CalloutContributionType>>;
@@ -1986,11 +2089,19 @@ export type CreateCalloutSettingsData = {
 export type CreateCalloutSettingsFramingData = {
   /** Can comment to callout framing. */
   commentsEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: Maybe<CreateCalloutContributorsSettingsData>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: Maybe<CreateCalloutSelectionSettingsData>;
 };
 
 export type CreateCalloutSettingsFramingInput = {
   /** Can comment to callout framing. */
   commentsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: InputMaybe<CreateCalloutContributorsSettingsInput>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: InputMaybe<CreateCalloutSelectionSettingsInput>;
 };
 
 export type CreateCalloutSettingsInput = {
@@ -2121,6 +2232,10 @@ export type CreateInnovationFlowStateInput = {
 export type CreateInnovationFlowStateSettingsData = {
   /** The flag to set. */
   allowNewCallouts: Scalars["Boolean"]["output"];
+  /** Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted. */
+  descriptionDisplayMode?: Maybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted. */
+  showPublishDetails?: Maybe<Scalars["Boolean"]["output"]>;
   /** Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted. */
   visible?: Maybe<Scalars["Boolean"]["output"]>;
 };
@@ -2128,6 +2243,10 @@ export type CreateInnovationFlowStateSettingsData = {
 export type CreateInnovationFlowStateSettingsInput = {
   /** The flag to set. */
   allowNewCallouts: Scalars["Boolean"]["input"];
+  /** Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted. */
+  descriptionDisplayMode?: InputMaybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted. */
+  showPublishDetails?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted. */
   visible?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
@@ -2135,6 +2254,8 @@ export type CreateInnovationFlowStateSettingsInput = {
 export type CreateInnovationHubOnAccountInput = {
   /** The Account where the InnovationHub is to be created. */
   accountID: Scalars["UUID"]["input"];
+  /** The Innovation Packs curated for this Innovation Hub. When omitted, the Innovation Hub is created with no Innovation Packs. */
+  innovationPackListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars["NameID"]["input"]>;
   profileData: CreateProfileInput;
@@ -2146,6 +2267,8 @@ export type CreateInnovationHubOnAccountInput = {
   subdomain: Scalars["String"]["input"];
   /** The type of Innovation Hub. */
   type: InnovationHubType;
+  /** The Virtual Contributors curated for this Innovation Hub. When omitted, the Innovation Hub is created with no Virtual Contributors. */
+  virtualContributorListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
 };
 
 export type CreateInnovationPackOnAccountInput = {
@@ -2393,6 +2516,8 @@ export type CreateSpaceSettingsPrivacyInput = {
   /** Flag to control if Platform Support has admin rights. */
   allowPlatformSupportAsAdmin?: InputMaybe<Scalars["Boolean"]["input"]>;
   mode?: InputMaybe<SpacePrivacyMode>;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. */
+  userInformationVisibility?: InputMaybe<UserInformationVisibility>;
 };
 
 export type CreateStateOnInnovationFlowInput = {
@@ -3362,6 +3487,10 @@ export type InnovationFlowState = {
 export type InnovationFlowStateSettings = {
   /** Whether new callouts can be added to this State. */
   allowNewCallouts: Scalars["Boolean"]["output"];
+  /** How Post descriptions in this State are displayed in the feed: expanded or collapsed. Default expanded. */
+  descriptionDisplayMode: CalloutDescriptionDisplayMode;
+  /** Whether Posts in this State show publish details (publisher, publish date, avatar) in the feed. Presentation only — does not restrict access to publisher data. Default true. */
+  showPublishDetails: Scalars["Boolean"]["output"];
   /** Whether this State/phase is shown in the member-facing navigation. Default true. UI-affordance only: it does NOT gate access to the phase content. */
   visible: Scalars["Boolean"]["output"];
 };
@@ -3375,6 +3504,8 @@ export type InnovationHub = {
   createdDate: Scalars["DateTime"]["output"];
   /** The ID of the entity */
   id: Scalars["UUID"]["output"];
+  /** The Innovation Packs curated for this Innovation Hub, in stored (curated) order, filtered to those the requesting agent may read. */
+  innovationPackListFilter?: Maybe<Array<InnovationPack>>;
   /** Flag to control if this InnovationHub is listed in the platform store. */
   listedInStore: Scalars["Boolean"]["output"];
   /** A name identifier of the entity, unique within a given scope. */
@@ -3394,6 +3525,8 @@ export type InnovationHub = {
   type: InnovationHubType;
   /** The date at which the entity was last updated. */
   updatedDate: Scalars["DateTime"]["output"];
+  /** The Virtual Contributors curated for this Innovation Hub, in stored (curated) order, filtered to those the requesting agent may read. */
+  virtualContributorListFilter?: Maybe<Array<VirtualContributor>>;
 };
 
 export enum InnovationHubType {
@@ -4530,6 +4663,17 @@ export type MoveSpaceL1ToSpaceL2Input = {
   targetSpaceL1ID: Scalars["UUID"]["input"];
 };
 
+export type MoveSpaceL2ToSpaceL1Input = {
+  /** Send invitations to former community members who are also in the target L0 community. */
+  autoInvite?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Custom invitation message. Used only when autoInvite is true. */
+  invitationMessage?: InputMaybe<Scalars["String"]["input"]>;
+  /** The L2 subspace to move (stays L2). */
+  spaceL2ID: Scalars["UUID"]["input"];
+  /** The target L1 subspace in a different L0 (new parent for the moved L2). */
+  targetSpaceL1ID: Scalars["UUID"]["input"];
+};
+
 export type Mutation = {
   /** Adds an Iframe Allowed URL to the Platform Settings */
   addIframeAllowedURL: Array<Scalars["String"]["output"]>;
@@ -4765,6 +4909,8 @@ export type Mutation = {
   moveSpaceL1ToSpaceL0: Space;
   /** Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges. */
   moveSpaceL1ToSpaceL2: Space;
+  /** Move an L2 sub-subspace to become an L2 subspace under a target L1 in a different L0 space.       The subspace stays at level 2 but changes both its parent L1 and its top-level L0.       All community roles (including admins) are cleared and pending invitations dropped.       Platform access rules are recomputed from the new parent hierarchy.       Requires platform admin privileges. */
+  moveSpaceL2ToSpaceL1: Space;
   /** Refresh the Bodies of Knowledge on All VCs */
   refreshAllBodiesOfKnowledge: Scalars["Boolean"]["output"];
   /** Triggers a request to the backing AI Service to refresh the knowledge that is available to it. */
@@ -4801,6 +4947,8 @@ export type Mutation = {
   removeUserFromGroup: UserGroup;
   /** Reorder Poll options. Requires UPDATE privilege. The provided list must contain exactly the same option IDs as the current poll options. */
   reorderPollOptions: Poll;
+  /** Replace the backing file of an existing CollaboraDocument in place, preserving its identity. Requires UPDATE on the document. The replacement must be an allowed OfficeDocs format, within the size cap, and the SAME document type as the current file. Refused while the document is being edited. */
+  replaceCollaboraDocument: CollaboraDocument;
   /** Resets the interaction with the VC by recreating the room. */
   resetConversationVc: Conversation;
   /** Reset all license plans on Accounts */
@@ -5393,6 +5541,10 @@ export type MutationMoveSpaceL1ToSpaceL2Args = {
   moveData: MoveSpaceL1ToSpaceL2Input;
 };
 
+export type MutationMoveSpaceL2ToSpaceL1Args = {
+  moveData: MoveSpaceL2ToSpaceL1Input;
+};
+
 export type MutationRefreshVirtualContributorBodyOfKnowledgeArgs = {
   refreshData: RefreshVirtualContributorBodyOfKnowledgeInput;
 };
@@ -5459,6 +5611,11 @@ export type MutationRemoveUserFromGroupArgs = {
 
 export type MutationReorderPollOptionsArgs = {
   optionData: ReorderPollOptionsInput;
+};
+
+export type MutationReplaceCollaboraDocumentArgs = {
+  file: Scalars["Upload"]["input"];
+  replaceData: ReplaceCollaboraDocumentInput;
 };
 
 export type MutationResetConversationVcArgs = {
@@ -6781,6 +6938,8 @@ export type Query = {
   aiServer: AiServer;
   /** Retrieves the editor URL for the specified CollaboraDocument. */
   collaboraEditorUrl: CollaboraEditorUrlResult;
+  /** Whether the WOPI save service backing this CollaboraDocument is currently reachable. A side-effect-free health check — unlike collaboraEditorUrl it issues no access token and records no analytics — used to surface a save-path outage in the editor. */
+  collaboraServiceAvailable: Scalars["Boolean"]["output"];
   /** Active Spaces only, order by most active in the past X days. */
   exploreSpaces: Array<Space>;
   /** Allow creation of inputs based on existing entities in the domain model */
@@ -6869,6 +7028,10 @@ export type QueryActorsWithCredentialArgs = {
 };
 
 export type QueryCollaboraEditorUrlArgs = {
+  collaboraDocumentID: Scalars["UUID"]["input"];
+};
+
+export type QueryCollaboraServiceAvailableArgs = {
   collaboraDocumentID: Scalars["UUID"]["input"];
 };
 
@@ -7158,6 +7321,13 @@ export type RemoveUserGroupMemberInput = {
 export type ReorderPollOptionsInput = {
   optionIDs: Array<Scalars["UUID"]["input"]>;
   pollID: Scalars["UUID"]["input"];
+};
+
+export type ReplaceCollaboraDocumentInput = {
+  /** The ID of the CollaboraDocument whose backing file is being replaced. */
+  ID: Scalars["UUID"]["input"];
+  /** Optional title chosen in the replace dialog (defaults to the incoming file title). When supplied it is persisted as the CollaboraDocument display name (the same entity), propagating to the editor title and the download filename. Omit to leave the current name unchanged. */
+  displayName?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RevokeAuthorizationCredentialInput = {
@@ -7653,6 +7823,25 @@ export type SearchResultCallout = SearchResult & {
   type: SearchResultType;
 };
 
+export type SearchResultCollaboraDocument = SearchResult & {
+  /** The Callout of the Collabora document. */
+  callout: Callout;
+  /** The Collabora document that was found. */
+  collaboraDocument: CollaboraDocument;
+  /** The identifier of the search result. Does not represent the entity in Alkemio. */
+  id: Scalars["UUID"]["output"];
+  /** Whether the Collabora document is a contribution (response) or part of the framing. */
+  isContribution: Scalars["Boolean"]["output"];
+  /** The score for this search result; more matches means a higher score. */
+  score: Scalars["Float"]["output"];
+  /** The Space of the Collabora document. */
+  space: Space;
+  /** The terms that were matched for this result */
+  terms: Array<Scalars["String"]["output"]>;
+  /** The type of returned result for this search. */
+  type: SearchResultType;
+};
+
 export type SearchResultMemo = SearchResult & {
   /** The Callout of the Memo. */
   callout: Callout;
@@ -7720,6 +7909,7 @@ export type SearchResultSpace = SearchResult & {
 /** The different types of available search results. */
 export enum SearchResultType {
   Callout = "CALLOUT",
+  CollaboraDocument = "COLLABORA_DOCUMENT",
   Memo = "MEMO",
   Organization = "ORGANIZATION",
   Post = "POST",
@@ -7983,7 +8173,10 @@ export type SpaceSettingsCollaboration = {
 };
 
 export type SpaceSettingsLayout = {
-  /** The default display mode for callout descriptions in this Space. */
+  /**
+   * The default display mode for callout descriptions in this Space.
+   * @deprecated REMOVE_AFTER=2026-10-31 | superseded by InnovationFlowStateSettings.descriptionDisplayMode
+   */
   calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode;
 };
 
@@ -8001,6 +8194,8 @@ export type SpaceSettingsPrivacy = {
   allowPlatformSupportAsAdmin: Scalars["Boolean"]["output"];
   /** The privacy mode for this Space */
   mode: SpacePrivacyMode;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. Absent is treated as follow-space-visibility. */
+  userInformationVisibility?: Maybe<UserInformationVisibility>;
 };
 
 export enum SpaceSortMode {
@@ -8542,6 +8737,15 @@ export type UpdateCalloutContributionDefaultsInput = {
   whiteboardContent?: InputMaybe<Scalars["WhiteboardContent"]["input"]>;
 };
 
+export type UpdateCalloutContributorsSettingsInput = {
+  /** When provided, replaces the selected contributor types (at least one). */
+  contributorTypes?: InputMaybe<Array<ActorType>>;
+  /** The default contributor type (one of contributorTypes). Defaults to the first selected type. */
+  defaultContributorType?: InputMaybe<ActorType>;
+  /** The default display mode. Defaults to LIST; MAP requires a locatable contributor type. */
+  defaultView?: InputMaybe<ContributorCollectionView>;
+};
+
 export type UpdateCalloutEntityInput = {
   ID: Scalars["UUID"]["input"];
   classification?: InputMaybe<UpdateClassificationInput>;
@@ -8583,6 +8787,13 @@ export type UpdateCalloutPublishInfoInput = {
   publisherID?: InputMaybe<Scalars["UUID"]["input"]>;
 };
 
+export type UpdateCalloutSelectionSettingsInput = {
+  /** The selection mode (AUTO or CUSTOM). When omitted, the stored mode is unchanged. */
+  mode?: InputMaybe<CalloutSelectionMode>;
+  /** Replaces the curated selection in full (CUSTOM mode). At most 500 entries. Deduplicated by the server. When omitted, the stored list is unchanged. */
+  selectedIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+};
+
 export type UpdateCalloutSettingsContributionInput = {
   /** Indicate who can add more contributions to the callout. */
   canAddContributions?: InputMaybe<CalloutAllowedActors>;
@@ -8595,6 +8806,10 @@ export type UpdateCalloutSettingsContributionInput = {
 export type UpdateCalloutSettingsFramingInput = {
   /** Can comment to callout framing. */
   commentsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS. */
+  contributors?: InputMaybe<UpdateCalloutContributorsSettingsInput>;
+  /** Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}. */
+  selection?: InputMaybe<UpdateCalloutSelectionSettingsInput>;
 };
 
 export type UpdateCalloutSettingsInput = {
@@ -8719,10 +8934,10 @@ export type UpdateInnovationFlowInput = {
 };
 
 export type UpdateInnovationFlowStateInput = {
-  /** The explanation text to clarify the State. */
+  /** Optional. The explanation text to clarify the State; omission leaves the stored value unchanged. */
   description?: InputMaybe<Scalars["Markdown"]["input"]>;
-  /** The display name for the State */
-  displayName: Scalars["String"]["input"];
+  /** Optional. The display name for the State; omission leaves the stored value unchanged. */
+  displayName?: InputMaybe<Scalars["String"]["input"]>;
   /** ID of the Innovation Flow */
   innovationFlowStateID: Scalars["UUID"]["input"];
   settings?: InputMaybe<UpdateInnovationFlowStateSettingsInput>;
@@ -8731,6 +8946,10 @@ export type UpdateInnovationFlowStateInput = {
 export type UpdateInnovationFlowStateSettingsInput = {
   /** Optional. Sets whether new callouts can be added to this State; omission leaves the stored value unchanged. */
   allowNewCallouts?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Optional. Sets how Post descriptions in this State are displayed in the feed; omission leaves the stored value unchanged. */
+  descriptionDisplayMode?: InputMaybe<CalloutDescriptionDisplayMode>;
+  /** Optional. Sets whether Posts in this State show publish details (publisher, publish date, avatar) in the feed; omission leaves the stored value unchanged. */
+  showPublishDetails?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged. */
   visible?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
@@ -8743,6 +8962,8 @@ export type UpdateInnovationFlowStatesSortOrderInput = {
 
 export type UpdateInnovationHubInput = {
   ID: Scalars["UUID"]["input"];
+  /** The Innovation Packs curated for this Innovation Hub; full replace. An empty list is allowed and hides the section. Omit to leave unchanged. */
+  innovationPackListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** Flag to control the visibility of the InnovationHub in the platform store. */
   listedInStore?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
@@ -8751,10 +8972,12 @@ export type UpdateInnovationHubInput = {
   profileData?: InputMaybe<UpdateProfileInput>;
   /** Visibility of the InnovationHub in searches. */
   searchVisibility?: InputMaybe<SearchVisibility>;
-  /** A list of Spaces to include in this Innovation Hub. Only valid when type 'list' is used. */
+  /** A list of Spaces to include in this Innovation Hub; full replace. An empty list is allowed and hides the Spaces listing. Only valid when type 'list' is used. */
   spaceListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
   /** Spaces with which visibility this Innovation Hub will display. Only valid when type 'visibility' is used. */
   spaceVisibilityFilter?: InputMaybe<SpaceVisibility>;
+  /** The Virtual Contributors curated for this Innovation Hub; full replace. An empty list is allowed and hides the section. Omit to leave unchanged. */
+  virtualContributorListFilter?: InputMaybe<Array<Scalars["UUID"]["input"]>>;
 };
 
 export type UpdateInnovationPackInput = {
@@ -9015,6 +9238,8 @@ export type UpdateSpaceSettingsPrivacyInput = {
   /** Flag to control if Platform Support has admin rights. */
   allowPlatformSupportAsAdmin?: InputMaybe<Scalars["Boolean"]["input"]>;
   mode?: InputMaybe<SpacePrivacyMode>;
+  /** Controls who may read member-user information. Follows space visibility by default, or restricts it to members only. */
+  userInformationVisibility?: InputMaybe<UserInformationVisibility>;
 };
 
 export type UpdateSubspacePinnedInput = {
@@ -9145,6 +9370,8 @@ export type UpdateUserSettingsNotificationInput = {
   organization?: InputMaybe<UpdateUserSettingsNotificationOrganizationInput>;
   /** Settings related to Platform Notifications. */
   platform?: InputMaybe<UpdateUserSettingsNotificationPlatformInput>;
+  /** Settings related to notification sound playback. */
+  sound?: InputMaybe<UpdateUserSettingsNotificationSoundInput>;
   /** Settings related to Space Notifications. */
   space?: InputMaybe<UpdateUserSettingsNotificationSpaceInput>;
   /** Settings related to User Notifications. */
@@ -9180,6 +9407,13 @@ export type UpdateUserSettingsNotificationPlatformInput = {
   forumDiscussionComment?: InputMaybe<NotificationSettingInput>;
   /** Receive a notification when a new Discussion is created in the Forum */
   forumDiscussionCreated?: InputMaybe<NotificationSettingInput>;
+};
+
+export type UpdateUserSettingsNotificationSoundInput = {
+  /** Play a sound when a chat message is received. Default true. */
+  chatMessage?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Play a sound when a non-chat in-app notification is received. Default true. */
+  inAppNotification?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type UpdateUserSettingsNotificationSpaceAdminInput = {
@@ -9591,6 +9825,12 @@ export type UserGroup = {
   updatedDate: Scalars["DateTime"]["output"];
 };
 
+/** Controls who may read member-user information in a Space. Follows space visibility by default, or restricts user info to members only. */
+export enum UserInformationVisibility {
+  FollowSpaceVisibility = "FOLLOW_SPACE_VISIBILITY",
+  MembersOnly = "MEMBERS_ONLY",
+}
+
 /** Minimal user-profile summary identifying a user without exposing PII beyond id + displayName. */
 export type UserProfileSummary = {
   displayName: Scalars["String"]["output"];
@@ -9644,6 +9884,8 @@ export type UserSettingsNotification = {
   organization: UserSettingsNotificationOrganization;
   /** The notifications settings for Platform events for this User */
   platform: UserSettingsNotificationPlatform;
+  /** The sound playback settings for this User. */
+  sound: UserSettingsNotificationSound;
   /** The notifications settings for Space events for this User */
   space: UserSettingsNotificationSpace;
   /** The notifications settings for User events for this User */
@@ -9688,6 +9930,13 @@ export type UserSettingsNotificationPlatformAdmin = {
   userProfileCreated: UserSettingsNotificationChannels;
   /** Receive a notification when a user profile is removed */
   userProfileRemoved: UserSettingsNotificationChannels;
+};
+
+export type UserSettingsNotificationSound = {
+  /** Play a sound when a chat message is received. Default true. */
+  chatMessage: Scalars["Boolean"]["output"];
+  /** Play a sound when a non-chat in-app notification is received. Default true. */
+  inAppNotification: Scalars["Boolean"]["output"];
 };
 
 export type UserSettingsNotificationSpace = {
@@ -10204,57 +10453,65 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutDiscussionComment,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutLinkCreated,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutMemoCreated,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutPostComment,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutPostCreated,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutPublished,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutWhiteboardContentModified,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
       | (Omit<
           SchemaTypes.ActivityLogEntryCalloutWhiteboardCreated,
-          "space" | "triggeredBy"
+          "callout" | "space" | "triggeredBy"
         > & {
+          callout: _RefType["Callout"];
           space?: SchemaTypes.Maybe<_RefType["Space"]>;
           triggeredBy: _RefType["User"];
         })
@@ -10333,7 +10590,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           | "profile"
           | "subspaceByNameID"
           | "subspaces"
-          | "templatesManager"
         > & {
           about: _RefType["SpaceAbout"];
           account: _RefType["Account"];
@@ -10345,7 +10601,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           profile?: SchemaTypes.Maybe<_RefType["Profile"]>;
           subspaceByNameID: _RefType["Space"];
           subspaces: Array<_RefType["Space"]>;
-          templatesManager?: SchemaTypes.Maybe<_RefType["TemplatesManager"]>;
         })
       | (Omit<
           SchemaTypes.Space,
@@ -10359,7 +10614,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           | "profile"
           | "subspaceByNameID"
           | "subspaces"
-          | "templatesManager"
         > & {
           about: _RefType["SpaceAbout"];
           account: _RefType["Account"];
@@ -10371,7 +10625,6 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           profile?: SchemaTypes.Maybe<_RefType["Profile"]>;
           subspaceByNameID: _RefType["Space"];
           subspaces: Array<_RefType["Space"]>;
-          templatesManager?: SchemaTypes.Maybe<_RefType["TemplatesManager"]>;
         })
       | (Omit<
           SchemaTypes.User,
@@ -10455,20 +10708,20 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
         })
       | (Omit<
           SchemaTypes.InAppNotificationPayloadSpaceCollaborationCallout,
-          "space"
-        > & { space: _RefType["Space"] })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutComment,
-          "space"
-        > & { space: _RefType["Space"] })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-          "space"
-        > & { space: _RefType["Space"] })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           SchemaTypes.InAppNotificationPayloadSpaceCollaborationPoll,
-          "space"
-        > & { space: _RefType["Space"] })
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
       | (Omit<
           SchemaTypes.InAppNotificationPayloadSpaceCommunicationMessageDirect,
           "space"
@@ -10515,16 +10768,23 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
           "space"
         > & { space: _RefType["Space"] });
     SearchResult:
-      | (Omit<SchemaTypes.SearchResultCallout, "space"> & {
+      | (Omit<SchemaTypes.SearchResultCallout, "callout" | "space"> & {
+          callout: _RefType["Callout"];
           space: _RefType["Space"];
         })
-      | (Omit<SchemaTypes.SearchResultMemo, "space"> & {
+      | (Omit<
+          SchemaTypes.SearchResultCollaboraDocument,
+          "callout" | "space"
+        > & { callout: _RefType["Callout"]; space: _RefType["Space"] })
+      | (Omit<SchemaTypes.SearchResultMemo, "callout" | "space"> & {
+          callout: _RefType["Callout"];
           space: _RefType["Space"];
         })
       | (Omit<SchemaTypes.SearchResultOrganization, "organization"> & {
           organization: _RefType["Organization"];
         })
-      | (Omit<SchemaTypes.SearchResultPost, "space"> & {
+      | (Omit<SchemaTypes.SearchResultPost, "callout" | "space"> & {
+          callout: _RefType["Callout"];
           space: _RefType["Space"];
         })
       | (Omit<SchemaTypes.SearchResultSpace, "parentSpace" | "space"> & {
@@ -10534,7 +10794,8 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> =
       | (Omit<SchemaTypes.SearchResultUser, "user"> & {
           user: _RefType["User"];
         })
-      | (Omit<SchemaTypes.SearchResultWhiteboard, "space"> & {
+      | (Omit<SchemaTypes.SearchResultWhiteboard, "callout" | "space"> & {
+          callout: _RefType["Callout"];
           space: _RefType["Space"];
         });
   };
@@ -10601,8 +10862,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutDiscussionComment: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutDiscussionComment,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10610,8 +10872,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutLinkCreated: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutLinkCreated,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10619,8 +10882,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutMemoCreated: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutMemoCreated,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10628,8 +10892,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutPostComment: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutPostComment,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10637,8 +10902,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutPostCreated: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutPostCreated,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10646,8 +10912,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutPublished: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutPublished,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10655,8 +10922,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutWhiteboardContentModified: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutWhiteboardContentModified,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10664,8 +10932,9 @@ export type ResolversTypes = {
   ActivityLogEntryCalloutWhiteboardCreated: ResolverTypeWrapper<
     Omit<
       SchemaTypes.ActivityLogEntryCalloutWhiteboardCreated,
-      "space" | "triggeredBy"
+      "callout" | "space" | "triggeredBy"
     > & {
+      callout: ResolversTypes["Callout"];
       space?: SchemaTypes.Maybe<ResolversTypes["Space"]>;
       triggeredBy: ResolversTypes["User"];
     }
@@ -10769,8 +11038,13 @@ export type ResolversTypes = {
   >;
   CalendarEventType: SchemaTypes.CalendarEventType;
   Callout: ResolverTypeWrapper<
-    Omit<SchemaTypes.Callout, "createdBy" | "publishedBy"> & {
+    Omit<
+      SchemaTypes.Callout,
+      "contributionDefaults" | "createdBy" | "framing" | "publishedBy"
+    > & {
+      contributionDefaults: ResolversTypes["CalloutContributionDefaults"];
       createdBy?: SchemaTypes.Maybe<ResolversTypes["User"]>;
+      framing: ResolversTypes["CalloutFraming"];
       publishedBy?: SchemaTypes.Maybe<ResolversTypes["User"]>;
     }
   >;
@@ -10783,19 +11057,31 @@ export type ResolversTypes = {
   CalloutContributionDefaults: ResolverTypeWrapper<SchemaTypes.CalloutContributionDefaults>;
   CalloutContributionType: SchemaTypes.CalloutContributionType;
   CalloutContributionsCountOutput: ResolverTypeWrapper<SchemaTypes.CalloutContributionsCountOutput>;
+  CalloutContributorsSettings: ResolverTypeWrapper<SchemaTypes.CalloutContributorsSettings>;
   CalloutDescriptionDisplayMode: SchemaTypes.CalloutDescriptionDisplayMode;
   CalloutFraming: ResolverTypeWrapper<
-    Omit<SchemaTypes.CalloutFraming, "profile"> & {
+    Omit<
+      SchemaTypes.CalloutFraming,
+      "contributorCounts" | "profile" | "subspaces"
+    > & {
+      contributorCounts: ResolversTypes["ContributorCollectionCounts"];
       profile: ResolversTypes["Profile"];
+      subspaces: Array<ResolversTypes["Space"]>;
     }
   >;
   CalloutFramingType: SchemaTypes.CalloutFramingType;
   CalloutPostCreated: ResolverTypeWrapper<SchemaTypes.CalloutPostCreated>;
+  CalloutSelectionMode: SchemaTypes.CalloutSelectionMode;
+  CalloutSelectionSettings: ResolverTypeWrapper<SchemaTypes.CalloutSelectionSettings>;
   CalloutSettings: ResolverTypeWrapper<SchemaTypes.CalloutSettings>;
   CalloutSettingsContribution: ResolverTypeWrapper<SchemaTypes.CalloutSettingsContribution>;
   CalloutSettingsFraming: ResolverTypeWrapper<SchemaTypes.CalloutSettingsFraming>;
   CalloutVisibility: SchemaTypes.CalloutVisibility;
-  CalloutsSet: ResolverTypeWrapper<SchemaTypes.CalloutsSet>;
+  CalloutsSet: ResolverTypeWrapper<
+    Omit<SchemaTypes.CalloutsSet, "callouts"> & {
+      callouts: Array<ResolversTypes["Callout"]>;
+    }
+  >;
   CalloutsSetType: SchemaTypes.CalloutsSetType;
   CastPollVoteInput: SchemaTypes.CastPollVoteInput;
   Classification: ResolverTypeWrapper<SchemaTypes.Classification>;
@@ -10808,8 +11094,7 @@ export type ResolversTypes = {
   CollaboraDocumentType: SchemaTypes.CollaboraDocumentType;
   CollaboraEditorUrlResult: ResolverTypeWrapper<SchemaTypes.CollaboraEditorUrlResult>;
   Collaboration: ResolverTypeWrapper<
-    Omit<SchemaTypes.Collaboration, "innovationFlow" | "timeline"> & {
-      innovationFlow: ResolversTypes["InnovationFlow"];
+    Omit<SchemaTypes.Collaboration, "timeline"> & {
       timeline: ResolversTypes["Timeline"];
     }
   >;
@@ -10879,7 +11164,11 @@ export type ResolversTypes = {
   >;
   ContentUpdatePolicy: SchemaTypes.ContentUpdatePolicy;
   ContributionsFilterInput: SchemaTypes.ContributionsFilterInput;
+  ContributorCollectionCounts: ResolverTypeWrapper<SchemaTypes.ContributorCollectionCounts>;
+  ContributorCollectionItem: ResolverTypeWrapper<SchemaTypes.ContributorCollectionItem>;
+  ContributorCollectionView: SchemaTypes.ContributorCollectionView;
   ContributorFilterInput: SchemaTypes.ContributorFilterInput;
+  ContributorLocation: ResolverTypeWrapper<SchemaTypes.ContributorLocation>;
   Conversation: ResolverTypeWrapper<
     Omit<SchemaTypes.Conversation, "members"> & {
       members: Array<ResolversTypes["Actor"]>;
@@ -10948,11 +11237,15 @@ export type ResolversTypes = {
   CreateCalloutContributionDefaultsData: ResolverTypeWrapper<SchemaTypes.CreateCalloutContributionDefaultsData>;
   CreateCalloutContributionDefaultsInput: SchemaTypes.CreateCalloutContributionDefaultsInput;
   CreateCalloutContributionInput: SchemaTypes.CreateCalloutContributionInput;
+  CreateCalloutContributorsSettingsData: ResolverTypeWrapper<SchemaTypes.CreateCalloutContributorsSettingsData>;
+  CreateCalloutContributorsSettingsInput: SchemaTypes.CreateCalloutContributorsSettingsInput;
   CreateCalloutData: ResolverTypeWrapper<SchemaTypes.CreateCalloutData>;
   CreateCalloutFramingData: ResolverTypeWrapper<SchemaTypes.CreateCalloutFramingData>;
   CreateCalloutFramingInput: SchemaTypes.CreateCalloutFramingInput;
   CreateCalloutInput: SchemaTypes.CreateCalloutInput;
   CreateCalloutOnCalloutsSetInput: SchemaTypes.CreateCalloutOnCalloutsSetInput;
+  CreateCalloutSelectionSettingsData: ResolverTypeWrapper<SchemaTypes.CreateCalloutSelectionSettingsData>;
+  CreateCalloutSelectionSettingsInput: SchemaTypes.CreateCalloutSelectionSettingsInput;
   CreateCalloutSettingsContributionData: ResolverTypeWrapper<SchemaTypes.CreateCalloutSettingsContributionData>;
   CreateCalloutSettingsContributionInput: SchemaTypes.CreateCalloutSettingsContributionInput;
   CreateCalloutSettingsData: ResolverTypeWrapper<SchemaTypes.CreateCalloutSettingsData>;
@@ -11104,6 +11397,7 @@ export type ResolversTypes = {
   Groupable: ResolverTypeWrapper<
     ResolversInterfaceTypes<ResolversTypes>["Groupable"]
   >;
+  ID: ResolverTypeWrapper<SchemaTypes.Scalars["ID"]["output"]>;
   ISearchCategoryResult: ResolverTypeWrapper<
     Omit<SchemaTypes.ISearchCategoryResult, "results"> & {
       results: Array<ResolversTypes["SearchResult"]>;
@@ -11175,26 +11469,26 @@ export type ResolversTypes = {
   InAppNotificationPayloadSpaceCollaborationCallout: ResolverTypeWrapper<
     Omit<
       SchemaTypes.InAppNotificationPayloadSpaceCollaborationCallout,
-      "space"
-    > & { space: ResolversTypes["Space"] }
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationCalloutComment: ResolverTypeWrapper<
     Omit<
       SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutComment,
-      "space"
-    > & { space: ResolversTypes["Space"] }
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationCalloutPostComment: ResolverTypeWrapper<
     Omit<
       SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-      "space"
-    > & { space: ResolversTypes["Space"] }
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCollaborationPoll: ResolverTypeWrapper<
     Omit<
       SchemaTypes.InAppNotificationPayloadSpaceCollaborationPoll,
-      "space"
-    > & { space: ResolversTypes["Space"] }
+      "callout" | "space"
+    > & { callout: ResolversTypes["Callout"]; space: ResolversTypes["Space"] }
   >;
   InAppNotificationPayloadSpaceCommunicationMessageDirect: ResolverTypeWrapper<
     Omit<
@@ -11261,10 +11555,8 @@ export type ResolversTypes = {
     }
   >;
   InnovationFlow: ResolverTypeWrapper<
-    Omit<SchemaTypes.InnovationFlow, "currentState" | "profile" | "states"> & {
-      currentState?: SchemaTypes.Maybe<ResolversTypes["InnovationFlowState"]>;
+    Omit<SchemaTypes.InnovationFlow, "profile"> & {
       profile: ResolversTypes["Profile"];
-      states: Array<ResolversTypes["InnovationFlowState"]>;
     }
   >;
   InnovationFlowSettings: ResolverTypeWrapper<SchemaTypes.InnovationFlowSettings>;
@@ -11277,9 +11569,16 @@ export type ResolversTypes = {
   InnovationHub: ResolverTypeWrapper<
     Omit<
       SchemaTypes.InnovationHub,
-      "account" | "profile" | "provider" | "spaceListFilter"
+      | "account"
+      | "innovationPackListFilter"
+      | "profile"
+      | "provider"
+      | "spaceListFilter"
     > & {
       account: ResolversTypes["Account"];
+      innovationPackListFilter?: SchemaTypes.Maybe<
+        Array<ResolversTypes["InnovationPack"]>
+      >;
       profile: ResolversTypes["Profile"];
       provider: ResolversTypes["Actor"];
       spaceListFilter?: SchemaTypes.Maybe<Array<ResolversTypes["Space"]>>;
@@ -11369,12 +11668,12 @@ export type ResolversTypes = {
       | "account"
       | "calendar"
       | "calendarEvent"
+      | "callout"
       | "collaboration"
       | "community"
       | "communityGuidelines"
       | "conversation"
       | "document"
-      | "innovationFlow"
       | "innovationHub"
       | "innovationPack"
       | "invitation"
@@ -11385,7 +11684,6 @@ export type ResolversTypes = {
       | "storageBucket"
       | "template"
       | "templateContentSpace"
-      | "templatesManager"
       | "templatesSet"
       | "user"
     > & {
@@ -11393,6 +11691,7 @@ export type ResolversTypes = {
       account?: SchemaTypes.Maybe<ResolversTypes["Account"]>;
       calendar?: SchemaTypes.Maybe<ResolversTypes["Calendar"]>;
       calendarEvent?: SchemaTypes.Maybe<ResolversTypes["CalendarEvent"]>;
+      callout?: SchemaTypes.Maybe<ResolversTypes["Callout"]>;
       collaboration?: SchemaTypes.Maybe<ResolversTypes["Collaboration"]>;
       community?: SchemaTypes.Maybe<ResolversTypes["Community"]>;
       communityGuidelines?: SchemaTypes.Maybe<
@@ -11400,7 +11699,6 @@ export type ResolversTypes = {
       >;
       conversation?: SchemaTypes.Maybe<ResolversTypes["Conversation"]>;
       document?: SchemaTypes.Maybe<ResolversTypes["Document"]>;
-      innovationFlow?: SchemaTypes.Maybe<ResolversTypes["InnovationFlow"]>;
       innovationHub?: SchemaTypes.Maybe<ResolversTypes["InnovationHub"]>;
       innovationPack?: SchemaTypes.Maybe<ResolversTypes["InnovationPack"]>;
       invitation?: SchemaTypes.Maybe<ResolversTypes["Invitation"]>;
@@ -11413,7 +11711,6 @@ export type ResolversTypes = {
       templateContentSpace?: SchemaTypes.Maybe<
         ResolversTypes["TemplateContentSpace"]
       >;
-      templatesManager?: SchemaTypes.Maybe<ResolversTypes["TemplatesManager"]>;
       templatesSet?: SchemaTypes.Maybe<ResolversTypes["TemplatesSet"]>;
       user?: SchemaTypes.Maybe<ResolversTypes["User"]>;
     }
@@ -11479,6 +11776,7 @@ export type ResolversTypes = {
   MoveCalloutContributionInput: SchemaTypes.MoveCalloutContributionInput;
   MoveSpaceL1ToSpaceL0Input: SchemaTypes.MoveSpaceL1ToSpaceL0Input;
   MoveSpaceL1ToSpaceL2Input: SchemaTypes.MoveSpaceL1ToSpaceL2Input;
+  MoveSpaceL2ToSpaceL1Input: SchemaTypes.MoveSpaceL2ToSpaceL1Input;
   Mutation: ResolverTypeWrapper<{}>;
   MutationType: SchemaTypes.MutationType;
   MySpaceResults: ResolverTypeWrapper<
@@ -11578,19 +11876,13 @@ export type ResolversTypes = {
   Platform: ResolverTypeWrapper<
     Omit<
       SchemaTypes.Platform,
-      | "configuration"
-      | "forum"
-      | "innovationHub"
-      | "library"
-      | "roleSet"
-      | "templatesManager"
+      "configuration" | "forum" | "innovationHub" | "library" | "roleSet"
     > & {
       configuration: ResolversTypes["Config"];
       forum: ResolversTypes["Forum"];
       innovationHub?: SchemaTypes.Maybe<ResolversTypes["InnovationHub"]>;
       library: ResolversTypes["Library"];
       roleSet: ResolversTypes["RoleSet"];
-      templatesManager?: SchemaTypes.Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   PlatformAccessRole: ResolverTypeWrapper<SchemaTypes.PlatformAccessRole>;
@@ -11696,7 +11988,6 @@ export type ResolversTypes = {
       | "profile"
       | "subspaceByNameID"
       | "subspaces"
-      | "templatesManager"
     > & {
       about: ResolversTypes["SpaceAbout"];
       account: ResolversTypes["Account"];
@@ -11708,7 +11999,6 @@ export type ResolversTypes = {
       profile?: SchemaTypes.Maybe<ResolversTypes["Profile"]>;
       subspaceByNameID: ResolversTypes["Space"];
       subspaces: Array<ResolversTypes["Space"]>;
-      templatesManager?: SchemaTypes.Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   RelayPaginatedSpaceEdge: ResolverTypeWrapper<
@@ -11726,6 +12016,7 @@ export type ResolversTypes = {
   RemoveRoleOnRoleSetInput: SchemaTypes.RemoveRoleOnRoleSetInput;
   RemoveUserGroupMemberInput: SchemaTypes.RemoveUserGroupMemberInput;
   ReorderPollOptionsInput: SchemaTypes.ReorderPollOptionsInput;
+  ReplaceCollaboraDocumentInput: SchemaTypes.ReplaceCollaboraDocumentInput;
   RevokeAuthorizationCredentialInput: SchemaTypes.RevokeAuthorizationCredentialInput;
   RevokeLicensePlanFromAccount: SchemaTypes.RevokeLicensePlanFromAccount;
   RevokeLicensePlanFromSpace: SchemaTypes.RevokeLicensePlanFromSpace;
@@ -11784,12 +12075,20 @@ export type ResolversTypes = {
     ResolversInterfaceTypes<ResolversTypes>["SearchResult"]
   >;
   SearchResultCallout: ResolverTypeWrapper<
-    Omit<SchemaTypes.SearchResultCallout, "space"> & {
+    Omit<SchemaTypes.SearchResultCallout, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
+      space: ResolversTypes["Space"];
+    }
+  >;
+  SearchResultCollaboraDocument: ResolverTypeWrapper<
+    Omit<SchemaTypes.SearchResultCollaboraDocument, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
       space: ResolversTypes["Space"];
     }
   >;
   SearchResultMemo: ResolverTypeWrapper<
-    Omit<SchemaTypes.SearchResultMemo, "space"> & {
+    Omit<SchemaTypes.SearchResultMemo, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
       space: ResolversTypes["Space"];
     }
   >;
@@ -11799,7 +12098,8 @@ export type ResolversTypes = {
     }
   >;
   SearchResultPost: ResolverTypeWrapper<
-    Omit<SchemaTypes.SearchResultPost, "space"> & {
+    Omit<SchemaTypes.SearchResultPost, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
       space: ResolversTypes["Space"];
     }
   >;
@@ -11816,7 +12116,8 @@ export type ResolversTypes = {
     }
   >;
   SearchResultWhiteboard: ResolverTypeWrapper<
-    Omit<SchemaTypes.SearchResultWhiteboard, "space"> & {
+    Omit<SchemaTypes.SearchResultWhiteboard, "callout" | "space"> & {
+      callout: ResolversTypes["Callout"];
       space: ResolversTypes["Space"];
     }
   >;
@@ -11839,7 +12140,6 @@ export type ResolversTypes = {
       | "profile"
       | "subspaceByNameID"
       | "subspaces"
-      | "templatesManager"
     > & {
       about: ResolversTypes["SpaceAbout"];
       account: ResolversTypes["Account"];
@@ -11851,7 +12151,6 @@ export type ResolversTypes = {
       profile?: SchemaTypes.Maybe<ResolversTypes["Profile"]>;
       subspaceByNameID: ResolversTypes["Space"];
       subspaces: Array<ResolversTypes["Space"]>;
-      templatesManager?: SchemaTypes.Maybe<ResolversTypes["TemplatesManager"]>;
     }
   >;
   SpaceAbout: ResolverTypeWrapper<
@@ -11935,8 +12234,9 @@ export type ResolversTypes = {
   Template: ResolverTypeWrapper<
     Omit<
       SchemaTypes.Template,
-      "communityGuidelines" | "contentSpace" | "profile"
+      "callout" | "communityGuidelines" | "contentSpace" | "profile"
     > & {
+      callout?: SchemaTypes.Maybe<ResolversTypes["Callout"]>;
       communityGuidelines?: SchemaTypes.Maybe<
         ResolversTypes["CommunityGuidelines"]
       >;
@@ -11968,8 +12268,7 @@ export type ResolversTypes = {
   >;
   TemplateType: SchemaTypes.TemplateType;
   TemplatesManager: ResolverTypeWrapper<
-    Omit<SchemaTypes.TemplatesManager, "templateDefaults" | "templatesSet"> & {
-      templateDefaults: Array<ResolversTypes["TemplateDefault"]>;
+    Omit<SchemaTypes.TemplatesManager, "templatesSet"> & {
       templatesSet?: SchemaTypes.Maybe<ResolversTypes["TemplatesSet"]>;
     }
   >;
@@ -12008,9 +12307,11 @@ export type ResolversTypes = {
   UpdateBaselineLicensePlanOnAccount: SchemaTypes.UpdateBaselineLicensePlanOnAccount;
   UpdateCalendarEventInput: SchemaTypes.UpdateCalendarEventInput;
   UpdateCalloutContributionDefaultsInput: SchemaTypes.UpdateCalloutContributionDefaultsInput;
+  UpdateCalloutContributorsSettingsInput: SchemaTypes.UpdateCalloutContributorsSettingsInput;
   UpdateCalloutEntityInput: SchemaTypes.UpdateCalloutEntityInput;
   UpdateCalloutFramingInput: SchemaTypes.UpdateCalloutFramingInput;
   UpdateCalloutPublishInfoInput: SchemaTypes.UpdateCalloutPublishInfoInput;
+  UpdateCalloutSelectionSettingsInput: SchemaTypes.UpdateCalloutSelectionSettingsInput;
   UpdateCalloutSettingsContributionInput: SchemaTypes.UpdateCalloutSettingsContributionInput;
   UpdateCalloutSettingsFramingInput: SchemaTypes.UpdateCalloutSettingsFramingInput;
   UpdateCalloutSettingsInput: SchemaTypes.UpdateCalloutSettingsInput;
@@ -12084,6 +12385,7 @@ export type ResolversTypes = {
   UpdateUserSettingsNotificationOrganizationInput: SchemaTypes.UpdateUserSettingsNotificationOrganizationInput;
   UpdateUserSettingsNotificationPlatformAdminInput: SchemaTypes.UpdateUserSettingsNotificationPlatformAdminInput;
   UpdateUserSettingsNotificationPlatformInput: SchemaTypes.UpdateUserSettingsNotificationPlatformInput;
+  UpdateUserSettingsNotificationSoundInput: SchemaTypes.UpdateUserSettingsNotificationSoundInput;
   UpdateUserSettingsNotificationSpaceAdminInput: SchemaTypes.UpdateUserSettingsNotificationSpaceAdminInput;
   UpdateUserSettingsNotificationSpaceInput: SchemaTypes.UpdateUserSettingsNotificationSpaceInput;
   UpdateUserSettingsNotificationUserInput: SchemaTypes.UpdateUserSettingsNotificationUserInput;
@@ -12137,6 +12439,7 @@ export type ResolversTypes = {
       profile?: SchemaTypes.Maybe<ResolversTypes["Profile"]>;
     }
   >;
+  UserInformationVisibility: SchemaTypes.UserInformationVisibility;
   UserProfileSummary: ResolverTypeWrapper<SchemaTypes.UserProfileSummary>;
   UserSettings: ResolverTypeWrapper<SchemaTypes.UserSettings>;
   UserSettingsAssistant: ResolverTypeWrapper<SchemaTypes.UserSettingsAssistant>;
@@ -12147,6 +12450,7 @@ export type ResolversTypes = {
   UserSettingsNotificationOrganization: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationOrganization>;
   UserSettingsNotificationPlatform: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationPlatform>;
   UserSettingsNotificationPlatformAdmin: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationPlatformAdmin>;
+  UserSettingsNotificationSound: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationSound>;
   UserSettingsNotificationSpace: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationSpace>;
   UserSettingsNotificationSpaceAdmin: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationSpaceAdmin>;
   UserSettingsNotificationUser: ResolverTypeWrapper<SchemaTypes.UserSettingsNotificationUser>;
@@ -12267,57 +12571,65 @@ export type ResolversParentTypes = {
   };
   ActivityLogEntryCalloutDiscussionComment: Omit<
     SchemaTypes.ActivityLogEntryCalloutDiscussionComment,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutLinkCreated: Omit<
     SchemaTypes.ActivityLogEntryCalloutLinkCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutMemoCreated: Omit<
     SchemaTypes.ActivityLogEntryCalloutMemoCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPostComment: Omit<
     SchemaTypes.ActivityLogEntryCalloutPostComment,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPostCreated: Omit<
     SchemaTypes.ActivityLogEntryCalloutPostCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutPublished: Omit<
     SchemaTypes.ActivityLogEntryCalloutPublished,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutWhiteboardContentModified: Omit<
     SchemaTypes.ActivityLogEntryCalloutWhiteboardContentModified,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
   ActivityLogEntryCalloutWhiteboardCreated: Omit<
     SchemaTypes.ActivityLogEntryCalloutWhiteboardCreated,
-    "space" | "triggeredBy"
+    "callout" | "space" | "triggeredBy"
   > & {
+    callout: ResolversParentTypes["Callout"];
     space?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
     triggeredBy: ResolversParentTypes["User"];
   };
@@ -12398,8 +12710,13 @@ export type ResolversParentTypes = {
     profile: ResolversParentTypes["Profile"];
     subspace?: SchemaTypes.Maybe<ResolversParentTypes["Space"]>;
   };
-  Callout: Omit<SchemaTypes.Callout, "createdBy" | "publishedBy"> & {
+  Callout: Omit<
+    SchemaTypes.Callout,
+    "contributionDefaults" | "createdBy" | "framing" | "publishedBy"
+  > & {
+    contributionDefaults: ResolversParentTypes["CalloutContributionDefaults"];
     createdBy?: SchemaTypes.Maybe<ResolversParentTypes["User"]>;
+    framing: ResolversParentTypes["CalloutFraming"];
     publishedBy?: SchemaTypes.Maybe<ResolversParentTypes["User"]>;
   };
   CalloutContribution: Omit<SchemaTypes.CalloutContribution, "createdBy"> & {
@@ -12407,14 +12724,23 @@ export type ResolversParentTypes = {
   };
   CalloutContributionDefaults: SchemaTypes.CalloutContributionDefaults;
   CalloutContributionsCountOutput: SchemaTypes.CalloutContributionsCountOutput;
-  CalloutFraming: Omit<SchemaTypes.CalloutFraming, "profile"> & {
+  CalloutContributorsSettings: SchemaTypes.CalloutContributorsSettings;
+  CalloutFraming: Omit<
+    SchemaTypes.CalloutFraming,
+    "contributorCounts" | "profile" | "subspaces"
+  > & {
+    contributorCounts: ResolversParentTypes["ContributorCollectionCounts"];
     profile: ResolversParentTypes["Profile"];
+    subspaces: Array<ResolversParentTypes["Space"]>;
   };
   CalloutPostCreated: SchemaTypes.CalloutPostCreated;
+  CalloutSelectionSettings: SchemaTypes.CalloutSelectionSettings;
   CalloutSettings: SchemaTypes.CalloutSettings;
   CalloutSettingsContribution: SchemaTypes.CalloutSettingsContribution;
   CalloutSettingsFraming: SchemaTypes.CalloutSettingsFraming;
-  CalloutsSet: SchemaTypes.CalloutsSet;
+  CalloutsSet: Omit<SchemaTypes.CalloutsSet, "callouts"> & {
+    callouts: Array<ResolversParentTypes["Callout"]>;
+  };
   CastPollVoteInput: SchemaTypes.CastPollVoteInput;
   Classification: SchemaTypes.Classification;
   CollaboraDocument: Omit<
@@ -12425,11 +12751,7 @@ export type ResolversParentTypes = {
     profile: ResolversParentTypes["Profile"];
   };
   CollaboraEditorUrlResult: SchemaTypes.CollaboraEditorUrlResult;
-  Collaboration: Omit<
-    SchemaTypes.Collaboration,
-    "innovationFlow" | "timeline"
-  > & {
-    innovationFlow: ResolversParentTypes["InnovationFlow"];
+  Collaboration: Omit<SchemaTypes.Collaboration, "timeline"> & {
     timeline: ResolversParentTypes["Timeline"];
   };
   Communication: SchemaTypes.Communication;
@@ -12483,7 +12805,10 @@ export type ResolversParentTypes = {
     authentication: ResolversParentTypes["AuthenticationConfig"];
   };
   ContributionsFilterInput: SchemaTypes.ContributionsFilterInput;
+  ContributorCollectionCounts: SchemaTypes.ContributorCollectionCounts;
+  ContributorCollectionItem: SchemaTypes.ContributorCollectionItem;
   ContributorFilterInput: SchemaTypes.ContributorFilterInput;
+  ContributorLocation: SchemaTypes.ContributorLocation;
   Conversation: Omit<SchemaTypes.Conversation, "members"> & {
     members: Array<ResolversParentTypes["Actor"]>;
   };
@@ -12541,11 +12866,15 @@ export type ResolversParentTypes = {
   CreateCalloutContributionDefaultsData: SchemaTypes.CreateCalloutContributionDefaultsData;
   CreateCalloutContributionDefaultsInput: SchemaTypes.CreateCalloutContributionDefaultsInput;
   CreateCalloutContributionInput: SchemaTypes.CreateCalloutContributionInput;
+  CreateCalloutContributorsSettingsData: SchemaTypes.CreateCalloutContributorsSettingsData;
+  CreateCalloutContributorsSettingsInput: SchemaTypes.CreateCalloutContributorsSettingsInput;
   CreateCalloutData: SchemaTypes.CreateCalloutData;
   CreateCalloutFramingData: SchemaTypes.CreateCalloutFramingData;
   CreateCalloutFramingInput: SchemaTypes.CreateCalloutFramingInput;
   CreateCalloutInput: SchemaTypes.CreateCalloutInput;
   CreateCalloutOnCalloutsSetInput: SchemaTypes.CreateCalloutOnCalloutsSetInput;
+  CreateCalloutSelectionSettingsData: SchemaTypes.CreateCalloutSelectionSettingsData;
+  CreateCalloutSelectionSettingsInput: SchemaTypes.CreateCalloutSelectionSettingsInput;
   CreateCalloutSettingsContributionData: SchemaTypes.CreateCalloutSettingsContributionData;
   CreateCalloutSettingsContributionInput: SchemaTypes.CreateCalloutSettingsContributionInput;
   CreateCalloutSettingsData: SchemaTypes.CreateCalloutSettingsData;
@@ -12684,6 +13013,7 @@ export type ResolversParentTypes = {
   GrantAuthorizationCredentialInput: SchemaTypes.GrantAuthorizationCredentialInput;
   GrantOrganizationAuthorizationCredentialInput: SchemaTypes.GrantOrganizationAuthorizationCredentialInput;
   Groupable: ResolversInterfaceTypes<ResolversParentTypes>["Groupable"];
+  ID: SchemaTypes.Scalars["ID"]["output"];
   ISearchCategoryResult: Omit<SchemaTypes.ISearchCategoryResult, "results"> & {
     results: Array<ResolversParentTypes["SearchResult"]>;
   };
@@ -12738,20 +13068,32 @@ export type ResolversParentTypes = {
   > & { space: ResolversParentTypes["Space"] };
   InAppNotificationPayloadSpaceCollaborationCallout: Omit<
     SchemaTypes.InAppNotificationPayloadSpaceCollaborationCallout,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationCalloutComment: Omit<
     SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutComment,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationCalloutPostComment: Omit<
     SchemaTypes.InAppNotificationPayloadSpaceCollaborationCalloutPostComment,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCollaborationPoll: Omit<
     SchemaTypes.InAppNotificationPayloadSpaceCollaborationPoll,
-    "space"
-  > & { space: ResolversParentTypes["Space"] };
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
   InAppNotificationPayloadSpaceCommunicationMessageDirect: Omit<
     SchemaTypes.InAppNotificationPayloadSpaceCommunicationMessageDirect,
     "space"
@@ -12801,15 +13143,8 @@ export type ResolversParentTypes = {
     SchemaTypes.InAppNotificationPayloadVirtualContributor,
     "space"
   > & { space: ResolversParentTypes["Space"] };
-  InnovationFlow: Omit<
-    SchemaTypes.InnovationFlow,
-    "currentState" | "profile" | "states"
-  > & {
-    currentState?: SchemaTypes.Maybe<
-      ResolversParentTypes["InnovationFlowState"]
-    >;
+  InnovationFlow: Omit<SchemaTypes.InnovationFlow, "profile"> & {
     profile: ResolversParentTypes["Profile"];
-    states: Array<ResolversParentTypes["InnovationFlowState"]>;
   };
   InnovationFlowSettings: SchemaTypes.InnovationFlowSettings;
   InnovationFlowState: Omit<
@@ -12823,9 +13158,16 @@ export type ResolversParentTypes = {
   InnovationFlowStateSettings: SchemaTypes.InnovationFlowStateSettings;
   InnovationHub: Omit<
     SchemaTypes.InnovationHub,
-    "account" | "profile" | "provider" | "spaceListFilter"
+    | "account"
+    | "innovationPackListFilter"
+    | "profile"
+    | "provider"
+    | "spaceListFilter"
   > & {
     account: ResolversParentTypes["Account"];
+    innovationPackListFilter?: SchemaTypes.Maybe<
+      Array<ResolversParentTypes["InnovationPack"]>
+    >;
     profile: ResolversParentTypes["Profile"];
     provider: ResolversParentTypes["Actor"];
     spaceListFilter?: SchemaTypes.Maybe<Array<ResolversParentTypes["Space"]>>;
@@ -12895,12 +13237,12 @@ export type ResolversParentTypes = {
     | "account"
     | "calendar"
     | "calendarEvent"
+    | "callout"
     | "collaboration"
     | "community"
     | "communityGuidelines"
     | "conversation"
     | "document"
-    | "innovationFlow"
     | "innovationHub"
     | "innovationPack"
     | "invitation"
@@ -12911,7 +13253,6 @@ export type ResolversParentTypes = {
     | "storageBucket"
     | "template"
     | "templateContentSpace"
-    | "templatesManager"
     | "templatesSet"
     | "user"
   > & {
@@ -12919,6 +13260,7 @@ export type ResolversParentTypes = {
     account?: SchemaTypes.Maybe<ResolversParentTypes["Account"]>;
     calendar?: SchemaTypes.Maybe<ResolversParentTypes["Calendar"]>;
     calendarEvent?: SchemaTypes.Maybe<ResolversParentTypes["CalendarEvent"]>;
+    callout?: SchemaTypes.Maybe<ResolversParentTypes["Callout"]>;
     collaboration?: SchemaTypes.Maybe<ResolversParentTypes["Collaboration"]>;
     community?: SchemaTypes.Maybe<ResolversParentTypes["Community"]>;
     communityGuidelines?: SchemaTypes.Maybe<
@@ -12926,7 +13268,6 @@ export type ResolversParentTypes = {
     >;
     conversation?: SchemaTypes.Maybe<ResolversParentTypes["Conversation"]>;
     document?: SchemaTypes.Maybe<ResolversParentTypes["Document"]>;
-    innovationFlow?: SchemaTypes.Maybe<ResolversParentTypes["InnovationFlow"]>;
     innovationHub?: SchemaTypes.Maybe<ResolversParentTypes["InnovationHub"]>;
     innovationPack?: SchemaTypes.Maybe<ResolversParentTypes["InnovationPack"]>;
     invitation?: SchemaTypes.Maybe<ResolversParentTypes["Invitation"]>;
@@ -12938,9 +13279,6 @@ export type ResolversParentTypes = {
     template?: SchemaTypes.Maybe<ResolversParentTypes["Template"]>;
     templateContentSpace?: SchemaTypes.Maybe<
       ResolversParentTypes["TemplateContentSpace"]
-    >;
-    templatesManager?: SchemaTypes.Maybe<
-      ResolversParentTypes["TemplatesManager"]
     >;
     templatesSet?: SchemaTypes.Maybe<ResolversParentTypes["TemplatesSet"]>;
     user?: SchemaTypes.Maybe<ResolversParentTypes["User"]>;
@@ -13000,6 +13338,7 @@ export type ResolversParentTypes = {
   MoveCalloutContributionInput: SchemaTypes.MoveCalloutContributionInput;
   MoveSpaceL1ToSpaceL0Input: SchemaTypes.MoveSpaceL1ToSpaceL0Input;
   MoveSpaceL1ToSpaceL2Input: SchemaTypes.MoveSpaceL1ToSpaceL2Input;
+  MoveSpaceL2ToSpaceL1Input: SchemaTypes.MoveSpaceL2ToSpaceL1Input;
   Mutation: {};
   MySpaceResults: Omit<
     SchemaTypes.MySpaceResults,
@@ -13081,21 +13420,13 @@ export type ResolversParentTypes = {
   PaginatedVirtualContributor: SchemaTypes.PaginatedVirtualContributor;
   Platform: Omit<
     SchemaTypes.Platform,
-    | "configuration"
-    | "forum"
-    | "innovationHub"
-    | "library"
-    | "roleSet"
-    | "templatesManager"
+    "configuration" | "forum" | "innovationHub" | "library" | "roleSet"
   > & {
     configuration: ResolversParentTypes["Config"];
     forum: ResolversParentTypes["Forum"];
     innovationHub?: SchemaTypes.Maybe<ResolversParentTypes["InnovationHub"]>;
     library: ResolversParentTypes["Library"];
     roleSet: ResolversParentTypes["RoleSet"];
-    templatesManager?: SchemaTypes.Maybe<
-      ResolversParentTypes["TemplatesManager"]
-    >;
   };
   PlatformAccessRole: SchemaTypes.PlatformAccessRole;
   PlatformAdminCommunicationQueryResults: SchemaTypes.PlatformAdminCommunicationQueryResults;
@@ -13180,7 +13511,6 @@ export type ResolversParentTypes = {
     | "profile"
     | "subspaceByNameID"
     | "subspaces"
-    | "templatesManager"
   > & {
     about: ResolversParentTypes["SpaceAbout"];
     account: ResolversParentTypes["Account"];
@@ -13192,9 +13522,6 @@ export type ResolversParentTypes = {
     profile?: SchemaTypes.Maybe<ResolversParentTypes["Profile"]>;
     subspaceByNameID: ResolversParentTypes["Space"];
     subspaces: Array<ResolversParentTypes["Space"]>;
-    templatesManager?: SchemaTypes.Maybe<
-      ResolversParentTypes["TemplatesManager"]
-    >;
   };
   RelayPaginatedSpaceEdge: Omit<SchemaTypes.RelayPaginatedSpaceEdge, "node"> & {
     node: ResolversParentTypes["RelayPaginatedSpace"];
@@ -13209,6 +13536,7 @@ export type ResolversParentTypes = {
   RemoveRoleOnRoleSetInput: SchemaTypes.RemoveRoleOnRoleSetInput;
   RemoveUserGroupMemberInput: SchemaTypes.RemoveUserGroupMemberInput;
   ReorderPollOptionsInput: SchemaTypes.ReorderPollOptionsInput;
+  ReplaceCollaboraDocumentInput: SchemaTypes.ReplaceCollaboraDocumentInput;
   RevokeAuthorizationCredentialInput: SchemaTypes.RevokeAuthorizationCredentialInput;
   RevokeLicensePlanFromAccount: SchemaTypes.RevokeLicensePlanFromAccount;
   RevokeLicensePlanFromSpace: SchemaTypes.RevokeLicensePlanFromSpace;
@@ -13253,17 +13581,30 @@ export type ResolversParentTypes = {
   SearchFilterInput: SchemaTypes.SearchFilterInput;
   SearchInput: SchemaTypes.SearchInput;
   SearchResult: ResolversInterfaceTypes<ResolversParentTypes>["SearchResult"];
-  SearchResultCallout: Omit<SchemaTypes.SearchResultCallout, "space"> & {
+  SearchResultCallout: Omit<
+    SchemaTypes.SearchResultCallout,
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
-  SearchResultMemo: Omit<SchemaTypes.SearchResultMemo, "space"> & {
+  SearchResultCollaboraDocument: Omit<
+    SchemaTypes.SearchResultCollaboraDocument,
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
+    space: ResolversParentTypes["Space"];
+  };
+  SearchResultMemo: Omit<SchemaTypes.SearchResultMemo, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SearchResultOrganization: Omit<
     SchemaTypes.SearchResultOrganization,
     "organization"
   > & { organization: ResolversParentTypes["Organization"] };
-  SearchResultPost: Omit<SchemaTypes.SearchResultPost, "space"> & {
+  SearchResultPost: Omit<SchemaTypes.SearchResultPost, "callout" | "space"> & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SearchResultSpace: Omit<
@@ -13276,7 +13617,11 @@ export type ResolversParentTypes = {
   SearchResultUser: Omit<SchemaTypes.SearchResultUser, "user"> & {
     user: ResolversParentTypes["User"];
   };
-  SearchResultWhiteboard: Omit<SchemaTypes.SearchResultWhiteboard, "space"> & {
+  SearchResultWhiteboard: Omit<
+    SchemaTypes.SearchResultWhiteboard,
+    "callout" | "space"
+  > & {
+    callout: ResolversParentTypes["Callout"];
     space: ResolversParentTypes["Space"];
   };
   SendDirectMessageToUsersInput: SchemaTypes.SendDirectMessageToUsersInput;
@@ -13296,7 +13641,6 @@ export type ResolversParentTypes = {
     | "profile"
     | "subspaceByNameID"
     | "subspaces"
-    | "templatesManager"
   > & {
     about: ResolversParentTypes["SpaceAbout"];
     account: ResolversParentTypes["Account"];
@@ -13308,9 +13652,6 @@ export type ResolversParentTypes = {
     profile?: SchemaTypes.Maybe<ResolversParentTypes["Profile"]>;
     subspaceByNameID: ResolversParentTypes["Space"];
     subspaces: Array<ResolversParentTypes["Space"]>;
-    templatesManager?: SchemaTypes.Maybe<
-      ResolversParentTypes["TemplatesManager"]
-    >;
   };
   SpaceAbout: Omit<
     SchemaTypes.SpaceAbout,
@@ -13372,8 +13713,9 @@ export type ResolversParentTypes = {
   Task: SchemaTypes.Task;
   Template: Omit<
     SchemaTypes.Template,
-    "communityGuidelines" | "contentSpace" | "profile"
+    "callout" | "communityGuidelines" | "contentSpace" | "profile"
   > & {
+    callout?: SchemaTypes.Maybe<ResolversParentTypes["Callout"]>;
     communityGuidelines?: SchemaTypes.Maybe<
       ResolversParentTypes["CommunityGuidelines"]
     >;
@@ -13400,11 +13742,7 @@ export type ResolversParentTypes = {
     innovationPack: ResolversParentTypes["InnovationPack"];
     template: ResolversParentTypes["Template"];
   };
-  TemplatesManager: Omit<
-    SchemaTypes.TemplatesManager,
-    "templateDefaults" | "templatesSet"
-  > & {
-    templateDefaults: Array<ResolversParentTypes["TemplateDefault"]>;
+  TemplatesManager: Omit<SchemaTypes.TemplatesManager, "templatesSet"> & {
     templatesSet?: SchemaTypes.Maybe<ResolversParentTypes["TemplatesSet"]>;
   };
   TemplatesSet: Omit<
@@ -13438,9 +13776,11 @@ export type ResolversParentTypes = {
   UpdateBaselineLicensePlanOnAccount: SchemaTypes.UpdateBaselineLicensePlanOnAccount;
   UpdateCalendarEventInput: SchemaTypes.UpdateCalendarEventInput;
   UpdateCalloutContributionDefaultsInput: SchemaTypes.UpdateCalloutContributionDefaultsInput;
+  UpdateCalloutContributorsSettingsInput: SchemaTypes.UpdateCalloutContributorsSettingsInput;
   UpdateCalloutEntityInput: SchemaTypes.UpdateCalloutEntityInput;
   UpdateCalloutFramingInput: SchemaTypes.UpdateCalloutFramingInput;
   UpdateCalloutPublishInfoInput: SchemaTypes.UpdateCalloutPublishInfoInput;
+  UpdateCalloutSelectionSettingsInput: SchemaTypes.UpdateCalloutSelectionSettingsInput;
   UpdateCalloutSettingsContributionInput: SchemaTypes.UpdateCalloutSettingsContributionInput;
   UpdateCalloutSettingsFramingInput: SchemaTypes.UpdateCalloutSettingsFramingInput;
   UpdateCalloutSettingsInput: SchemaTypes.UpdateCalloutSettingsInput;
@@ -13514,6 +13854,7 @@ export type ResolversParentTypes = {
   UpdateUserSettingsNotificationOrganizationInput: SchemaTypes.UpdateUserSettingsNotificationOrganizationInput;
   UpdateUserSettingsNotificationPlatformAdminInput: SchemaTypes.UpdateUserSettingsNotificationPlatformAdminInput;
   UpdateUserSettingsNotificationPlatformInput: SchemaTypes.UpdateUserSettingsNotificationPlatformInput;
+  UpdateUserSettingsNotificationSoundInput: SchemaTypes.UpdateUserSettingsNotificationSoundInput;
   UpdateUserSettingsNotificationSpaceAdminInput: SchemaTypes.UpdateUserSettingsNotificationSpaceAdminInput;
   UpdateUserSettingsNotificationSpaceInput: SchemaTypes.UpdateUserSettingsNotificationSpaceInput;
   UpdateUserSettingsNotificationUserInput: SchemaTypes.UpdateUserSettingsNotificationUserInput;
@@ -13572,6 +13913,7 @@ export type ResolversParentTypes = {
   UserSettingsNotificationOrganization: SchemaTypes.UserSettingsNotificationOrganization;
   UserSettingsNotificationPlatform: SchemaTypes.UserSettingsNotificationPlatform;
   UserSettingsNotificationPlatformAdmin: SchemaTypes.UserSettingsNotificationPlatformAdmin;
+  UserSettingsNotificationSound: SchemaTypes.UserSettingsNotificationSound;
   UserSettingsNotificationSpace: SchemaTypes.UserSettingsNotificationSpace;
   UserSettingsNotificationSpaceAdmin: SchemaTypes.UserSettingsNotificationSpaceAdmin;
   UserSettingsNotificationUser: SchemaTypes.UserSettingsNotificationUser;
@@ -14708,6 +15050,28 @@ export type CalloutContributionsCountOutputResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CalloutContributorsSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CalloutContributorsSettings"] = ResolversParentTypes["CalloutContributorsSettings"]
+> = {
+  contributorTypes?: Resolver<
+    Array<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultContributorType?: Resolver<
+    ResolversTypes["ActorType"],
+    ParentType,
+    ContextType
+  >;
+  defaultView?: Resolver<
+    ResolversTypes["ContributorCollectionView"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CalloutFramingResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CalloutFraming"] = ResolversParentTypes["CalloutFraming"]
@@ -14721,6 +15085,17 @@ export type CalloutFramingResolvers<
     SchemaTypes.Maybe<ResolversTypes["CollaboraDocument"]>,
     ParentType,
     ContextType
+  >;
+  contributorCounts?: Resolver<
+    ResolversTypes["ContributorCollectionCounts"],
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    Array<ResolversTypes["ContributorCollectionItem"]>,
+    ParentType,
+    ContextType,
+    RequireFields<SchemaTypes.CalloutFramingContributorsArgs, "type">
   >;
   createdDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
@@ -14745,6 +15120,7 @@ export type CalloutFramingResolvers<
     ContextType
   >;
   profile?: Resolver<ResolversTypes["Profile"], ParentType, ContextType>;
+  subspaces?: Resolver<Array<ResolversTypes["Space"]>, ParentType, ContextType>;
   type?: Resolver<
     ResolversTypes["CalloutFramingType"],
     ParentType,
@@ -14767,6 +15143,19 @@ export type CalloutPostCreatedResolvers<
   contributionID?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   post?: Resolver<ResolversTypes["Post"], ParentType, ContextType>;
   sortOrder?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CalloutSelectionSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CalloutSelectionSettings"] = ResolversParentTypes["CalloutSelectionSettings"]
+> = {
+  mode?: Resolver<
+    ResolversTypes["CalloutSelectionMode"],
+    ParentType,
+    ContextType
+  >;
+  selectedIds?: Resolver<Array<ResolversTypes["ID"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -14821,6 +15210,16 @@ export type CalloutSettingsFramingResolvers<
 > = {
   commentsEnabled?: Resolver<
     ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CalloutContributorsSettings"]>,
+    ParentType,
+    ContextType
+  >;
+  selection?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CalloutSelectionSettings"]>,
     ParentType,
     ContextType
   >;
@@ -15196,6 +15595,82 @@ export type ConfigResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ContributorCollectionCountsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorCollectionCounts"] = ResolversParentTypes["ContributorCollectionCounts"]
+> = {
+  organizations?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  users?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  virtualContributors?: Resolver<
+    ResolversTypes["Int"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ContributorCollectionItemResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorCollectionItem"] = ResolversParentTypes["ContributorCollectionItem"]
+> = {
+  avatarUrl?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  displayName?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  location?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["ContributorLocation"]>,
+    ParentType,
+    ContextType
+  >;
+  roleLabel?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  type?: Resolver<ResolversTypes["ActorType"], ParentType, ContextType>;
+  url?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ContributorLocationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["ContributorLocation"] = ResolversParentTypes["ContributorLocation"]
+> = {
+  city?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  country?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  hasValidCoordinates?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  latitude?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["Float"]>,
+    ParentType,
+    ContextType
+  >;
+  longitude?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["Float"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ConversationResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["Conversation"] = ResolversParentTypes["Conversation"]
@@ -15424,6 +15899,28 @@ export type CreateCalloutContributionDefaultsDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CreateCalloutContributorsSettingsDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CreateCalloutContributorsSettingsData"] = ResolversParentTypes["CreateCalloutContributorsSettingsData"]
+> = {
+  contributorTypes?: Resolver<
+    Array<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultContributorType?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["ActorType"]>,
+    ParentType,
+    ContextType
+  >;
+  defaultView?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["ContributorCollectionView"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CreateCalloutDataResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CreateCalloutData"] = ResolversParentTypes["CreateCalloutData"]
@@ -15518,6 +16015,23 @@ export type CreateCalloutFramingDataResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CreateCalloutSelectionSettingsDataResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["CreateCalloutSelectionSettingsData"] = ResolversParentTypes["CreateCalloutSelectionSettingsData"]
+> = {
+  mode?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CalloutSelectionMode"]>,
+    ParentType,
+    ContextType
+  >;
+  selectedIds?: Resolver<
+    SchemaTypes.Maybe<Array<ResolversTypes["ID"]>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CreateCalloutSettingsContributionDataResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["CreateCalloutSettingsContributionData"] = ResolversParentTypes["CreateCalloutSettingsContributionData"]
@@ -15573,6 +16087,16 @@ export type CreateCalloutSettingsFramingDataResolvers<
 > = {
   commentsEnabled?: Resolver<
     SchemaTypes.Maybe<ResolversTypes["Boolean"]>,
+    ParentType,
+    ContextType
+  >;
+  contributors?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CreateCalloutContributorsSettingsData"]>,
+    ParentType,
+    ContextType
+  >;
+  selection?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CreateCalloutSelectionSettingsData"]>,
     ParentType,
     ContextType
   >;
@@ -15695,6 +16219,16 @@ export type CreateInnovationFlowStateSettingsDataResolvers<
 > = {
   allowNewCallouts?: Resolver<
     ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  descriptionDisplayMode?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["CalloutDescriptionDisplayMode"]>,
+    ParentType,
+    ContextType
+  >;
+  showPublishDetails?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["Boolean"]>,
     ParentType,
     ContextType
   >;
@@ -16817,6 +17351,16 @@ export type InnovationFlowStateSettingsResolvers<
     ParentType,
     ContextType
   >;
+  descriptionDisplayMode?: Resolver<
+    ResolversTypes["CalloutDescriptionDisplayMode"],
+    ParentType,
+    ContextType
+  >;
+  showPublishDetails?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
   visible?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -16833,6 +17377,11 @@ export type InnovationHubResolvers<
   >;
   createdDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  innovationPackListFilter?: Resolver<
+    SchemaTypes.Maybe<Array<ResolversTypes["InnovationPack"]>>,
+    ParentType,
+    ContextType
+  >;
   listedInStore?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   nameID?: Resolver<ResolversTypes["NameID"], ParentType, ContextType>;
   profile?: Resolver<ResolversTypes["Profile"], ParentType, ContextType>;
@@ -16855,6 +17404,11 @@ export type InnovationHubResolvers<
   subdomain?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   type?: Resolver<ResolversTypes["InnovationHubType"], ParentType, ContextType>;
   updatedDate?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  virtualContributorListFilter?: Resolver<
+    SchemaTypes.Maybe<Array<ResolversTypes["VirtualContributor"]>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -19002,6 +19556,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<SchemaTypes.MutationMoveSpaceL1ToSpaceL2Args, "moveData">
   >;
+  moveSpaceL2ToSpaceL1?: Resolver<
+    ResolversTypes["Space"],
+    ParentType,
+    ContextType,
+    RequireFields<SchemaTypes.MutationMoveSpaceL2ToSpaceL1Args, "moveData">
+  >;
   refreshAllBodiesOfKnowledge?: Resolver<
     ResolversTypes["Boolean"],
     ParentType,
@@ -19138,6 +19698,15 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<SchemaTypes.MutationReorderPollOptionsArgs, "optionData">
+  >;
+  replaceCollaboraDocument?: Resolver<
+    ResolversTypes["CollaboraDocument"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      SchemaTypes.MutationReplaceCollaboraDocumentArgs,
+      "file" | "replaceData"
+    >
   >;
   resetConversationVc?: Resolver<
     ResolversTypes["Conversation"],
@@ -21070,6 +21639,15 @@ export type QueryResolvers<
       "collaboraDocumentID"
     >
   >;
+  collaboraServiceAvailable?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType,
+    RequireFields<
+      SchemaTypes.QueryCollaboraServiceAvailableArgs,
+      "collaboraDocumentID"
+    >
+  >;
   exploreSpaces?: Resolver<
     Array<ResolversTypes["Space"]>,
     ParentType,
@@ -21812,6 +22390,7 @@ export type SearchResultResolvers<
 > = {
   __resolveType: TypeResolveFn<
     | "SearchResultCallout"
+    | "SearchResultCollaboraDocument"
     | "SearchResultMemo"
     | "SearchResultOrganization"
     | "SearchResultPost"
@@ -21833,6 +22412,25 @@ export type SearchResultCalloutResolvers<
 > = {
   callout?: Resolver<ResolversTypes["Callout"], ParentType, ContextType>;
   id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  score?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  space?: Resolver<ResolversTypes["Space"], ParentType, ContextType>;
+  terms?: Resolver<Array<ResolversTypes["String"]>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes["SearchResultType"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type SearchResultCollaboraDocumentResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["SearchResultCollaboraDocument"] = ResolversParentTypes["SearchResultCollaboraDocument"]
+> = {
+  callout?: Resolver<ResolversTypes["Callout"], ParentType, ContextType>;
+  collaboraDocument?: Resolver<
+    ResolversTypes["CollaboraDocument"],
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes["UUID"], ParentType, ContextType>;
+  isContribution?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   score?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   space?: Resolver<ResolversTypes["Space"], ParentType, ContextType>;
   terms?: Resolver<Array<ResolversTypes["String"]>, ParentType, ContextType>;
@@ -22258,6 +22856,11 @@ export type SpaceSettingsPrivacyResolvers<
     ContextType
   >;
   mode?: Resolver<ResolversTypes["SpacePrivacyMode"], ParentType, ContextType>;
+  userInformationVisibility?: Resolver<
+    SchemaTypes.Maybe<ResolversTypes["UserInformationVisibility"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -23387,6 +23990,11 @@ export type UserSettingsNotificationResolvers<
     ParentType,
     ContextType
   >;
+  sound?: Resolver<
+    ResolversTypes["UserSettingsNotificationSound"],
+    ParentType,
+    ContextType
+  >;
   space?: Resolver<
     ResolversTypes["UserSettingsNotificationSpace"],
     ParentType,
@@ -23480,6 +24088,19 @@ export type UserSettingsNotificationPlatformAdminResolvers<
   >;
   userProfileRemoved?: Resolver<
     ResolversTypes["UserSettingsNotificationChannels"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserSettingsNotificationSoundResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["UserSettingsNotificationSound"] = ResolversParentTypes["UserSettingsNotificationSound"]
+> = {
+  chatMessage?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  inAppNotification?: Resolver<
+    ResolversTypes["Boolean"],
     ParentType,
     ContextType
   >;
@@ -24096,8 +24717,10 @@ export type Resolvers<ContextType = any> = {
   CalloutContribution?: CalloutContributionResolvers<ContextType>;
   CalloutContributionDefaults?: CalloutContributionDefaultsResolvers<ContextType>;
   CalloutContributionsCountOutput?: CalloutContributionsCountOutputResolvers<ContextType>;
+  CalloutContributorsSettings?: CalloutContributorsSettingsResolvers<ContextType>;
   CalloutFraming?: CalloutFramingResolvers<ContextType>;
   CalloutPostCreated?: CalloutPostCreatedResolvers<ContextType>;
+  CalloutSelectionSettings?: CalloutSelectionSettingsResolvers<ContextType>;
   CalloutSettings?: CalloutSettingsResolvers<ContextType>;
   CalloutSettingsContribution?: CalloutSettingsContributionResolvers<ContextType>;
   CalloutSettingsFraming?: CalloutSettingsFramingResolvers<ContextType>;
@@ -24120,6 +24743,9 @@ export type Resolvers<ContextType = any> = {
   CommunityInvitationResult?: CommunityInvitationResultResolvers<ContextType>;
   CommunityMembershipResult?: CommunityMembershipResultResolvers<ContextType>;
   Config?: ConfigResolvers<ContextType>;
+  ContributorCollectionCounts?: ContributorCollectionCountsResolvers<ContextType>;
+  ContributorCollectionItem?: ContributorCollectionItemResolvers<ContextType>;
+  ContributorLocation?: ContributorLocationResolvers<ContextType>;
   Conversation?: ConversationResolvers<ContextType>;
   ConversationCreatedEvent?: ConversationCreatedEventResolvers<ContextType>;
   ConversationDeletedEvent?: ConversationDeletedEventResolvers<ContextType>;
@@ -24132,8 +24758,10 @@ export type Resolvers<ContextType = any> = {
   ConversationUpdatedEvent?: ConversationUpdatedEventResolvers<ContextType>;
   CreateCalloutContributionData?: CreateCalloutContributionDataResolvers<ContextType>;
   CreateCalloutContributionDefaultsData?: CreateCalloutContributionDefaultsDataResolvers<ContextType>;
+  CreateCalloutContributorsSettingsData?: CreateCalloutContributorsSettingsDataResolvers<ContextType>;
   CreateCalloutData?: CreateCalloutDataResolvers<ContextType>;
   CreateCalloutFramingData?: CreateCalloutFramingDataResolvers<ContextType>;
+  CreateCalloutSelectionSettingsData?: CreateCalloutSelectionSettingsDataResolvers<ContextType>;
   CreateCalloutSettingsContributionData?: CreateCalloutSettingsContributionDataResolvers<ContextType>;
   CreateCalloutSettingsData?: CreateCalloutSettingsDataResolvers<ContextType>;
   CreateCalloutSettingsFramingData?: CreateCalloutSettingsFramingDataResolvers<ContextType>;
@@ -24317,6 +24945,7 @@ export type Resolvers<ContextType = any> = {
   SearchCursor?: GraphQLScalarType;
   SearchResult?: SearchResultResolvers<ContextType>;
   SearchResultCallout?: SearchResultCalloutResolvers<ContextType>;
+  SearchResultCollaboraDocument?: SearchResultCollaboraDocumentResolvers<ContextType>;
   SearchResultMemo?: SearchResultMemoResolvers<ContextType>;
   SearchResultOrganization?: SearchResultOrganizationResolvers<ContextType>;
   SearchResultPost?: SearchResultPostResolvers<ContextType>;
@@ -24382,6 +25011,7 @@ export type Resolvers<ContextType = any> = {
   UserSettingsNotificationOrganization?: UserSettingsNotificationOrganizationResolvers<ContextType>;
   UserSettingsNotificationPlatform?: UserSettingsNotificationPlatformResolvers<ContextType>;
   UserSettingsNotificationPlatformAdmin?: UserSettingsNotificationPlatformAdminResolvers<ContextType>;
+  UserSettingsNotificationSound?: UserSettingsNotificationSoundResolvers<ContextType>;
   UserSettingsNotificationSpace?: UserSettingsNotificationSpaceResolvers<ContextType>;
   UserSettingsNotificationSpaceAdmin?: UserSettingsNotificationSpaceAdminResolvers<ContextType>;
   UserSettingsNotificationUser?: UserSettingsNotificationUserResolvers<ContextType>;
@@ -69119,6 +69749,4531 @@ export type MoveSpaceL1ToSpaceL2Mutation = {
   };
 };
 
+export type MoveSpaceL2ToSpaceL1MutationVariables = SchemaTypes.Exact<{
+  moveData: SchemaTypes.MoveSpaceL2ToSpaceL1Input;
+}>;
+
+export type MoveSpaceL2ToSpaceL1Mutation = {
+  moveSpaceL2ToSpaceL1: {
+    id: string;
+    nameID: string;
+    visibility: SchemaTypes.SpaceVisibility;
+    level: SchemaTypes.SpaceLevel;
+    account: {
+      id: string;
+      spaces: Array<{ id: string }>;
+      authorization?:
+        | {
+            myPrivileges?:
+              | Array<SchemaTypes.AuthorizationPrivilege>
+              | undefined;
+          }
+        | undefined;
+      host?:
+        | {
+            id: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  url: string;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  storageBucket: {
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    parentEntity?:
+                      | { displayName: string; type: SchemaTypes.ProfileType }
+                      | undefined;
+                    documents: Array<{
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>;
+                  };
+                }
+              | undefined;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }
+        | undefined;
+    };
+    authorization?:
+      | { myPrivileges?: Array<SchemaTypes.AuthorizationPrivilege> | undefined }
+      | undefined;
+    about: {
+      id: string;
+      why?: any | undefined;
+      who?: any | undefined;
+      authorization?:
+        | {
+            myPrivileges?:
+              | Array<SchemaTypes.AuthorizationPrivilege>
+              | undefined;
+          }
+        | undefined;
+      profile: {
+        id: string;
+        displayName: string;
+        description?: any | undefined;
+        url: string;
+        tagline?: string | undefined;
+        references?:
+          | Array<{
+              id: string;
+              name: string;
+              uri: string;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>
+          | undefined;
+        tagsets?:
+          | Array<{
+              id: string;
+              name: string;
+              tags: Array<string>;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>
+          | undefined;
+        location?:
+          | { country?: string | undefined; city?: string | undefined }
+          | undefined;
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+        storageBucket: {
+          id: string;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          parentEntity?:
+            | { displayName: string; type: SchemaTypes.ProfileType }
+            | undefined;
+          documents: Array<{
+            id: string;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+        };
+      };
+      metrics?: Array<{ id: string; name: string; value: string }> | undefined;
+      provider?: { id: string } | undefined;
+    };
+    community: {
+      id: string;
+      authorization?:
+        | {
+            myPrivileges?:
+              | Array<SchemaTypes.AuthorizationPrivilege>
+              | undefined;
+          }
+        | undefined;
+      groups: Array<{
+        id: string;
+        members?:
+          | Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: SchemaTypes.VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>
+          | undefined;
+        profile?:
+          | {
+              id: string;
+              displayName: string;
+              description?: any | undefined;
+              url: string;
+              tagline?: string | undefined;
+              references?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              tagsets?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    tags: Array<string>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              location?:
+                | { country?: string | undefined; city?: string | undefined }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              storageBucket: {
+                id: string;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                parentEntity?:
+                  | { displayName: string; type: SchemaTypes.ProfileType }
+                  | undefined;
+                documents: Array<{
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+              };
+            }
+          | undefined;
+      }>;
+      roleSet: {
+        id: string;
+        applications: Array<{
+          id: string;
+          state: string;
+          nextEvents: Array<string>;
+          isFinalized: boolean;
+          lifecycle: { id: string };
+          questions: Array<{ id: string }>;
+          actor: {
+            id: string;
+            profile?: { id: string; displayName: string } | undefined;
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        memberUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        leadUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        adminUsers: Array<{
+          id: string;
+          nameID: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        memberOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: SchemaTypes.VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | {
+                                    displayName: string;
+                                    type: SchemaTypes.ProfileType;
+                                  }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: SchemaTypes.OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        leadOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: SchemaTypes.VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | {
+                                    displayName: string;
+                                    type: SchemaTypes.ProfileType;
+                                  }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: SchemaTypes.OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+        adminOrganizations: Array<{
+          id: string;
+          nameID: string;
+          legalEntityName?: string | undefined;
+          domain?: string | undefined;
+          website?: string | undefined;
+          contactEmail?: string | undefined;
+          roleSet: {
+            id: string;
+            usersInRole: Array<{
+              id: string;
+              nameID: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+              profile?:
+                | {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    visuals: Array<{
+                      id: string;
+                      name: SchemaTypes.VisualType;
+                      uri: string;
+                    }>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+          };
+          account?:
+            | {
+                id: string;
+                spaces: Array<{ id: string }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                host?:
+                  | {
+                      id: string;
+                      profile?:
+                        | {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | {
+                                    displayName: string;
+                                    type: SchemaTypes.ProfileType;
+                                  }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          actor: { id: string };
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                visuals: Array<{
+                  id: string;
+                  name: SchemaTypes.VisualType;
+                  uri: string;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          verification: {
+            id: string;
+            status: SchemaTypes.OrganizationVerificationEnum;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            lifecycle: { id: string };
+          };
+          settings: {
+            privacy: { contributionRolesPubliclyVisible: boolean };
+            membership: { allowUsersMatchingDomainToJoin: boolean };
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        }>;
+      };
+      communication: {
+        id: string;
+        updates: {
+          id: string;
+          messages: Array<{
+            __typename: "Message";
+            id: any;
+            message: any;
+            threadID?: any | undefined;
+            reactions: Array<{
+              __typename: "Reaction";
+              id: any;
+              emoji: any;
+              sender?:
+                | {
+                    __typename: "User";
+                    id: string;
+                    profile?:
+                      | {
+                          __typename: "Profile";
+                          id: string;
+                          displayName: string;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+            sender?:
+              | {
+                  __typename: "Actor";
+                  id: string;
+                  profile?:
+                    | {
+                        __typename: "Profile";
+                        id: string;
+                        displayName: string;
+                        url: string;
+                        description?: any | undefined;
+                        tagsets?:
+                          | Array<{
+                              __typename: "Tagset";
+                              id: string;
+                              name: string;
+                              tags: Array<string>;
+                              allowedValues: Array<string>;
+                              type: SchemaTypes.TagsetType;
+                            }>
+                          | undefined;
+                        location?:
+                          | {
+                              __typename: "Location";
+                              id: string;
+                              country?: string | undefined;
+                              city?: string | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        };
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+      };
+    };
+    collaboration: {
+      id: string;
+      calloutsSet: {
+        id: string;
+        callouts: Array<{
+          id: string;
+          activity: number;
+          nameID: string;
+          publishedDate?: Date | undefined;
+          sortOrder: number;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          comments?:
+            | {
+                id: string;
+                messagesCount: number;
+                messages: Array<{ message: any }>;
+              }
+            | undefined;
+          contributions: Array<{
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            createdBy?: { email: string } | undefined;
+            link?:
+              | {
+                  id: string;
+                  uri: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                }
+              | undefined;
+            post?:
+              | {
+                  id: string;
+                  nameID: string;
+                  createdDate: Date;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: SchemaTypes.VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                  comments: {
+                    id: string;
+                    messagesCount: number;
+                    messages: Array<{
+                      id: any;
+                      message: any;
+                      sender?: { id: string } | undefined;
+                    }>;
+                  };
+                  createdBy?: { email: string } | undefined;
+                }
+              | undefined;
+            whiteboard?:
+              | {
+                  id: string;
+                  nameID: string;
+                  content: any;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: SchemaTypes.VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                }
+              | undefined;
+          }>;
+          createdBy?: { email: string } | undefined;
+          framing: {
+            id: string;
+            profile: {
+              id: string;
+              displayName: string;
+              description?: any | undefined;
+              url: string;
+              tagline?: string | undefined;
+              references?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              tagsets?:
+                | Array<{
+                    id: string;
+                    name: string;
+                    tags: Array<string>;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>
+                | undefined;
+              location?:
+                | { country?: string | undefined; city?: string | undefined }
+                | undefined;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              storageBucket: {
+                id: string;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                parentEntity?:
+                  | { displayName: string; type: SchemaTypes.ProfileType }
+                  | undefined;
+                documents: Array<{
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+              };
+            };
+            whiteboard?:
+              | {
+                  id: string;
+                  nameID: string;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    visual?:
+                      | {
+                          __typename: "Visual";
+                          id: string;
+                          uri: string;
+                          name: SchemaTypes.VisualType;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  };
+                }
+              | undefined;
+          };
+          publishedBy?: { email: string } | undefined;
+          settings: {
+            visibility: SchemaTypes.CalloutVisibility;
+            framing: { commentsEnabled: boolean };
+            contribution: {
+              enabled: boolean;
+              canAddContributions: SchemaTypes.CalloutAllowedActors;
+              commentsEnabled: boolean;
+            };
+          };
+        }>;
+      };
+      authorization?:
+        | {
+            myPrivileges?:
+              | Array<SchemaTypes.AuthorizationPrivilege>
+              | undefined;
+          }
+        | undefined;
+      innovationFlow: {
+        id: string;
+        profile: {
+          id: string;
+          displayName: string;
+          description?: any | undefined;
+          url: string;
+          tagline?: string | undefined;
+          references?:
+            | Array<{
+                id: string;
+                name: string;
+                uri: string;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          tagsets?:
+            | Array<{
+                id: string;
+                name: string;
+                tags: Array<string>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          location?:
+            | { country?: string | undefined; city?: string | undefined }
+            | undefined;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          storageBucket: {
+            id: string;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            parentEntity?:
+              | { displayName: string; type: SchemaTypes.ProfileType }
+              | undefined;
+            documents: Array<{
+              id: string;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+          };
+        };
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+        currentState?:
+          | { description?: any | undefined; displayName: string }
+          | undefined;
+        states: Array<{ description?: any | undefined; displayName: string }>;
+      };
+    };
+    subspaces: Array<{
+      id: string;
+      nameID: string;
+      pinned: boolean;
+      sortOrder: number;
+      about: {
+        id: string;
+        why?: any | undefined;
+        who?: any | undefined;
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+        profile: {
+          id: string;
+          displayName: string;
+          description?: any | undefined;
+          url: string;
+          tagline?: string | undefined;
+          references?:
+            | Array<{
+                id: string;
+                name: string;
+                uri: string;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          tagsets?:
+            | Array<{
+                id: string;
+                name: string;
+                tags: Array<string>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          location?:
+            | { country?: string | undefined; city?: string | undefined }
+            | undefined;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          storageBucket: {
+            id: string;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            parentEntity?:
+              | { displayName: string; type: SchemaTypes.ProfileType }
+              | undefined;
+            documents: Array<{
+              id: string;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+          };
+        };
+        metrics?:
+          | Array<{ id: string; name: string; value: string }>
+          | undefined;
+        provider?: { id: string } | undefined;
+      };
+      collaboration: {
+        id: string;
+        calloutsSet: {
+          id: string;
+          callouts: Array<{
+            id: string;
+            activity: number;
+            nameID: string;
+            publishedDate?: Date | undefined;
+            sortOrder: number;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            comments?:
+              | {
+                  id: string;
+                  messagesCount: number;
+                  messages: Array<{ message: any }>;
+                }
+              | undefined;
+            contributions: Array<{
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              createdBy?: { email: string } | undefined;
+              link?:
+                | {
+                    id: string;
+                    uri: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | {
+                              displayName: string;
+                              type: SchemaTypes.ProfileType;
+                            }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                    };
+                  }
+                | undefined;
+              post?:
+                | {
+                    id: string;
+                    nameID: string;
+                    createdDate: Date;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: SchemaTypes.VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | {
+                              displayName: string;
+                              type: SchemaTypes.ProfileType;
+                            }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                    comments: {
+                      id: string;
+                      messagesCount: number;
+                      messages: Array<{
+                        id: any;
+                        message: any;
+                        sender?: { id: string } | undefined;
+                      }>;
+                    };
+                    createdBy?: { email: string } | undefined;
+                  }
+                | undefined;
+              whiteboard?:
+                | {
+                    id: string;
+                    nameID: string;
+                    content: any;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: SchemaTypes.VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | {
+                              displayName: string;
+                              type: SchemaTypes.ProfileType;
+                            }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                  }
+                | undefined;
+            }>;
+            createdBy?: { email: string } | undefined;
+            framing: {
+              id: string;
+              profile: {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                url: string;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                storageBucket: {
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  parentEntity?:
+                    | { displayName: string; type: SchemaTypes.ProfileType }
+                    | undefined;
+                  documents: Array<{
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>;
+                };
+              };
+              whiteboard?:
+                | {
+                    id: string;
+                    nameID: string;
+                    profile: {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      url: string;
+                      tagline?: string | undefined;
+                      visual?:
+                        | {
+                            __typename: "Visual";
+                            id: string;
+                            uri: string;
+                            name: SchemaTypes.VisualType;
+                          }
+                        | undefined;
+                      storageBucket: {
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                        parentEntity?:
+                          | {
+                              displayName: string;
+                              type: SchemaTypes.ProfileType;
+                            }
+                          | undefined;
+                        documents: Array<{
+                          id: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>;
+                      };
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    };
+                  }
+                | undefined;
+            };
+            publishedBy?: { email: string } | undefined;
+            settings: {
+              visibility: SchemaTypes.CalloutVisibility;
+              framing: { commentsEnabled: boolean };
+              contribution: {
+                enabled: boolean;
+                canAddContributions: SchemaTypes.CalloutAllowedActors;
+                commentsEnabled: boolean;
+              };
+            };
+          }>;
+        };
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+        innovationFlow: {
+          id: string;
+          profile: {
+            id: string;
+            displayName: string;
+            description?: any | undefined;
+            url: string;
+            tagline?: string | undefined;
+            references?:
+              | Array<{
+                  id: string;
+                  name: string;
+                  uri: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>
+              | undefined;
+            tagsets?:
+              | Array<{
+                  id: string;
+                  name: string;
+                  tags: Array<string>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>
+              | undefined;
+            location?:
+              | { country?: string | undefined; city?: string | undefined }
+              | undefined;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+            storageBucket: {
+              id: string;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              parentEntity?:
+                | { displayName: string; type: SchemaTypes.ProfileType }
+                | undefined;
+              documents: Array<{
+                id: string;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+            };
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          currentState?:
+            | { description?: any | undefined; displayName: string }
+            | undefined;
+          states: Array<{ description?: any | undefined; displayName: string }>;
+        };
+      };
+      authorization?:
+        | {
+            myPrivileges?:
+              | Array<SchemaTypes.AuthorizationPrivilege>
+              | undefined;
+          }
+        | undefined;
+      community: {
+        id: string;
+        authorization?:
+          | {
+              myPrivileges?:
+                | Array<SchemaTypes.AuthorizationPrivilege>
+                | undefined;
+            }
+          | undefined;
+        groups: Array<{
+          id: string;
+          members?:
+            | Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: SchemaTypes.VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>
+            | undefined;
+          profile?:
+            | {
+                id: string;
+                displayName: string;
+                description?: any | undefined;
+                url: string;
+                tagline?: string | undefined;
+                references?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      uri: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                tagsets?:
+                  | Array<{
+                      id: string;
+                      name: string;
+                      tags: Array<string>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }>
+                  | undefined;
+                location?:
+                  | { country?: string | undefined; city?: string | undefined }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+                storageBucket: {
+                  id: string;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  parentEntity?:
+                    | { displayName: string; type: SchemaTypes.ProfileType }
+                    | undefined;
+                  documents: Array<{
+                    id: string;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                  }>;
+                };
+              }
+            | undefined;
+        }>;
+        roleSet: {
+          id: string;
+          applications: Array<{
+            id: string;
+            state: string;
+            nextEvents: Array<string>;
+            isFinalized: boolean;
+            lifecycle: { id: string };
+            questions: Array<{ id: string }>;
+            actor: {
+              id: string;
+              profile?: { id: string; displayName: string } | undefined;
+            };
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          memberUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          leadUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          adminUsers: Array<{
+            id: string;
+            nameID: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          memberOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: SchemaTypes.VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | {
+                                      displayName: string;
+                                      type: SchemaTypes.ProfileType;
+                                    }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: SchemaTypes.OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          leadOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: SchemaTypes.VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | {
+                                      displayName: string;
+                                      type: SchemaTypes.ProfileType;
+                                    }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: SchemaTypes.OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+          adminOrganizations: Array<{
+            id: string;
+            nameID: string;
+            legalEntityName?: string | undefined;
+            domain?: string | undefined;
+            website?: string | undefined;
+            contactEmail?: string | undefined;
+            roleSet: {
+              id: string;
+              usersInRole: Array<{
+                id: string;
+                nameID: string;
+                firstName: string;
+                lastName: string;
+                email: string;
+                profile?:
+                  | {
+                      id: string;
+                      displayName: string;
+                      description?: any | undefined;
+                      tagline?: string | undefined;
+                      references?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            uri: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      tagsets?:
+                        | Array<{
+                            id: string;
+                            name: string;
+                            tags: Array<string>;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                          }>
+                        | undefined;
+                      location?:
+                        | {
+                            country?: string | undefined;
+                            city?: string | undefined;
+                          }
+                        | undefined;
+                      visuals: Array<{
+                        id: string;
+                        name: SchemaTypes.VisualType;
+                        uri: string;
+                      }>;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+            };
+            account?:
+              | {
+                  id: string;
+                  spaces: Array<{ id: string }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  host?:
+                    | {
+                        id: string;
+                        profile?:
+                          | {
+                              id: string;
+                              displayName: string;
+                              description?: any | undefined;
+                              url: string;
+                              tagline?: string | undefined;
+                              references?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    uri: string;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              tagsets?:
+                                | Array<{
+                                    id: string;
+                                    name: string;
+                                    tags: Array<string>;
+                                    authorization?:
+                                      | {
+                                          myPrivileges?:
+                                            | Array<SchemaTypes.AuthorizationPrivilege>
+                                            | undefined;
+                                        }
+                                      | undefined;
+                                  }>
+                                | undefined;
+                              location?:
+                                | {
+                                    country?: string | undefined;
+                                    city?: string | undefined;
+                                  }
+                                | undefined;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              storageBucket: {
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                                parentEntity?:
+                                  | {
+                                      displayName: string;
+                                      type: SchemaTypes.ProfileType;
+                                    }
+                                  | undefined;
+                                documents: Array<{
+                                  id: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>;
+                              };
+                            }
+                          | undefined;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            actor: { id: string };
+            profile?:
+              | {
+                  id: string;
+                  displayName: string;
+                  description?: any | undefined;
+                  tagline?: string | undefined;
+                  references?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        uri: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  tagsets?:
+                    | Array<{
+                        id: string;
+                        name: string;
+                        tags: Array<string>;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>
+                    | undefined;
+                  location?:
+                    | {
+                        country?: string | undefined;
+                        city?: string | undefined;
+                      }
+                    | undefined;
+                  visuals: Array<{
+                    id: string;
+                    name: SchemaTypes.VisualType;
+                    uri: string;
+                  }>;
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            verification: {
+              id: string;
+              status: SchemaTypes.OrganizationVerificationEnum;
+              state: string;
+              nextEvents: Array<string>;
+              isFinalized: boolean;
+              authorization?:
+                | {
+                    myPrivileges?:
+                      | Array<SchemaTypes.AuthorizationPrivilege>
+                      | undefined;
+                  }
+                | undefined;
+              lifecycle: { id: string };
+            };
+            settings: {
+              privacy: { contributionRolesPubliclyVisible: boolean };
+              membership: { allowUsersMatchingDomainToJoin: boolean };
+            };
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          }>;
+        };
+        communication: {
+          id: string;
+          updates: {
+            id: string;
+            messages: Array<{
+              __typename: "Message";
+              id: any;
+              message: any;
+              threadID?: any | undefined;
+              reactions: Array<{
+                __typename: "Reaction";
+                id: any;
+                emoji: any;
+                sender?:
+                  | {
+                      __typename: "User";
+                      id: string;
+                      profile?:
+                        | {
+                            __typename: "Profile";
+                            id: string;
+                            displayName: string;
+                          }
+                        | undefined;
+                    }
+                  | undefined;
+              }>;
+              sender?:
+                | {
+                    __typename: "Actor";
+                    id: string;
+                    profile?:
+                      | {
+                          __typename: "Profile";
+                          id: string;
+                          displayName: string;
+                          url: string;
+                          description?: any | undefined;
+                          tagsets?:
+                            | Array<{
+                                __typename: "Tagset";
+                                id: string;
+                                name: string;
+                                tags: Array<string>;
+                                allowedValues: Array<string>;
+                                type: SchemaTypes.TagsetType;
+                              }>
+                            | undefined;
+                          location?:
+                            | {
+                                __typename: "Location";
+                                id: string;
+                                country?: string | undefined;
+                                city?: string | undefined;
+                              }
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+            }>;
+            authorization?:
+              | {
+                  myPrivileges?:
+                    | Array<SchemaTypes.AuthorizationPrivilege>
+                    | undefined;
+                }
+              | undefined;
+          };
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+        };
+      };
+    }>;
+    settings: {
+      sortMode: SchemaTypes.SpaceSortMode;
+      privacy: {
+        mode: SchemaTypes.SpacePrivacyMode;
+        allowPlatformSupportAsAdmin: boolean;
+      };
+      membership: {
+        allowSubspaceAdminsToInviteMembers: boolean;
+        policy: SchemaTypes.CommunityMembershipPolicy;
+        trustedOrganizations: Array<string>;
+      };
+      collaboration: {
+        allowMembersToCreateCallouts: boolean;
+        allowMembersToCreateSubspaces: boolean;
+        inheritMembershipRights: boolean;
+        allowEventsFromSubspaces: boolean;
+        allowMembersToVideoCall: boolean;
+      };
+    };
+    templatesManager?:
+      | {
+          id: string;
+          authorization?:
+            | {
+                myPrivileges?:
+                  | Array<SchemaTypes.AuthorizationPrivilege>
+                  | undefined;
+              }
+            | undefined;
+          templatesSet?:
+            | {
+                id: string;
+                spaceTemplates: Array<{
+                  id: string;
+                  type: SchemaTypes.TemplateType;
+                  profile: {
+                    displayName: string;
+                    description?: any | undefined;
+                    id: string;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                postTemplates: Array<{
+                  id: string;
+                  type: SchemaTypes.TemplateType;
+                  postDefaultDescription?: any | undefined;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                whiteboardTemplates: Array<{
+                  id: string;
+                  type: SchemaTypes.TemplateType;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  whiteboard?:
+                    | {
+                        id: string;
+                        content: any;
+                        profile: {
+                          id: string;
+                          displayName: string;
+                          description?: any | undefined;
+                          url: string;
+                          tagline?: string | undefined;
+                          references?:
+                            | Array<{
+                                id: string;
+                                name: string;
+                                uri: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>
+                            | undefined;
+                          tagsets?:
+                            | Array<{
+                                id: string;
+                                name: string;
+                                tags: Array<string>;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>
+                            | undefined;
+                          location?:
+                            | {
+                                country?: string | undefined;
+                                city?: string | undefined;
+                              }
+                            | undefined;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                          storageBucket: {
+                            id: string;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            parentEntity?:
+                              | {
+                                  displayName: string;
+                                  type: SchemaTypes.ProfileType;
+                                }
+                              | undefined;
+                            documents: Array<{
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                            }>;
+                          };
+                        };
+                      }
+                    | undefined;
+                }>;
+                communityGuidelinesTemplates: Array<{
+                  id: string;
+                  type: SchemaTypes.TemplateType;
+                  profile: {
+                    displayName: string;
+                    description?: any | undefined;
+                    id: string;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                }>;
+                calloutTemplates: Array<{
+                  id: string;
+                  type: SchemaTypes.TemplateType;
+                  profile: {
+                    id: string;
+                    displayName: string;
+                    description?: any | undefined;
+                    url: string;
+                    tagline?: string | undefined;
+                    references?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          uri: string;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    tagsets?:
+                      | Array<{
+                          id: string;
+                          name: string;
+                          tags: Array<string>;
+                          authorization?:
+                            | {
+                                myPrivileges?:
+                                  | Array<SchemaTypes.AuthorizationPrivilege>
+                                  | undefined;
+                              }
+                            | undefined;
+                        }>
+                      | undefined;
+                    location?:
+                      | {
+                          country?: string | undefined;
+                          city?: string | undefined;
+                        }
+                      | undefined;
+                    authorization?:
+                      | {
+                          myPrivileges?:
+                            | Array<SchemaTypes.AuthorizationPrivilege>
+                            | undefined;
+                        }
+                      | undefined;
+                    storageBucket: {
+                      id: string;
+                      authorization?:
+                        | {
+                            myPrivileges?:
+                              | Array<SchemaTypes.AuthorizationPrivilege>
+                              | undefined;
+                          }
+                        | undefined;
+                      parentEntity?:
+                        | { displayName: string; type: SchemaTypes.ProfileType }
+                        | undefined;
+                      documents: Array<{
+                        id: string;
+                        authorization?:
+                          | {
+                              myPrivileges?:
+                                | Array<SchemaTypes.AuthorizationPrivilege>
+                                | undefined;
+                            }
+                          | undefined;
+                      }>;
+                    };
+                  };
+                  authorization?:
+                    | {
+                        myPrivileges?:
+                          | Array<SchemaTypes.AuthorizationPrivilege>
+                          | undefined;
+                      }
+                    | undefined;
+                  callout?:
+                    | {
+                        id: string;
+                        framing: {
+                          profile: {
+                            id: string;
+                            displayName: string;
+                            description?: any | undefined;
+                            url: string;
+                            tagline?: string | undefined;
+                            references?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  uri: string;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            tagsets?:
+                              | Array<{
+                                  id: string;
+                                  name: string;
+                                  tags: Array<string>;
+                                  authorization?:
+                                    | {
+                                        myPrivileges?:
+                                          | Array<SchemaTypes.AuthorizationPrivilege>
+                                          | undefined;
+                                      }
+                                    | undefined;
+                                }>
+                              | undefined;
+                            location?:
+                              | {
+                                  country?: string | undefined;
+                                  city?: string | undefined;
+                                }
+                              | undefined;
+                            authorization?:
+                              | {
+                                  myPrivileges?:
+                                    | Array<SchemaTypes.AuthorizationPrivilege>
+                                    | undefined;
+                                }
+                              | undefined;
+                            storageBucket: {
+                              id: string;
+                              authorization?:
+                                | {
+                                    myPrivileges?:
+                                      | Array<SchemaTypes.AuthorizationPrivilege>
+                                      | undefined;
+                                  }
+                                | undefined;
+                              parentEntity?:
+                                | {
+                                    displayName: string;
+                                    type: SchemaTypes.ProfileType;
+                                  }
+                                | undefined;
+                              documents: Array<{
+                                id: string;
+                                authorization?:
+                                  | {
+                                      myPrivileges?:
+                                        | Array<SchemaTypes.AuthorizationPrivilege>
+                                        | undefined;
+                                    }
+                                  | undefined;
+                              }>;
+                            };
+                          };
+                        };
+                      }
+                    | undefined;
+                }>;
+                authorization?:
+                  | {
+                      myPrivileges?:
+                        | Array<SchemaTypes.AuthorizationPrivilege>
+                        | undefined;
+                    }
+                  | undefined;
+              }
+            | undefined;
+          templateDefaults: Array<{ id: string }>;
+        }
+      | undefined;
+  };
+};
+
 export type DeleteDocumentMutationVariables = SchemaTypes.Exact<{
   deleteData: SchemaTypes.DeleteDocumentInput;
 }>;
@@ -92146,6 +97301,7 @@ export type SearchQuery = {
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
+        | { type: SchemaTypes.SearchResultType }
         | {
             type: SchemaTypes.SearchResultType;
             parentSpace?:
@@ -92191,6 +97347,7 @@ export type SearchQuery = {
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
+        | { type: SchemaTypes.SearchResultType }
       >;
     };
     contributionResults: {
@@ -92215,6 +97372,7 @@ export type SearchQuery = {
           }
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
+        | { type: SchemaTypes.SearchResultType }
         | {
             type: SchemaTypes.SearchResultType;
             post: { id: string; profile: { displayName: string } };
@@ -92235,6 +97393,7 @@ export type SearchQuery = {
     };
     actorResults: {
       results: Array<
+        | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
         | { type: SchemaTypes.SearchResultType }
         | {
@@ -110826,6 +115985,14 @@ export const MoveSpaceL1ToSpaceL2Document = gql`
   }
   ${SpaceDataFragmentDoc}
 `;
+export const MoveSpaceL2ToSpaceL1Document = gql`
+  mutation MoveSpaceL2ToSpaceL1($moveData: MoveSpaceL2ToSpaceL1Input!) {
+    moveSpaceL2ToSpaceL1(moveData: $moveData) {
+      ...SpaceData
+    }
+  }
+  ${SpaceDataFragmentDoc}
+`;
 export const DeleteDocumentDocument = gql`
   mutation DeleteDocument($deleteData: DeleteDocumentInput!) {
     deleteDocument(deleteData: $deleteData) {
@@ -113515,6 +118682,7 @@ const ConvertSpaceL2ToSpaceL1DocumentString = print(
 );
 const MoveSpaceL1ToSpaceL0DocumentString = print(MoveSpaceL1ToSpaceL0Document);
 const MoveSpaceL1ToSpaceL2DocumentString = print(MoveSpaceL1ToSpaceL2Document);
+const MoveSpaceL2ToSpaceL1DocumentString = print(MoveSpaceL2ToSpaceL1Document);
 const DeleteDocumentDocumentString = print(DeleteDocumentDocument);
 const CreateSpaceBasicDataDocumentString = print(CreateSpaceBasicDataDocument);
 const DeleteSpaceDocumentString = print(DeleteSpaceDocument);
@@ -115004,6 +120172,28 @@ export function getSdk(
             { ...requestHeaders, ...wrappedRequestHeaders }
           ),
         "MoveSpaceL1ToSpaceL2",
+        "mutation",
+        variables
+      );
+    },
+    MoveSpaceL2ToSpaceL1(
+      variables: SchemaTypes.MoveSpaceL2ToSpaceL1MutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders
+    ): Promise<{
+      data: SchemaTypes.MoveSpaceL2ToSpaceL1Mutation;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<SchemaTypes.MoveSpaceL2ToSpaceL1Mutation>(
+            MoveSpaceL2ToSpaceL1DocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        "MoveSpaceL2ToSpaceL1",
         "mutation",
         variables
       );

--- a/lib/src/scenario/graphql/mutations/convert/moveSpaceL2ToSpaceL1.graphql
+++ b/lib/src/scenario/graphql/mutations/convert/moveSpaceL2ToSpaceL1.graphql
@@ -1,0 +1,7 @@
+mutation MoveSpaceL2ToSpaceL1(
+  $moveData: MoveSpaceL2ToSpaceL1Input!
+) {
+  moveSpaceL2ToSpaceL1(moveData: $moveData) {
+    ...SpaceData
+  }
+}

--- a/server-api/src/functional-api/journey/conversion/conversion.request.params.ts
+++ b/server-api/src/functional-api/journey/conversion/conversion.request.params.ts
@@ -104,3 +104,35 @@ export const moveSpaceL1ToSpaceL2 = async (
 
   return graphqlErrorWrapper(callback, role);
 };
+
+export const moveSpaceL2ToSpaceL1 = async (
+  spaceL2ID: string,
+  targetSpaceL1ID: string,
+  options?: {
+    autoInvite?: boolean;
+    invitationMessage?: string;
+  },
+  role = TestUser.GLOBAL_ADMIN
+) => {
+  const graphqlClient = getGraphqlClient();
+  const callback = (authToken: string | undefined) =>
+    graphqlClient.MoveSpaceL2ToSpaceL1(
+      {
+        moveData: {
+          spaceL2ID,
+          targetSpaceL1ID,
+          ...(options?.autoInvite !== undefined && {
+            autoInvite: options.autoInvite,
+          }),
+          ...(options?.invitationMessage !== undefined && {
+            invitationMessage: options.invitationMessage,
+          }),
+        },
+      },
+      {
+        authorization: `Bearer ${authToken}`,
+      }
+    );
+
+  return graphqlErrorWrapper(callback, role);
+};

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
@@ -212,12 +212,12 @@ describe('Move L1 to L0 - validation errors', () => {
  * keeps stale anonymous READ (a visibility leak of a subspace inside a private
  * space), and a private→public move keeps a stale lockout.
  *
- * ⚠️ EXPECTED TO FAIL against a server whose moveSpaceL1ToSpaceL0 omits
- * `updatePlatformRolesAccessRecursively` (alkem-io/server develop as of this
- * writing). The two "BEFORE the move" baselines pass; the two "after moving"
- * assertions fail until the server adds the recompute (see the resolver's
- * moveSpaceL2ToSpaceL1 for the reference call). Mirrors
- * move-L2-to-L1-authorization.it-spec.ts.
+ * ⚠️ These fail against a server that omits the recompute in moveSpaceL1ToSpaceL0
+ * (i.e. alkem-io/server before alkem-io/server#6304 / issue #6303) and pass once
+ * that fix is deployed. The two "after moving" tests each re-assert the anonymous
+ * precondition inline before the move, so a scenario that fails to grant anonymous
+ * read fails LOUDLY as a setup error instead of masking the leak with a vacuous
+ * [] → []. Mirrors move-L2-to-L1-authorization.it-spec.ts.
  */
 const anonymousSpacePrivileges = async (spaceId: string) => {
   const graphqlClient = getGraphqlClient();
@@ -296,6 +296,14 @@ describe('Move L1 to L0 - privacy recompute (platform-level anonymous access)', 
     });
 
     test('after moving into the private L0, anonymous access is revoked entirely', async () => {
+      // Precondition guard: the public source MUST grant anonymous read here,
+      // else the post-move [] would be a vacuous pass that hides the leak.
+      const before = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(
+        before,
+        'precondition: anonymous must be able to read the PUBLIC source L1 before the move — if this is [], the scenario is not establishing anonymous read and the test below would pass vacuously'
+      ).toEqual(sorted_read_readAbout_readLicense);
+
       const res = await moveSpaceL1ToSpaceL0(
         sourceScenario.subspace.id,
         targetScenario.space.id

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
@@ -212,12 +212,13 @@ describe('Move L1 to L0 - validation errors', () => {
  * keeps stale anonymous READ (a visibility leak of a subspace inside a private
  * space), and a private→public move keeps a stale lockout.
  *
- * ⚠️ These fail against a server that omits the recompute in moveSpaceL1ToSpaceL0
- * (i.e. alkem-io/server before alkem-io/server#6304 / issue #6303) and pass once
- * that fix is deployed. The two "after moving" tests each re-assert the anonymous
- * precondition inline before the move, so a scenario that fails to grant anonymous
- * read fails LOUDLY as a setup error instead of masking the leak with a vacuous
- * [] → []. Mirrors move-L2-to-L1-authorization.it-spec.ts.
+ * The recompute in moveSpaceL1ToSpaceL0 landed in alkem-io/server#6304 (fixes
+ * #6303), so these pass against current server. They were red before that fix.
+ * The two "after moving" tests each re-assert the anonymous precondition inline
+ * before the move, so a scenario that fails to grant anonymous read fails LOUDLY
+ * as a setup error instead of masking a regression with a vacuous [] → []. If
+ * the recompute is ever reverted, the "after moving" assertions go red again.
+ * Mirrors move-L2-to-L1-authorization.it-spec.ts.
  */
 const anonymousSpacePrivileges = async (spaceId: string) => {
   const graphqlClient = getGraphqlClient();

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L0-authorization.it-spec.ts
@@ -2,11 +2,18 @@ import {
   TestScenarioConfig,
   TestScenarioFactory,
   TestUser,
+  getGraphqlClient,
+  sorted_read_readAbout_readLicense,
 } from '@alkemio/tests-lib';
+import { graphqlErrorWrapper } from '@alkemio/tests-lib/utils/graphql.wrapper';
 import { moveSpaceL1ToSpaceL0 } from './conversion.request.params';
 import { getSpaceData } from '../space/space.request.params';
 import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
-import { SpaceLevel } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  CommunityMembershipPolicy,
+  SpaceLevel,
+  SpacePrivacyMode,
+} from '@alkemio/tests-lib/core/generated/alkemio-schema';
 
 let sourceScenario: OrganizationWithSpaceModel;
 let targetScenario: OrganizationWithSpaceModel;
@@ -190,5 +197,177 @@ describe('Move L1 to L0 - validation errors', () => {
     );
 
     expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Move L1 to L0 - privacy recompute (platform-level anonymous access)
+ *
+ * A cross-L0 move must RECOMPUTE the moved subtree's platformRolesAccess from
+ * the NEW parent hierarchy before the authorization policy is re-applied — as
+ * moveSpaceL2ToSpaceL1 and convertSpaceL1ToSpaceL0 already do. That persisted
+ * jsonb field gates anonymous/guest/registered READ, and applyAuthorizationPolicy
+ * only READS it (server: space.service.authorization.ts) — it never re-derives
+ * it. If the move omits the recompute, a public L1 dragged into a PRIVATE L0
+ * keeps stale anonymous READ (a visibility leak of a subspace inside a private
+ * space), and a private→public move keeps a stale lockout.
+ *
+ * ⚠️ EXPECTED TO FAIL against a server whose moveSpaceL1ToSpaceL0 omits
+ * `updatePlatformRolesAccessRecursively` (alkem-io/server develop as of this
+ * writing). The two "BEFORE the move" baselines pass; the two "after moving"
+ * assertions fail until the server adds the recompute (see the resolver's
+ * moveSpaceL2ToSpaceL1 for the reference call). Mirrors
+ * move-L2-to-L1-authorization.it-spec.ts.
+ */
+const anonymousSpacePrivileges = async (spaceId: string) => {
+  const graphqlClient = getGraphqlClient();
+  const callback = (authToken: string | undefined) =>
+    graphqlClient.PrivateSpaceData(
+      { nameId: spaceId },
+      authToken ? { authorization: `Bearer ${authToken}` } : {}
+    );
+  const request = await graphqlErrorWrapper(callback);
+  return request?.data?.lookup?.space?.authorization?.myPrivileges?.sort() ?? [];
+};
+
+// Source: public L0 → public L1 (the L1 leaf we move).
+const privacyPublicSourceConfig: TestScenarioConfig = {
+  name: 'move-l1-l0-priv-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    settings: {
+      privacy: { mode: SpacePrivacyMode.Public },
+      membership: { policy: CommunityMembershipPolicy.Applications },
+    },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      settings: { privacy: { mode: SpacePrivacyMode.Public } },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+describe('Move L1 to L0 - privacy recompute (platform-level anonymous access)', () => {
+  describe('public source → private destination L0 revokes anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    const privateTargetConfig: TestScenarioConfig = {
+      name: 'move-l1-l0-pub2priv-tgt',
+      space: {
+        collaboration: { addPostCallout: true },
+        settings: { privacy: { mode: SpacePrivacyMode.Private } },
+        community: {
+          admins: [TestUser.SPACE_ADMIN],
+          members: [TestUser.SPACE_MEMBER],
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario = await TestScenarioFactory.createBaseScenario({
+        ...privacyPublicSourceConfig,
+        name: 'move-l1-l0-pub2priv-src',
+      });
+      targetScenario =
+        await TestScenarioFactory.createBaseScenario(privateTargetConfig);
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous can read the public L1 BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
+
+    test('after moving into the private L0, anonymous access is revoked entirely', async () => {
+      const res = await moveSpaceL1ToSpaceL0(
+        sourceScenario.subspace.id,
+        targetScenario.space.id
+      );
+      expect(res.data?.moveSpaceL1ToSpaceL0).toBeDefined();
+
+      // Recomputed from the NEW (private) L0: anonymous loses ALL access. A
+      // stale platformRolesAccess (no recompute) leaves anonymous READ on a
+      // subspace inside a private space — the visibility leak this test guards.
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual([]);
+    });
+  });
+
+  describe('private source → public destination L0 grants anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    // Source L0 PRIVATE; the L1 leaf itself stays PUBLIC (via the spread), so
+    // any anonymous access it has must come from the chain, not its own mode.
+    const privateSourceConfig: TestScenarioConfig = {
+      ...privacyPublicSourceConfig,
+      name: 'move-l1-l0-priv2pub-src',
+      space: {
+        ...privacyPublicSourceConfig.space!,
+        settings: {
+          privacy: { mode: SpacePrivacyMode.Private },
+          membership: { policy: CommunityMembershipPolicy.Applications },
+        },
+      },
+    };
+
+    const publicTargetConfig: TestScenarioConfig = {
+      name: 'move-l1-l0-priv2pub-tgt',
+      space: {
+        collaboration: { addPostCallout: true },
+        settings: { privacy: { mode: SpacePrivacyMode.Public } },
+        community: {
+          admins: [TestUser.SPACE_ADMIN],
+          members: [TestUser.SPACE_MEMBER],
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario =
+        await TestScenarioFactory.createBaseScenario(privateSourceConfig);
+      targetScenario =
+        await TestScenarioFactory.createBaseScenario(publicTargetConfig);
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous has no access to the public L1 under a private L0 BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual([]);
+    });
+
+    test('after moving into the public L0, anonymous can read (no stale lockout)', async () => {
+      const res = await moveSpaceL1ToSpaceL0(
+        sourceScenario.subspace.id,
+        targetScenario.space.id
+      );
+      expect(res.data?.moveSpaceL1ToSpaceL0).toBeDefined();
+
+      // Recomputed from the NEW (public) L0: the public L1 regains full READ. A
+      // stale platformRolesAccess would keep it locked out under the old chain.
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
   });
 });

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
@@ -2,11 +2,18 @@ import {
   TestScenarioConfig,
   TestScenarioFactory,
   TestUser,
+  getGraphqlClient,
+  sorted_read_readAbout_readLicense,
 } from '@alkemio/tests-lib';
+import { graphqlErrorWrapper } from '@alkemio/tests-lib/utils/graphql.wrapper';
 import { moveSpaceL1ToSpaceL2 } from './conversion.request.params';
 import { getSpaceData } from '../space/space.request.params';
 import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
-import { SpaceLevel } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import {
+  CommunityMembershipPolicy,
+  SpaceLevel,
+  SpacePrivacyMode,
+} from '@alkemio/tests-lib/core/generated/alkemio-schema';
 
 let sourceScenario: OrganizationWithSpaceModel;
 let targetScenario: OrganizationWithSpaceModel;
@@ -248,5 +255,193 @@ describe('Move L1 to L2 - validation errors', () => {
     );
 
     expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Move L1 to L2 - privacy recompute (platform-level anonymous access)
+ *
+ * A cross-L0 move+demotion must RECOMPUTE the moved subtree's platformRolesAccess
+ * from the NEW parent hierarchy (target L0 → target L1) before the authorization
+ * policy is re-applied — as moveSpaceL2ToSpaceL1 and convertSpaceL1ToSpaceL0
+ * already do. That persisted jsonb field gates anonymous/guest/registered READ,
+ * and applyAuthorizationPolicy only READS it (server: space.service.authorization.ts).
+ * If the move omits the recompute, a public L1 demoted into a PRIVATE chain keeps
+ * stale anonymous READ (visibility leak), and a private→public move keeps a stale
+ * lockout.
+ *
+ * ⚠️ EXPECTED TO FAIL against a server whose moveSpaceL1ToSpaceL2 omits
+ * `updatePlatformRolesAccessRecursively` (alkem-io/server develop as of this
+ * writing). The two "BEFORE the move" baselines pass; the two "after moving"
+ * assertions fail until the server adds the recompute. Mirrors
+ * move-L2-to-L1-authorization.it-spec.ts.
+ */
+const anonymousSpacePrivileges = async (spaceId: string) => {
+  const graphqlClient = getGraphqlClient();
+  const callback = (authToken: string | undefined) =>
+    graphqlClient.PrivateSpaceData(
+      { nameId: spaceId },
+      authToken ? { authorization: `Bearer ${authToken}` } : {}
+    );
+  const request = await graphqlErrorWrapper(callback);
+  return request?.data?.lookup?.space?.authorization?.myPrivileges?.sort() ?? [];
+};
+
+// Source: public L0 → public L1 (the L1 leaf we move; it becomes an L2).
+const privacyPublicSourceConfig: TestScenarioConfig = {
+  name: 'move-l1-l2-priv-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    settings: {
+      privacy: { mode: SpacePrivacyMode.Public },
+      membership: { policy: CommunityMembershipPolicy.Applications },
+    },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      settings: { privacy: { mode: SpacePrivacyMode.Public } },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+describe('Move L1 to L2 - privacy recompute (platform-level anonymous access)', () => {
+  describe('public source → private destination chain revokes anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    // Destination chain (target L0 + target L1) is PRIVATE.
+    const privateTargetConfig: TestScenarioConfig = {
+      name: 'move-l1-l2-pub2priv-tgt',
+      space: {
+        collaboration: { addPostCallout: true },
+        settings: { privacy: { mode: SpacePrivacyMode.Private } },
+        community: {
+          admins: [TestUser.SPACE_ADMIN],
+          members: [TestUser.SPACE_MEMBER],
+        },
+        subspace: {
+          collaboration: { addPostCallout: true },
+          settings: { privacy: { mode: SpacePrivacyMode.Private } },
+          community: {
+            admins: [TestUser.SUBSPACE_ADMIN],
+            members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario = await TestScenarioFactory.createBaseScenario({
+        ...privacyPublicSourceConfig,
+        name: 'move-l1-l2-pub2priv-src',
+      });
+      targetScenario =
+        await TestScenarioFactory.createBaseScenario(privateTargetConfig);
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous can read the public L1 BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
+
+    test('after demotion into the private chain, anonymous access is revoked entirely', async () => {
+      const res = await moveSpaceL1ToSpaceL2(
+        sourceScenario.subspace.id,
+        targetScenario.subspace.id // target L1 → moved space becomes its L2
+      );
+      expect(res.data?.moveSpaceL1ToSpaceL2).toBeDefined();
+
+      // Recomputed from the NEW (private) chain: anonymous loses ALL access. A
+      // stale platformRolesAccess would leave anonymous READ on a subspace
+      // inside a private space — the visibility leak this test guards.
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual([]);
+    });
+  });
+
+  describe('private source → public destination chain grants anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    // Source L0 PRIVATE; the L1 leaf itself stays PUBLIC (via the spread).
+    const privateSourceConfig: TestScenarioConfig = {
+      ...privacyPublicSourceConfig,
+      name: 'move-l1-l2-priv2pub-src',
+      space: {
+        ...privacyPublicSourceConfig.space!,
+        settings: {
+          privacy: { mode: SpacePrivacyMode.Private },
+          membership: { policy: CommunityMembershipPolicy.Applications },
+        },
+      },
+    };
+
+    // Destination chain (target L0 + target L1) is PUBLIC.
+    const publicTargetConfig: TestScenarioConfig = {
+      name: 'move-l1-l2-priv2pub-tgt',
+      space: {
+        collaboration: { addPostCallout: true },
+        settings: { privacy: { mode: SpacePrivacyMode.Public } },
+        community: {
+          admins: [TestUser.SPACE_ADMIN],
+          members: [TestUser.SPACE_MEMBER],
+        },
+        subspace: {
+          collaboration: { addPostCallout: true },
+          settings: { privacy: { mode: SpacePrivacyMode.Public } },
+          community: {
+            admins: [TestUser.SUBSPACE_ADMIN],
+            members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario =
+        await TestScenarioFactory.createBaseScenario(privateSourceConfig);
+      targetScenario =
+        await TestScenarioFactory.createBaseScenario(publicTargetConfig);
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous has no access to the public L1 under a private chain BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual([]);
+    });
+
+    test('after demotion into the public chain, anonymous can read (no stale lockout)', async () => {
+      const res = await moveSpaceL1ToSpaceL2(
+        sourceScenario.subspace.id,
+        targetScenario.subspace.id
+      );
+      expect(res.data?.moveSpaceL1ToSpaceL2).toBeDefined();
+
+      // Recomputed from the NEW (public) chain: the public (now L2) space
+      // regains full READ. A stale platformRolesAccess would keep it locked out.
+      const privs = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
   });
 });

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
@@ -270,12 +270,13 @@ describe('Move L1 to L2 - validation errors', () => {
  * stale anonymous READ (visibility leak), and a private→public move keeps a stale
  * lockout.
  *
- * ⚠️ These fail against a server that omits the recompute in moveSpaceL1ToSpaceL2
- * (i.e. alkem-io/server before alkem-io/server#6304 / issue #6303) and pass once
- * that fix is deployed. The two "after moving" tests each re-assert the anonymous
- * precondition inline before the move, so a scenario that fails to grant anonymous
- * read fails LOUDLY as a setup error instead of masking the leak with a vacuous
- * [] → []. Mirrors move-L2-to-L1-authorization.it-spec.ts.
+ * The recompute in moveSpaceL1ToSpaceL2 landed in alkem-io/server#6304 (fixes
+ * #6303), so these pass against current server. They were red before that fix.
+ * The two "after moving" tests each re-assert the anonymous precondition inline
+ * before the move, so a scenario that fails to grant anonymous read fails LOUDLY
+ * as a setup error instead of masking a regression with a vacuous [] → []. If
+ * the recompute is ever reverted, the "after moving" assertions go red again.
+ * Mirrors move-L2-to-L1-authorization.it-spec.ts.
  */
 const anonymousSpacePrivileges = async (spaceId: string) => {
   const graphqlClient = getGraphqlClient();

--- a/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L1-to-L2-authorization.it-spec.ts
@@ -270,11 +270,12 @@ describe('Move L1 to L2 - validation errors', () => {
  * stale anonymous READ (visibility leak), and a private→public move keeps a stale
  * lockout.
  *
- * ⚠️ EXPECTED TO FAIL against a server whose moveSpaceL1ToSpaceL2 omits
- * `updatePlatformRolesAccessRecursively` (alkem-io/server develop as of this
- * writing). The two "BEFORE the move" baselines pass; the two "after moving"
- * assertions fail until the server adds the recompute. Mirrors
- * move-L2-to-L1-authorization.it-spec.ts.
+ * ⚠️ These fail against a server that omits the recompute in moveSpaceL1ToSpaceL2
+ * (i.e. alkem-io/server before alkem-io/server#6304 / issue #6303) and pass once
+ * that fix is deployed. The two "after moving" tests each re-assert the anonymous
+ * precondition inline before the move, so a scenario that fails to grant anonymous
+ * read fails LOUDLY as a setup error instead of masking the leak with a vacuous
+ * [] → []. Mirrors move-L2-to-L1-authorization.it-spec.ts.
  */
 const anonymousSpacePrivileges = async (spaceId: string) => {
   const graphqlClient = getGraphqlClient();
@@ -362,6 +363,14 @@ describe('Move L1 to L2 - privacy recompute (platform-level anonymous access)', 
     });
 
     test('after demotion into the private chain, anonymous access is revoked entirely', async () => {
+      // Precondition guard: the public source MUST grant anonymous read here,
+      // else the post-move [] would be a vacuous pass that hides the leak.
+      const before = await anonymousSpacePrivileges(sourceScenario.subspace.id);
+      expect(
+        before,
+        'precondition: anonymous must be able to read the PUBLIC source L1 before the move — if this is [], the scenario is not establishing anonymous read and the test below would pass vacuously'
+      ).toEqual(sorted_read_readAbout_readLicense);
+
       const res = await moveSpaceL1ToSpaceL2(
         sourceScenario.subspace.id,
         targetScenario.subspace.id // target L1 → moved space becomes its L2

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
@@ -12,6 +12,7 @@ import {
   eventOnRoleSetInvitation,
 } from '@functional-api/roleset/roleset-events.request.params';
 import { getSingleInvitationResult } from '@functional-api/roleset/roleset.request.params';
+import { COMBINED_FLOW_REJECTION } from '@functional-api/roleset/hierarchy-parity/hierarchy-parity.fixture';
 import {
   CommunityMembershipPolicy,
   SpacePrivacyMode,
@@ -204,7 +205,11 @@ describe('Move L2 to L1 - pre-existing applications and invitations', () => {
       TestUser.SUBSUBSPACE_MEMBER
     );
 
-    expect(deniedApp.error?.errors?.length).toBeGreaterThan(0);
+    // Assert the specific eligibility denial, not merely that some error
+    // occurred — an unrelated GraphQL failure would otherwise satisfy the test.
+    expect(deniedApp.error?.errors?.[0]?.message).toMatch(
+      COMBINED_FLOW_REJECTION
+    );
     expect(deniedApp.data?.applyForEntryRoleOnRoleSet?.id).toBeUndefined();
   });
 });

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
@@ -190,4 +190,21 @@ describe('Move L2 to L1 - pre-existing applications and invitations', () => {
       'approved'
     );
   });
+
+  test('a wiped former L2 member cannot apply after the move (recomputed eligibility)', async () => {
+    // SUBSUBSPACE_MEMBER was a member of the SOURCE L2; the move wiped that role
+    // and they are absent from the NEW parent chain (target L1). Apply-eligibility
+    // is recomputed from the new hierarchy:
+    //   - tier 1 (direct-parent members): they are NOT a target-L1 member;
+    //   - tier 2 (any authenticated platform user): requires an all-public +
+    //     opted-in chain, and the moved L2's chain is private — so it is off.
+    // Both tiers therefore deny them ROLESET_ENTRY_ROLE_APPLY. The apply must fail.
+    const deniedApp = await createApplication(
+      sourceScenario.subsubspace.community.roleSetId,
+      TestUser.SUBSUBSPACE_MEMBER
+    );
+
+    expect(deniedApp.error?.errors?.length).toBeGreaterThan(0);
+    expect(deniedApp.data?.applyForEntryRoleOnRoleSet?.id).toBeUndefined();
+  });
 });

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
@@ -167,9 +167,19 @@ describe('Move L2 to L1 - pre-existing applications and invitations', () => {
   });
 
   test('new application can be submitted and approved after move', async () => {
+    // Apply as a member of the moved L2's NEW direct parent (target L1). After
+    // the move, apply-eligibility is recomputed from the new hierarchy:
+    //   - direct-parent (target L1) members get ROLESET_ENTRY_ROLE_APPLY
+    //     unconditionally (privacy-independent);
+    //   - the broader "any authenticated platform user" tier applies ONLY when
+    //     every ancestor is public + opted-in — a private L0/L1 removes it.
+    // The moved L2's chain here is private, so a former L2 member
+    // (SUBSUBSPACE_MEMBER, wiped by the move and absent from the new chain)
+    // correctly cannot apply. SUBSPACE_MEMBER is a target-L1 member and not a
+    // member of the wiped L2, so it is genuinely eligible.
     const newApp = await createApplication(
       sourceScenario.subsubspace.community.roleSetId,
-      TestUser.SUBSUBSPACE_MEMBER
+      TestUser.SUBSPACE_MEMBER
     );
     const newAppId = newApp?.data?.applyForEntryRoleOnRoleSet?.id ?? '';
     expect(newAppId).not.toBe('');

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-applications-invitations.it-spec.ts
@@ -1,0 +1,183 @@
+import {
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+  TestUserManager,
+} from '@alkemio/tests-lib';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import { inviteForEntryRoleOnRoleSet } from '@functional-api/roleset/invitations/invitation.request.params';
+import { createApplication } from '@functional-api/roleset/application/application.request.params';
+import {
+  eventOnRoleSetApplication,
+  eventOnRoleSetInvitation,
+} from '@functional-api/roleset/roleset-events.request.params';
+import { getSingleInvitationResult } from '@functional-api/roleset/roleset.request.params';
+import {
+  CommunityMembershipPolicy,
+  SpacePrivacyMode,
+} from '@alkemio/client-lib';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { RoleName } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+
+/**
+ * Move L2 to L1 - pre-existing applications and invitations
+ * (workspace#030-move-subspace-parent, US2-AS1 / FR-004)
+ *
+ * A cross-L0 move drops the moved L2 subspace's pending invitations and
+ * applications along with all community roles. Mirrors
+ * move-L1-to-L2-applications-invitations.it-spec.ts on an L2 source.
+ */
+
+let sourceScenario: OrganizationWithSpaceModel;
+let targetScenario: OrganizationWithSpaceModel;
+let invitationId: string;
+let applicationId: string;
+
+const sourceConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-inv-src',
+  space: {
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+        settings: {
+          membership: { policy: CommunityMembershipPolicy.Applications },
+          privacy: { mode: SpacePrivacyMode.Private },
+        },
+      },
+    },
+  },
+};
+
+const targetConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-inv-tgt',
+  space: {
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+beforeAll(async () => {
+  sourceScenario = await TestScenarioFactory.createBaseScenario(sourceConfig);
+  targetScenario = await TestScenarioFactory.createBaseScenario(targetConfig);
+
+  // Create pending invitation on the L2 before move
+  const invitationData = await inviteForEntryRoleOnRoleSet(
+    sourceScenario.subsubspace.community.roleSetId,
+    [TestUserManager.users.nonSpaceMember.id],
+    [],
+    'welcome before move',
+    [RoleName.Member],
+    TestUser.GLOBAL_ADMIN
+  );
+  const invitationResult = getSingleInvitationResult(invitationData);
+  invitationId = invitationResult?.invitation?.id ?? '';
+
+  // Create pending application on the L2 before move
+  const applicationData = await createApplication(
+    sourceScenario.subsubspace.community.roleSetId,
+    TestUser.SPACE_MEMBER
+  );
+  applicationId = applicationData?.data?.applyForEntryRoleOnRoleSet?.id ?? '';
+
+  // Execute cross-L0 L2→L1 move
+  await moveSpaceL2ToSpaceL1(
+    sourceScenario.subsubspace.id,
+    targetScenario.subspace.id
+  );
+});
+
+afterAll(async () => {
+  await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+  await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+});
+
+describe('Move L2 to L1 - pre-existing applications and invitations', () => {
+  test('pending invitation is invalidated after cross-L0 move (FR-004)', async () => {
+    const acceptResult = await eventOnRoleSetInvitation(
+      invitationId,
+      'ACCEPT',
+      TestUser.NON_SPACE_MEMBER
+    );
+
+    const hasError =
+      acceptResult.error?.errors !== undefined &&
+      acceptResult.error.errors.length > 0;
+    expect(hasError).toBe(true);
+  });
+
+  test('pending application is invalidated after cross-L0 move (FR-004)', async () => {
+    const approveResult = await eventOnRoleSetApplication(
+      applicationId,
+      'APPROVE'
+    );
+
+    const hasError =
+      approveResult.error?.errors !== undefined &&
+      approveResult.error.errors.length > 0;
+    expect(hasError).toBe(true);
+  });
+
+  test('new invitation can be created after move', async () => {
+    const newInvitation = await inviteForEntryRoleOnRoleSet(
+      sourceScenario.subsubspace.community.roleSetId,
+      [TestUserManager.users.qaUser.id],
+      [],
+      'welcome after move',
+      [RoleName.Member],
+      TestUser.GLOBAL_ADMIN
+    );
+
+    const result = getSingleInvitationResult(newInvitation);
+    expect(result?.invitation?.id).toBeDefined();
+  });
+
+  test('new application can be submitted and approved after move', async () => {
+    const newApp = await createApplication(
+      sourceScenario.subsubspace.community.roleSetId,
+      TestUser.SUBSUBSPACE_MEMBER
+    );
+    const newAppId = newApp?.data?.applyForEntryRoleOnRoleSet?.id ?? '';
+    expect(newAppId).not.toBe('');
+
+    const approveResult = await eventOnRoleSetApplication(newAppId, 'APPROVE');
+    expect(approveResult.status).toBe(200);
+    expect(approveResult?.data?.eventOnApplication?.state).toContain(
+      'approved'
+    );
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-authorization.it-spec.ts
@@ -1,5 +1,4 @@
 import {
-  readAboutPrivilege,
   sorted_read_readAbout_readLicense,
   TestScenarioConfig,
   TestScenarioFactory,
@@ -231,19 +230,22 @@ describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', (
       expect(privs).toEqual(sorted_read_readAbout_readLicense);
     });
 
-    test('after moving into the private chain, anonymous read is revoked (recomputed access)', async () => {
+    test('after moving into the private chain, anonymous access is revoked entirely (recomputed access)', async () => {
       const res = await moveSpaceL2ToSpaceL1(
         sourceScenario.subsubspace.id,
         targetScenario.subspace.id
       );
       expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
 
-      // Recomputed platform-access from the NEW (private) chain: anonymous
-      // loses READ and keeps only READ_ABOUT — no residual visibility.
+      // Recomputed platform-access from the NEW (private) chain: a subspace's
+      // anonymous access is gated behind the parent's anonymous READ. The new
+      // parent chain (private L1 under private L0) grants anonymous nothing, so
+      // the moved L2 — even though its own privacy mode is still public — loses
+      // ALL anonymous access, not merely READ. No residual visibility.
       const privs = await anonymousSpacePrivileges(
         sourceScenario.subsubspace.id
       );
-      expect(privs).toEqual(readAboutPrivilege);
+      expect(privs).toEqual([]);
     });
   });
 
@@ -251,7 +253,10 @@ describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', (
     let sourceScenario: OrganizationWithSpaceModel;
     let targetScenario: OrganizationWithSpaceModel;
 
-    // Source top-level chain is PRIVATE.
+    // Source L0 + L1 are PRIVATE; the moved L2 leaf itself stays PUBLIC. This
+    // isolates the recompute: any anonymous access the L2 has must come from
+    // its parent chain, not its own privacy mode — so BEFORE (private chain) it
+    // has none, and AFTER (public chain) it regains full READ. Mirrors block 1.
     const privateSourceConfig: TestScenarioConfig = {
       ...publicSourceConfig,
       name: 'move-l2-l1-priv2pub-src',
@@ -264,10 +269,7 @@ describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', (
         subspace: {
           ...publicSourceConfig.space!.subspace!,
           settings: { privacy: { mode: SpacePrivacyMode.Private } },
-          subspace: {
-            ...publicSourceConfig.space!.subspace!.subspace!,
-            settings: { privacy: { mode: SpacePrivacyMode.Private } },
-          },
+          // L2 leaf left PUBLIC (inherits publicSourceConfig's subsubspace).
         },
       },
     };
@@ -286,11 +288,13 @@ describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', (
       await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
     });
 
-    test('anonymous cannot read the private L2 BEFORE the move', async () => {
+    test('anonymous has no access to the public L2 under a private chain BEFORE the move', async () => {
+      // The L2 is public, but its private parent chain gates anonymous access
+      // to nothing — so anonymous sees the L2 not at all.
       const privs = await anonymousSpacePrivileges(
         sourceScenario.subsubspace.id
       );
-      expect(privs).toEqual(readAboutPrivilege);
+      expect(privs).toEqual([]);
     });
 
     test('after moving into the public chain, anonymous can read (no stale lockout)', async () => {
@@ -300,8 +304,9 @@ describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', (
       );
       expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
 
-      // Recomputed platform-access from the NEW (public) chain: anonymous
-      // regains READ — no lockout from stale rules of the old private chain.
+      // Recomputed platform-access from the NEW (public) chain: the public L2
+      // regains full READ — no lockout from stale rules of the old private
+      // chain, and no partial state.
       const privs = await anonymousSpacePrivileges(
         sourceScenario.subsubspace.id
       );

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-authorization.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-authorization.it-spec.ts
@@ -1,0 +1,311 @@
+import {
+  readAboutPrivilege,
+  sorted_read_readAbout_readLicense,
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+  getGraphqlClient,
+} from '@alkemio/tests-lib';
+import { graphqlErrorWrapper } from '@alkemio/tests-lib/utils/graphql.wrapper';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import { getSpaceData } from '../space/space.request.params';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import {
+  CommunityMembershipPolicy,
+  SpaceLevel,
+  SpacePrivacyMode,
+} from '@alkemio/tests-lib/core/generated/alkemio-schema';
+
+/**
+ * Move L2 to L1 - authorization & privacy recompute
+ * (workspace#030-move-subspace-parent)
+ *
+ * Covers:
+ * - FR-012 / S9: the operation is platform-admin-only at the API. GLOBAL_ADMIN
+ *   succeeds; SPACE_ADMIN / SPACE_MEMBER / NON_SPACE_MEMBER are rejected.
+ * - FR-006 / US2-AS4 / SC-003 / contract S7 (decision log D-5): on every move
+ *   the moved subspace's platform-level access rules are RECOMPUTED from the
+ *   NEW parent chain before the authorization policy is re-applied. We assert
+ *   the RECOMPUTED anonymous access on a differing-privacy pair — not merely
+ *   that a re-apply ran:
+ *     * public source → private destination chain ⇒ anonymous read is revoked
+ *       (drops to READ_ABOUT only): no residual visibility from the old chain.
+ *     * private source → public destination chain ⇒ anonymous can read: no
+ *       lockout from stale rules of the old chain.
+ *
+ * The anonymous probe mirrors graphql-guard-public-private-access.it-spec.ts:
+ * call graphqlErrorWrapper without a role and omit the Authorization header.
+ */
+
+const anonymousSpacePrivileges = async (spaceId: string) => {
+  const graphqlClient = getGraphqlClient();
+  const callback = (authToken: string | undefined) =>
+    graphqlClient.PrivateSpaceData(
+      { nameId: spaceId },
+      authToken ? { authorization: `Bearer ${authToken}` } : {}
+    );
+  const request = await graphqlErrorWrapper(callback);
+  return request?.data?.lookup?.space?.authorization?.myPrivileges?.sort() ?? [];
+};
+
+// Source hierarchy: L0 → L1 → L2, all PUBLIC.
+const publicSourceConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-auth-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    settings: {
+      privacy: { mode: SpacePrivacyMode.Public },
+      membership: { policy: CommunityMembershipPolicy.Applications },
+    },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      settings: { privacy: { mode: SpacePrivacyMode.Public } },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        collaboration: { addPostCallout: true },
+        settings: { privacy: { mode: SpacePrivacyMode.Public } },
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+      },
+    },
+  },
+};
+
+// Target hierarchy: L0 → L1, PUBLIC.
+const publicTargetConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-auth-tgt',
+  space: {
+    collaboration: { addPostCallout: true },
+    settings: { privacy: { mode: SpacePrivacyMode.Public } },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      settings: { privacy: { mode: SpacePrivacyMode.Public } },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+describe('Move L2 to L1 - platform-admin gate (FR-012 / S9)', () => {
+  let sourceScenario: OrganizationWithSpaceModel;
+  let targetScenario: OrganizationWithSpaceModel;
+
+  beforeAll(async () => {
+    sourceScenario = await TestScenarioFactory.createBaseScenario({
+      ...publicSourceConfig,
+      name: 'move-l2-l1-gate-src',
+    });
+    targetScenario = await TestScenarioFactory.createBaseScenario({
+      ...publicTargetConfig,
+      name: 'move-l2-l1-gate-tgt',
+    });
+  });
+
+  afterAll(async () => {
+    await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+    await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+  });
+
+  test('Space Admin cannot execute the move', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      sourceScenario.subsubspace.id,
+      targetScenario.subspace.id,
+      undefined,
+      TestUser.SPACE_ADMIN
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('Space Member cannot execute the move', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      sourceScenario.subsubspace.id,
+      targetScenario.subspace.id,
+      undefined,
+      TestUser.SPACE_MEMBER
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('Non-space member cannot execute the move', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      sourceScenario.subsubspace.id,
+      targetScenario.subspace.id,
+      undefined,
+      TestUser.NON_SPACE_MEMBER
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('Platform Admin (GLOBAL_ADMIN) can execute the move; stays L2', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      sourceScenario.subsubspace.id,
+      targetScenario.subspace.id,
+      undefined,
+      TestUser.GLOBAL_ADMIN
+    );
+
+    expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
+    expect(res.data?.moveSpaceL2ToSpaceL1?.level).toEqual(SpaceLevel.L2);
+
+    // Authorization chain rebuilt from the target L1: admin retains full CRUD.
+    const movedSpaceData = await getSpaceData(sourceScenario.subsubspace.id);
+    const privileges =
+      movedSpaceData.data?.lookup.space?.authorization?.myPrivileges ?? [];
+    expect(privileges).toEqual(
+      expect.arrayContaining(['CREATE', 'READ', 'UPDATE', 'DELETE'])
+    );
+  });
+});
+
+describe('Move L2 to L1 - privacy recompute (FR-006 / US2-AS4 / SC-003 / S7)', () => {
+  describe('public source → private destination chain revokes anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    // Destination top-level chain is PRIVATE.
+    const privateTargetConfig: TestScenarioConfig = {
+      ...publicTargetConfig,
+      name: 'move-l2-l1-priv-tgt',
+      space: {
+        ...publicTargetConfig.space!,
+        settings: { privacy: { mode: SpacePrivacyMode.Private } },
+        subspace: {
+          ...publicTargetConfig.space!.subspace!,
+          settings: { privacy: { mode: SpacePrivacyMode.Private } },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario = await TestScenarioFactory.createBaseScenario({
+        ...publicSourceConfig,
+        name: 'move-l2-l1-pub2priv-src',
+      });
+      targetScenario =
+        await TestScenarioFactory.createBaseScenario(privateTargetConfig);
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous can read the public L2 BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(
+        sourceScenario.subsubspace.id
+      );
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
+
+    test('after moving into the private chain, anonymous read is revoked (recomputed access)', async () => {
+      const res = await moveSpaceL2ToSpaceL1(
+        sourceScenario.subsubspace.id,
+        targetScenario.subspace.id
+      );
+      expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
+
+      // Recomputed platform-access from the NEW (private) chain: anonymous
+      // loses READ and keeps only READ_ABOUT — no residual visibility.
+      const privs = await anonymousSpacePrivileges(
+        sourceScenario.subsubspace.id
+      );
+      expect(privs).toEqual(readAboutPrivilege);
+    });
+  });
+
+  describe('private source → public destination chain grants anonymous read', () => {
+    let sourceScenario: OrganizationWithSpaceModel;
+    let targetScenario: OrganizationWithSpaceModel;
+
+    // Source top-level chain is PRIVATE.
+    const privateSourceConfig: TestScenarioConfig = {
+      ...publicSourceConfig,
+      name: 'move-l2-l1-priv2pub-src',
+      space: {
+        ...publicSourceConfig.space!,
+        settings: {
+          privacy: { mode: SpacePrivacyMode.Private },
+          membership: { policy: CommunityMembershipPolicy.Applications },
+        },
+        subspace: {
+          ...publicSourceConfig.space!.subspace!,
+          settings: { privacy: { mode: SpacePrivacyMode.Private } },
+          subspace: {
+            ...publicSourceConfig.space!.subspace!.subspace!,
+            settings: { privacy: { mode: SpacePrivacyMode.Private } },
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      sourceScenario =
+        await TestScenarioFactory.createBaseScenario(privateSourceConfig);
+      targetScenario = await TestScenarioFactory.createBaseScenario({
+        ...publicTargetConfig,
+        name: 'move-l2-l1-priv2pub-tgt',
+      });
+    });
+
+    afterAll(async () => {
+      await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+      await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+    });
+
+    test('anonymous cannot read the private L2 BEFORE the move', async () => {
+      const privs = await anonymousSpacePrivileges(
+        sourceScenario.subsubspace.id
+      );
+      expect(privs).toEqual(readAboutPrivilege);
+    });
+
+    test('after moving into the public chain, anonymous can read (no stale lockout)', async () => {
+      const res = await moveSpaceL2ToSpaceL1(
+        sourceScenario.subsubspace.id,
+        targetScenario.subspace.id
+      );
+      expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
+
+      // Recomputed platform-access from the NEW (public) chain: anonymous
+      // regains READ — no lockout from stale rules of the old private chain.
+      const privs = await anonymousSpacePrivileges(
+        sourceScenario.subsubspace.id
+      );
+      expect(privs).toEqual(sorted_read_readAbout_readLicense);
+    });
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-auto-invite.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-auto-invite.it-spec.ts
@@ -1,0 +1,158 @@
+import {
+  delay,
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+} from '@alkemio/tests-lib';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import { getCommunityApplicationsInvitations } from '@functional-api/roleset/roleset.request.params';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+
+/**
+ * Move L2 to L1 - auto-invite (workspace#030-move-subspace-parent, US4-AS1/AS2, FR-011)
+ *
+ * On a cross-L0 move the admin MAY enable auto-invite: invitations go only to
+ * former members of the moved subspace who are ALSO members of the destination
+ * top-level community. Left off, no invitation is sent. Mirrors
+ * move-L1-to-L2-auto-invite.it-spec.ts on an L2 source.
+ *
+ * The source L2 community and the target L0 community deliberately share
+ * members (SUBSUBSPACE_MEMBER / SUBSUBSPACE_ADMIN) so the overlap set the
+ * auto-invite must cover is non-empty.
+ */
+
+let sourceScenario: OrganizationWithSpaceModel;
+let targetScenario: OrganizationWithSpaceModel;
+
+const sourceConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-inv-auto-src',
+  space: {
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+      },
+    },
+  },
+};
+
+// Target L0 community overlaps the source L2 members (subsubspace member/admin).
+const targetConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-inv-auto-tgt',
+  space: {
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+beforeAll(async () => {
+  sourceScenario = await TestScenarioFactory.createBaseScenario(sourceConfig);
+  targetScenario = await TestScenarioFactory.createBaseScenario(targetConfig);
+});
+
+afterAll(async () => {
+  await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+  await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+});
+
+describe('Move L2 to L1 - auto-invite disabled (US4-AS2)', () => {
+  test('no invitations created when autoInvite is false', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      sourceScenario.subsubspace.id,
+      targetScenario.subspace.id,
+      { autoInvite: false }
+    );
+    expect(res.data?.moveSpaceL2ToSpaceL1).toBeDefined();
+
+    await delay(2000);
+
+    // Query the moved space's roleSet for invitations
+    const roleSetData = await getCommunityApplicationsInvitations(
+      sourceScenario.subsubspace.community.roleSetId
+    );
+
+    expect(roleSetData.data?.lookup.roleSet?.invitations).toHaveLength(0);
+  });
+});
+
+describe('Move L2 to L1 - auto-invite enabled (US4-AS1)', () => {
+  let sourceScenario2: OrganizationWithSpaceModel;
+  let targetScenario2: OrganizationWithSpaceModel;
+
+  beforeAll(async () => {
+    sourceScenario2 = await TestScenarioFactory.createBaseScenario({
+      ...sourceConfig,
+      name: 'move-l2-l1-inv-auto-src2',
+    });
+    targetScenario2 = await TestScenarioFactory.createBaseScenario({
+      ...targetConfig,
+      name: 'move-l2-l1-inv-auto-tgt2',
+    });
+
+    await moveSpaceL2ToSpaceL1(
+      sourceScenario2.subsubspace.id,
+      targetScenario2.subspace.id,
+      {
+        autoInvite: true,
+        invitationMessage:
+          'Your subspace has been moved. Please rejoin the community.',
+      }
+    );
+
+    await delay(5000);
+  });
+
+  afterAll(async () => {
+    await TestScenarioFactory.cleanUpBaseScenario(sourceScenario2);
+    await TestScenarioFactory.cleanUpBaseScenario(targetScenario2);
+  });
+
+  test('auto-invite creates invitations for overlapping former members (FR-011)', async () => {
+    const roleSetData = await getCommunityApplicationsInvitations(
+      sourceScenario2.subsubspace.community.roleSetId
+    );
+    const invitations = roleSetData.data?.lookup.roleSet?.invitations ?? [];
+
+    // Overlap set (source L2 members also in target L0): SUBSUBSPACE_MEMBER,
+    // SUBSUBSPACE_ADMIN. Auto-invite must produce at least those invitations.
+    // The custom invitation message (US4-AS1 "carrying the message") is
+    // asserted at the server resolver level (contract S10) — the admin roleset
+    // invitations query used here does not expose the welcome message field.
+    expect(invitations.length).toBeGreaterThan(0);
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-basic.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-basic.it-spec.ts
@@ -1,0 +1,361 @@
+import {
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+} from '@alkemio/tests-lib';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import { getSpaceData } from '../space/space.request.params';
+import { getSpaceLicenseSubscriptions } from '@functional-api/license/license.params.request';
+import { stripProfileUrls } from '@utils/array.matcher';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+import { SpaceLevel } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+
+/**
+ * Move L2 to L1 - basic (workspace#030-move-subspace-parent, US2-AS1 / US2-AS3)
+ *
+ * New server capability moveSpaceL2ToSpaceL1: moves an L2 subspace (Y) nested
+ * under an L1 subspace of Space A so it becomes a child of an L1 subspace (B1)
+ * belonging to a DIFFERENT top-level Space B. Y stays at level L2.
+ *
+ * Mirrors move-L1-to-L2-basic.it-spec.ts; the source hierarchy carries an
+ * extra L2 level (space.subspace.subspace → subsubspace) and we move that
+ * subsubspace, not the subspace.
+ *
+ * Covers: FR-003 (new capability, stays L2), FR-005 (structural consistency:
+ * new parent, top-level-ancestor, sort order 0, account inherited), FR-007
+ * (rejections: L1 source, L0/L2 target, same-L0 target, current parent) and
+ * FR-012 / S9 (platform-admin gate). Contract test plan: S1, S2, S3, S4.
+ */
+
+let sourceScenario: OrganizationWithSpaceModel;
+let targetScenario: OrganizationWithSpaceModel;
+
+// Source: L0 → L1 → L2 (Space A → A1 → Y). We move the L2 (subsubspace).
+const sourceConfig: TestScenarioConfig = {
+  name: 'move-l2-to-l1-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        collaboration: {
+          addPostCallout: true,
+          addPostCollectionCallout: true,
+          addWhiteboardCallout: true,
+        },
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+      },
+    },
+  },
+};
+
+// Target: L0 → L1 (Space B → B1). B1 is the destination parent.
+const targetConfig: TestScenarioConfig = {
+  name: 'move-l2-to-l1-tgt',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+let subsubspaceBefore: Awaited<ReturnType<typeof getSpaceData>>;
+let movedSpace:
+  | NonNullable<
+      Awaited<ReturnType<typeof moveSpaceL2ToSpaceL1>>['data']
+    >['moveSpaceL2ToSpaceL1']
+  | undefined;
+
+beforeAll(async () => {
+  sourceScenario = await TestScenarioFactory.createBaseScenario(sourceConfig);
+  targetScenario = await TestScenarioFactory.createBaseScenario(targetConfig);
+
+  // Capture state before move
+  subsubspaceBefore = await getSpaceData(sourceScenario.subsubspace.id);
+
+  // Execute cross-L0 L2→L1 move: Y (subsubspace) → under B1 (target subspace)
+  const res = await moveSpaceL2ToSpaceL1(
+    sourceScenario.subsubspace.id,
+    targetScenario.subspace.id
+  );
+  movedSpace = res.data?.moveSpaceL2ToSpaceL1;
+});
+
+afterAll(async () => {
+  // Source cleanup first: it deletes the moved space (sourceScenario.subsubspace.id,
+  // now an L2 under the target B1) so the target subspace is child-free before
+  // target cleanup runs.
+  await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+  await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+});
+
+describe('Move L2 to L1 - basic', () => {
+  test('space stays at level L2 after the move (US2-AS1 / S4)', () => {
+    expect(movedSpace?.level).toEqual(SpaceLevel.L2);
+  });
+
+  test('moved space appears in target L1 (B1) subspaces', async () => {
+    const targetL1Data = await getSpaceData(targetScenario.subspace.id);
+    const subspaceIds =
+      targetL1Data.data?.lookup.space?.subspaces.map(s => s.id) ?? [];
+
+    expect(subspaceIds).toContain(sourceScenario.subsubspace.id);
+  });
+
+  test('moved space no longer nested under source L1 (A1)', async () => {
+    const sourceL1Data = await getSpaceData(sourceScenario.subspace.id);
+    const subspaceIds =
+      sourceL1Data.data?.lookup.space?.subspaces.map(s => s.id) ?? [];
+
+    expect(subspaceIds).not.toContain(sourceScenario.subsubspace.id);
+  });
+
+  test('collaboration content is preserved (excluding profile urls)', () => {
+    expect(stripProfileUrls(movedSpace?.collaboration)).toEqual(
+      stripProfileUrls(subsubspaceBefore.data?.lookup.space?.collaboration)
+    );
+  });
+
+  test('about fields are preserved or updated correctly after cross-L0 move', () => {
+    const aboutBefore = subsubspaceBefore.data?.lookup.space?.about;
+
+    // authorization is preserved
+    expect(movedSpace?.about.authorization).toEqual(aboutBefore?.authorization);
+
+    // profile: id and displayName preserved (url points to new hierarchy)
+    expect(movedSpace?.about.profile).toEqual(
+      expect.objectContaining({
+        id: aboutBefore?.profile?.id,
+        displayName: aboutBefore?.profile?.displayName,
+        description: aboutBefore?.profile?.description,
+        references: aboutBefore?.profile?.references,
+        tagline: aboutBefore?.profile?.tagline,
+        tagsets: aboutBefore?.profile?.tagsets,
+        location: aboutBefore?.profile?.location,
+        authorization: aboutBefore?.profile?.authorization,
+        storageBucket: aboutBefore?.profile?.storageBucket,
+      })
+    );
+
+    // provider changes to target organization
+    expect(movedSpace?.about.provider?.id).toEqual(
+      targetScenario.organization.id
+    );
+
+    // who/why are preserved
+    expect(movedSpace?.about.who).toEqual(aboutBefore?.who);
+    expect(movedSpace?.about.why).toEqual(aboutBefore?.why);
+  });
+
+  test('visibility/privacy is preserved', () => {
+    expect(movedSpace?.visibility).toEqual(
+      subsubspaceBefore.data?.lookup.space?.visibility
+    );
+  });
+
+  test('settings are preserved', () => {
+    expect(movedSpace?.settings).toEqual(
+      subsubspaceBefore.data?.lookup.space?.settings
+    );
+  });
+
+  test('account is inherited from target L0 (FR-005)', async () => {
+    const movedData = await getSpaceData(sourceScenario.subsubspace.id);
+    const targetL0Data = await getSpaceData(targetScenario.space.id);
+
+    expect(movedData.data?.lookup.space?.account.id).toEqual(
+      targetL0Data.data?.lookup.space?.account.id
+    );
+  });
+
+  test('license subscriptions inherited from target L0', async () => {
+    const targetLicense = await getSpaceLicenseSubscriptions(
+      targetScenario.space.id
+    );
+    const movedLicense = await getSpaceLicenseSubscriptions(
+      sourceScenario.subsubspace.id
+    );
+
+    const sortedTarget =
+      targetLicense.data?.lookup.space?.subscriptions?.sort((a, b) =>
+        a.name.localeCompare(b.name)
+      ) ?? [];
+    const sortedMoved =
+      movedLicense.data?.lookup.space?.subscriptions?.sort((a, b) =>
+        a.name.localeCompare(b.name)
+      ) ?? [];
+
+    expect(sortedMoved).toEqual(sortedTarget);
+  });
+
+  test('moved space is first among target L1 (B1) subspaces (sort order 0)', async () => {
+    const targetL1Data = await getSpaceData(targetScenario.subspace.id);
+    const subspaces = targetL1Data.data?.lookup.space?.subspaces ?? [];
+    const firstSubspaceId = subspaces[0]?.id;
+
+    expect(firstSubspaceId).toEqual(sourceScenario.subsubspace.id);
+  });
+});
+
+/**
+ * Rejections (FR-007) and the platform-admin gate (FR-012 / S9). Each rejection
+ * uses a fresh pair of scenarios so a failed move cannot pollute the assertions
+ * of a later case, and asserts an error plus no observable change.
+ */
+describe('Move L2 to L1 - rejections and authorization', () => {
+  let rejSource: OrganizationWithSpaceModel;
+  let rejTarget: OrganizationWithSpaceModel;
+
+  beforeAll(async () => {
+    rejSource = await TestScenarioFactory.createBaseScenario({
+      ...sourceConfig,
+      name: 'move-l2-l1-rej-src',
+    });
+    rejTarget = await TestScenarioFactory.createBaseScenario({
+      ...targetConfig,
+      name: 'move-l2-l1-rej-tgt',
+    });
+  });
+
+  afterAll(async () => {
+    await TestScenarioFactory.cleanUpBaseScenario(rejSource);
+    await TestScenarioFactory.cleanUpBaseScenario(rejTarget);
+  });
+
+  test('rejects a non-admin caller — Space Admin (S9 / FR-012)', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      rejTarget.subspace.id,
+      undefined,
+      TestUser.SPACE_ADMIN
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+
+    // No change: Y still nested under the source L1 (A1)
+    const sourceL1Data = await getSpaceData(rejSource.subspace.id);
+    const subspaceIds =
+      sourceL1Data.data?.lookup.space?.subspaces.map(s => s.id) ?? [];
+    expect(subspaceIds).toContain(rejSource.subsubspace.id);
+  });
+
+  test('rejects a non-admin caller — Non-space member (S9 / FR-012)', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      rejTarget.subspace.id,
+      undefined,
+      TestUser.NON_SPACE_MEMBER
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects an L1 source — source must be L2 (S1)', async () => {
+    // rejSource.subspace is an L1, not an L2 — invalid for this operation.
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subspace.id,
+      rejTarget.subspace.id
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects an L0 source — source must be L2 (S1)', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.space.id,
+      rejTarget.subspace.id
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects an L0 target — target must be L1 (S2)', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      rejTarget.space.id // L0, not L1
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects an L2 target — target must be L1 (S2)', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      rejSource.subsubspace.id // L2, not L1
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects a same-L0 target — only cross-L0 supported (US2-AS3 / S3)', async () => {
+    // Target L1 lives inside the source's OWN top-level space (A1). Same-L0
+    // lateral re-parenting is a deferred capability and must be rejected.
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      rejSource.subspace.id // the source's own current L1 parent, same L0
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+
+    // No change: Y still nested under A1
+    const sourceL1Data = await getSpaceData(rejSource.subspace.id);
+    const subspaceIds =
+      sourceL1Data.data?.lookup.space?.subspaces.map(s => s.id) ?? [];
+    expect(subspaceIds).toContain(rejSource.subsubspace.id);
+  });
+
+  test('rejects an invalid spaceL2ID', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      '00000000-0000-0000-0000-000000000000',
+      rejTarget.subspace.id
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+
+  test('rejects an invalid targetSpaceL1ID', async () => {
+    const res = await moveSpaceL2ToSpaceL1(
+      rejSource.subsubspace.id,
+      '00000000-0000-0000-0000-000000000000'
+    );
+
+    expect(res.error?.errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-basic.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-basic.it-spec.ts
@@ -235,9 +235,11 @@ describe('Move L2 to L1 - basic', () => {
 });
 
 /**
- * Rejections (FR-007) and the platform-admin gate (FR-012 / S9). Each rejection
- * uses a fresh pair of scenarios so a failed move cannot pollute the assertions
- * of a later case, and asserts an error plus no observable change.
+ * Rejections (FR-007) and the platform-admin gate (FR-012 / S9). A single pair
+ * of scenarios (rejSource/rejTarget) is created once in beforeAll and shared
+ * across every case — this is safe because each move is REJECTED and therefore
+ * produces no observable state change to pollute a later assertion. Each case
+ * asserts an error plus (where relevant) that nothing moved.
  */
 describe('Move L2 to L1 - rejections and authorization', () => {
   let rejSource: OrganizationWithSpaceModel;

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-community.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-community.it-spec.ts
@@ -1,0 +1,135 @@
+import {
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+} from '@alkemio/tests-lib';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import { getSpaceData } from '../space/space.request.params';
+import {
+  getRoleSetUsersInMemberRole,
+  getRoleSetUsersInLeadRole,
+  getRoleSetMembersList,
+} from '@functional-api/roleset/roleset.request.params';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+
+/**
+ * Move L2 to L1 - community roles cleared
+ * (workspace#030-move-subspace-parent, US2-AS1 / FR-004 / SC-002 / contract S5)
+ *
+ * Every cross-L0 move is wipe-all: the moved L2 subspace's community loses ALL
+ * roles — members, leads and admins — because only cross-L0 ships (decision
+ * log D-1/D-4). Mirrors move-L1-to-L2-community.it-spec.ts on an L2 source.
+ */
+
+let sourceScenario: OrganizationWithSpaceModel;
+let targetScenario: OrganizationWithSpaceModel;
+
+const sourceConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-comm-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SPACE_ADMIN,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        collaboration: { addPostCallout: true },
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+      },
+    },
+  },
+};
+
+const targetConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-comm-tgt',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+beforeAll(async () => {
+  sourceScenario = await TestScenarioFactory.createBaseScenario(sourceConfig);
+  targetScenario = await TestScenarioFactory.createBaseScenario(targetConfig);
+
+  await moveSpaceL2ToSpaceL1(
+    sourceScenario.subsubspace.id,
+    targetScenario.subspace.id
+  );
+});
+
+afterAll(async () => {
+  await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+  await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+});
+
+describe('Move L2 to L1 - community roles cleared', () => {
+  test('all members are removed (FR-004 / SC-002)', async () => {
+    const members = await getRoleSetUsersInMemberRole(
+      sourceScenario.subsubspace.community.roleSetId
+    );
+
+    expect(members).toHaveLength(0);
+  });
+
+  test('all leads are removed (FR-004)', async () => {
+    const leads = await getRoleSetUsersInLeadRole(
+      sourceScenario.subsubspace.community.roleSetId
+    );
+
+    expect(leads).toHaveLength(0);
+  });
+
+  test('all admins are removed — wipe-all, incl. admins (S5 / FR-004)', async () => {
+    const spaceData = await getSpaceData(sourceScenario.subsubspace.id);
+    const admins =
+      spaceData.data?.lookup.space?.community.roleSet.adminUsers ?? [];
+
+    expect(admins).toHaveLength(0);
+  });
+
+  test('all member organizations are removed (FR-004)', async () => {
+    const roleSetData = await getRoleSetMembersList(
+      sourceScenario.subsubspace.community.roleSetId
+    );
+    const memberOrgs =
+      roleSetData.data?.lookup.roleSet?.memberOrganizations ?? [];
+
+    expect(memberOrgs).toHaveLength(0);
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-rooms.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-rooms.it-spec.ts
@@ -1,0 +1,180 @@
+import {
+  TestScenarioConfig,
+  TestScenarioFactory,
+  TestUser,
+} from '@alkemio/tests-lib';
+import { moveSpaceL2ToSpaceL1 } from './conversion.request.params';
+import {
+  getSpaceData,
+  getSpaceCommunication,
+} from '../space/space.request.params';
+import { sendMessageToRoom } from '@functional-api/communications/communication.params';
+import {
+  createCalendarEventOnCalendar,
+  getCalendarEvents,
+  getSpaceCalendarId,
+} from '@functional-api/calendar/calendar.request.params';
+import { CalendarEventType } from '@alkemio/tests-lib/core/generated/alkemio-schema';
+import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/OrganizationWithSpaceModel';
+
+/**
+ * Move L2 to L1 - rooms and communication
+ * (workspace#030-move-subspace-parent, FR-013)
+ *
+ * Messaging-room cleanup after a move is best-effort and never fails the move.
+ * Discussion/comment rooms and their history are preserved; the announcement
+ * (updates) channel is reset. Former members lose access to the moved space.
+ * Mirrors move-L1-to-L2-rooms.it-spec.ts on an L2 source.
+ */
+
+let sourceScenario: OrganizationWithSpaceModel;
+let targetScenario: OrganizationWithSpaceModel;
+let calendarEventId: string;
+
+const sourceConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-rooms-src',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+        TestUser.SUBSUBSPACE_MEMBER,
+        TestUser.SUBSUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [
+          TestUser.SUBSPACE_MEMBER,
+          TestUser.SUBSPACE_ADMIN,
+          TestUser.SUBSUBSPACE_MEMBER,
+          TestUser.SUBSUBSPACE_ADMIN,
+        ],
+      },
+      subspace: {
+        collaboration: { addPostCallout: true },
+        community: {
+          admins: [TestUser.SUBSUBSPACE_ADMIN],
+          members: [TestUser.SUBSUBSPACE_MEMBER, TestUser.SUBSUBSPACE_ADMIN],
+        },
+      },
+    },
+  },
+};
+
+const targetConfig: TestScenarioConfig = {
+  name: 'move-l2-l1-rooms-tgt',
+  space: {
+    collaboration: { addPostCallout: true },
+    community: {
+      admins: [TestUser.SPACE_ADMIN],
+      members: [
+        TestUser.SPACE_MEMBER,
+        TestUser.SUBSPACE_MEMBER,
+        TestUser.SUBSPACE_ADMIN,
+      ],
+    },
+    subspace: {
+      collaboration: { addPostCallout: true },
+      community: {
+        admins: [TestUser.SUBSPACE_ADMIN],
+        members: [TestUser.SUBSPACE_MEMBER, TestUser.SUBSPACE_ADMIN],
+      },
+    },
+  },
+};
+
+beforeAll(async () => {
+  sourceScenario = await TestScenarioFactory.createBaseScenario(sourceConfig);
+  targetScenario = await TestScenarioFactory.createBaseScenario(targetConfig);
+
+  // Create a calendar event on the L2 before move
+  const calendarRes = await getSpaceCalendarId(sourceScenario.subsubspace.id);
+  const calendarId =
+    calendarRes.data?.lookup?.space?.collaboration?.timeline?.calendar?.id ??
+    '';
+  const calEventRes = await createCalendarEventOnCalendar(calendarId, {
+    displayName: 'Event before move L2 to L1',
+    startDate: '2026-06-01T10:00:00.000Z',
+    durationMinutes: 60,
+    multipleDays: false,
+    wholeDay: false,
+    type: CalendarEventType.Event,
+  });
+  calendarEventId = calEventRes.data?.createEventOnCalendar?.id ?? '';
+
+  // Send message to callout post comments room (discussion — preserved)
+  await sendMessageToRoom(
+    sourceScenario.subsubspace.collaboration.calloutPostCommentsId,
+    'Test callout message before L2→L1 move'
+  );
+
+  // Send message to updates room (announcement channel — reset on move)
+  await sendMessageToRoom(
+    sourceScenario.subsubspace.communication.updatesId,
+    'Test updates message before L2→L1 move'
+  );
+
+  // Execute cross-L0 L2→L1 move
+  await moveSpaceL2ToSpaceL1(
+    sourceScenario.subsubspace.id,
+    targetScenario.subspace.id
+  );
+});
+
+afterAll(async () => {
+  await TestScenarioFactory.cleanUpBaseScenario(sourceScenario);
+  await TestScenarioFactory.cleanUpBaseScenario(targetScenario);
+});
+
+describe('Move L2 to L1 - rooms and communication', () => {
+  test('callout discussion room messages are preserved', async () => {
+    const spaceData = await getSpaceData(sourceScenario.subsubspace.id);
+    const callouts =
+      spaceData.data?.lookup.space?.collaboration.calloutsSet.callouts ?? [];
+    const postCallout = callouts.find(
+      c => c.id === sourceScenario.subsubspace.collaboration.calloutPostId
+    );
+    const comments = postCallout?.comments?.messages ?? [];
+    const messageTexts = comments.map(m => m.message);
+
+    expect(messageTexts).toContain('Test callout message before L2→L1 move');
+  });
+
+  test('calendar events are preserved after cross-L0 move', async () => {
+    const calendarRes = await getCalendarEvents(sourceScenario.subsubspace.id);
+    const events =
+      calendarRes.data?.lookup?.space?.collaboration?.timeline?.calendar
+        ?.events ?? [];
+
+    const preserved = events.find(e => e.id === calendarEventId);
+    expect(preserved).toBeDefined();
+    expect(preserved?.profile.displayName).toBe('Event before move L2 to L1');
+  });
+
+  test('announcement (updates) channel is reset after cross-L0 move (FR-013)', async () => {
+    const commData = await getSpaceCommunication(sourceScenario.subsubspace.id);
+    const updatesMessages =
+      commData.data?.lookup.space?.community.communication.updates.messages ??
+      [];
+
+    // The announcement channel is reset (recreated empty) on a cross-L0 move.
+    expect(updatesMessages).toHaveLength(0);
+  });
+
+  test('former member cannot access the moved space (FR-004 downstream)', async () => {
+    const spaceData = await getSpaceData(
+      sourceScenario.subsubspace.id,
+      TestUser.SUBSUBSPACE_MEMBER
+    );
+
+    const privileges =
+      spaceData.data?.lookup.space?.authorization?.myPrivileges ?? [];
+    expect(privileges).not.toContain('UPDATE');
+  });
+});

--- a/server-api/src/functional-api/journey/conversion/move-L2-to-L1-rooms.it-spec.ts
+++ b/server-api/src/functional-api/journey/conversion/move-L2-to-L1-rooms.it-spec.ts
@@ -21,10 +21,12 @@ import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/O
  * Move L2 to L1 - rooms and communication
  * (workspace#030-move-subspace-parent, FR-013)
  *
- * Messaging-room cleanup after a move is best-effort and never fails the move.
- * Discussion/comment rooms and their history are preserved; the announcement
- * (updates) channel is reset. Former members lose access to the moved space.
- * Mirrors move-L1-to-L2-rooms.it-spec.ts on an L2 source.
+ * A cross-L0 move removes memberships and pending applications/invitations
+ * only; all content travels with the space. Discussion/comment rooms, the
+ * updates (announcement) channel, and calendar events keep their history
+ * (epic alkem-io/alkemio#1846: "Updates go with the space"). Former members
+ * lose access to the moved space. Mirrors move-L1-to-L2-rooms.it-spec.ts on
+ * an L2 source.
  */
 
 let sourceScenario: OrganizationWithSpaceModel;
@@ -157,14 +159,17 @@ describe('Move L2 to L1 - rooms and communication', () => {
     expect(preserved?.profile.displayName).toBe('Event before move L2 to L1');
   });
 
-  test('announcement (updates) channel is reset after cross-L0 move (FR-013)', async () => {
+  test('updates (announcement) channel messages are preserved after cross-L0 move (FR-013)', async () => {
     const commData = await getSpaceCommunication(sourceScenario.subsubspace.id);
     const updatesMessages =
       commData.data?.lookup.space?.community.communication.updates.messages ??
       [];
 
-    // The announcement channel is reset (recreated empty) on a cross-L0 move.
-    expect(updatesMessages).toHaveLength(0);
+    // Content travels with the space: a cross-L0 move removes memberships and
+    // pending applications/invitations only. The updates channel and its
+    // history are preserved (epic alkem-io/alkemio#1846: "Updates go with the
+    // space"), like discussion messages and calendar events above.
+    expect(updatesMessages).toHaveLength(1);
   });
 
   test('former member cannot access the moved space (FR-004 downstream)', async () => {


### PR DESCRIPTION
## Summary

Adds the missing **server-api** cross-service coverage for the new **`moveSpaceL2ToSpaceL1`** server capability shipped in `workspace#030-move-subspace-parent` (server [#6292](https://github.com/alkem-io/server/pull/6292), now on `develop`): a cross-L0 move of an L2 subspace to a target L1 under a **different** top-level space, staying at L2. Mirrors the shipped `move-L1-to-L2-*` family.

Authored by `/test-suites 030 --author --scope server-api`.

## What to review (the 8 authored files — ~1,367 lines)

**server-api** — `src/functional-api/journey/conversion/`

| File | Acceptance criteria |
|------|---------------------|
| `move-L2-to-L1-basic.it-spec.ts` | US2-AS1 happy path (stays L2, content intact, under B1, gone from A1, sort-order 0, account inherited) — FR-003/FR-005, contract S4. Rejections (FR-007): L1/L0 source → S1, L0/L2 target → S2, same-L0 target → US2-AS3/S3, invalid IDs. Admin gate S9/FR-012, each with a no-change assertion. |
| `move-L2-to-L1-community.it-spec.ts` | Wipe-all: members/leads/admins/member-orgs all 0 — S5, FR-004, SC-002. |
| `move-L2-to-L1-authorization.it-spec.ts` | FR-012/S9 admin-only gate; FR-006/US2-AS4/SC-003/S7 privacy **recompute** — asserts the recomputed anonymous access (D-5) on public↔private-parent pairs (public→private revokes anonymous READ; private→public restores it), not merely that policy re-apply ran. |
| `move-L2-to-L1-applications-invitations.it-spec.ts` | FR-004: pending invitation + application dropped; new ones work post-move. |
| `move-L2-to-L1-auto-invite.it-spec.ts` | US4-AS1/AS2, FR-011 (off ⇒ 0 invitations; on ⇒ overlapping former members invited). |
| `move-L2-to-L1-rooms.it-spec.ts` | FR-013: discussion messages + calendar events preserved, announcement/updates channel reset, former member loses access. |

- `conversion.request.params.ts` — new `moveSpaceL2ToSpaceL1(spaceL2ID, targetSpaceL1ID, options?, role?)` request helper (mirrors the L1-move fns).

**lib**
- `src/scenario/graphql/mutations/convert/moveSpaceL2ToSpaceL1.graphql` — new mutation op matching the contract signature (`moveSpaceL2ToSpaceL1(moveData: MoveSpaceL2ToSpaceL1Input!): Space!`).

Scenario setup mirrors the L1→L2 family extended one level: source builds `L0 → L1 → L2` and moves the L2 to a target L1 in a different L0 via `TestScenarioFactory` / `OrganizationWithSpaceModel`.

## ⚠️ Generated SDK diff — not for line review

`lib/src/core/generated/graphql.ts` and `alkemio-schema.ts` account for **~89% of this diff (10.7k / 12.1k lines)** and are **codegen output**, not hand-written. Most of it is **pre-existing schema drift already on `develop`** (spec 013/025 types the committed SDK had fallen behind on) — regenerating to pick up `MoveSpaceL2ToSpaceL1` also pulls that in. Review the `MoveSpaceL2ToSpaceL1` SDK additions; treat the rest as a mechanical `pnpm codegen` refresh.

## Static gates

- **typecheck** (lib + server-api `tsc --noEmit`): pass.
- **ESLint** on the authored files: 0 problems.
- **codegen** (lib): regenerated against the live post-#6292 `develop` server (confirmed the exact 4-field `MoveSpaceL2ToSpaceL1Input`).

## Not executed

These are auth-backed integration specs — **authored, not executed** here (no auth harness: Kratos personas, MailSlurper, `.env`). Run via `forge-verify` or `pnpm --filter @alkemio/test-suite-server-api run test:journey` against a booted stack (the `journey` project glob already includes these files — no `vitest.config.ts` change needed).

## Out of scope

US2-AS5 / FR-008 / SC-004 (fault-injected **transaction rollback**, contract S6) needs a server-side fault seam — it belongs to the **server** repo's integration tests (the R-3 mitigator), not a black-box test-suites spec. No spec authored for it.

Relates to alkem-io/server#6224

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Move L2 to L1” capability that relocates a level 2 space under a new level 1 parent while preserving collaboration content, about info, visibility/settings, and correct hierarchy/ordering.
  - Supports optional auto-invites with a custom invitation message during the move.

- **Bug Fixes**
  - Invalidates pre-move pending invitations and applications after the move.
  - Clears community role memberships for the moved space where applicable, while preserving room/announcement history.

- **Tests**
  - Expanded functional and authorization coverage for basic, rooms, community roles, auto-invite, invitation/application invalidation, and anonymous privacy recomputation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->