### PR TITLE
ci(027): exit self-hosted runners — nightly/manual + legacy ARC to hosted (workspace#027-arc-v3-runner-migration)

### DIFF
--- a/.github/workflows/cleanup-old-playwright-reports.yml
+++ b/.github/workflows/cleanup-old-playwright-reports.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -12,7 +12,7 @@ jobs:
 
   run-e2e-tests:
     needs: cleanup-db
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -49,7 +49,7 @@ jobs:
 
   run-e2e-tests:
     needs: cleanup-db
-    runs-on: m4
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/nightly-client-tests.yml
+++ b/.github/workflows/nightly-client-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — test-suites (wave 2, all-hosted)

Moves all 5 self-hosted selectors to `ubuntu-latest`: the **server-API nightly** and manual builds off `m4` (closes R-3 — the kubeconfig-holding job leaves the shared host), plus 3 legacy `arc-runner-set` consumers (client nightly, gh-pages deploy, playwright cleanup). Zero self-hosted selectors remain.

**Verified:** routing checker PASS; `pnpm install --frozen-lockfile` clean. ✅ **All-hosted — may merge independently of the wave-1 lane** (no ARC selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)