### PR TITLE
ci(027 H6): route E2E nightly to the fast arc-e2e privileged lane

### DIFF
--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -12,7 +12,7 @@ jobs:
 
   run-e2e-tests:
     needs: cleanup-db
-    runs-on: ubuntu-latest
+    runs-on: arc-e2e-linux-x64
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -49,7 +49,7 @@ jobs:
 
   run-e2e-tests:
     needs: cleanup-db
-    runs-on: ubuntu-latest
+    runs-on: arc-e2e-linux-x64
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — H6d (E2E speed)

Routes the credentialed `run-e2e-tests` job (nightly-build-trigger + manual-build-trigger) from `ubuntu-latest` to **`arc-e2e-linux-x64`** — the dedicated ephemeral gen-v3 privileged lane — for M4-class speed on the ~64-min server-API E2E, without putting the kubeconfig on the secret-free trusted lane.

**Only `run-e2e-tests` moves**; the lock/deploy/cleanup orchestration jobs stay hosted.

**Safe because** the lane is: test-suites-only (`alkemio-e2e-ci` group), **schedule/dispatch-triggered only — never `pull_request`** (fork code never reaches it), ephemeral (fresh pod per run, no credential residue — the M4's core R-3 flaw), hardened (non-root/seccomp/drop-ALL/no-SA-token), and denied the platform cluster's own kube-API + metadata. Strictly safer than the persistent M4 it replaces.

**Verified:** e2e lane live (listener registered against `alkemio-e2e-ci`); routing checker extended to enforce the credentialed-lane boundary (declared jobs only, no PR triggers) — PASS. First full E2E-on-lane runs on the next nightly (or a manual dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)