### PR TITLE
fix(client-web): stabilize E2E for full-suite nightly runs

### DIFF
--- a/.github/workflows/nightly-client-tests.yml
+++ b/.github/workflows/nightly-client-tests.yml
@@ -36,7 +36,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Browsers
-        run: pnpm --filter @alkemio/test-suite-client-web exec playwright install --with-deps
+        # The nightly config pins channel: 'chrome' (branded Chrome, matching the
+        # interactive config), so install that channel explicitly — the default
+        # `playwright install` only provisions the bundled Chromium.
+        run: pnpm --filter @alkemio/test-suite-client-web exec playwright install --with-deps chromium chrome
 
       - name: Set run folder variables
         run: |

--- a/client-web/config/global-setup.ts
+++ b/client-web/config/global-setup.ts
@@ -4,12 +4,31 @@ import {
   testConfiguration,
 } from '@alkemio/tests-lib';
 import dotenv from 'dotenv';
+import fs from 'fs';
 import path from 'path';
 
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
+/**
+ * Remove cached per-persona sessions from previous runs. The authenticated
+ * session fixture reuses `.auth/persona.*.json` across worker restarts within a
+ * run; clearing them here keeps that reuse strictly run-scoped, so a stale /
+ * expired Kratos session can never leak into a fresh run.
+ */
+function clearPersonaSessions() {
+  const authDir = path.resolve(__dirname, '..', '.auth');
+  if (!fs.existsSync(authDir)) return;
+  for (const file of fs.readdirSync(authDir)) {
+    if (file.startsWith('persona.') && file.endsWith('.json')) {
+      fs.rmSync(path.join(authDir, file), { force: true });
+    }
+  }
+}
+
 export default async function globalSetup() {
   console.log('[globalSetup] Starting Playwright global setup...');
+
+  clearPersonaSessions();
 
   if (!testConfiguration.registerUsers) return;
 

--- a/client-web/config/global-setup.ts
+++ b/client-web/config/global-setup.ts
@@ -14,9 +14,15 @@ dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
  * session fixture reuses `.auth/persona.*.json` across worker restarts within a
  * run; clearing them here keeps that reuse strictly run-scoped, so a stale /
  * expired Kratos session can never leak into a fresh run.
+ *
+ * Resolve `.auth` from `process.cwd()` — NOT `__dirname` — so this matches the
+ * location the fixture writes to (`authenticated-session.fixture.ts` also uses
+ * `process.cwd()/.auth`). globalSetup and the workers share one cwd, so both
+ * always agree; deriving from `__dirname` here would point at `client-web/.auth`
+ * and silently miss (leak) sessions whenever Playwright runs from another cwd.
  */
 function clearPersonaSessions() {
-  const authDir = path.resolve(__dirname, '..', '.auth');
+  const authDir = path.join(process.cwd(), '.auth');
   if (!fs.existsSync(authDir)) return;
   for (const file of fs.readdirSync(authDir)) {
     if (file.startsWith('persona.') && file.endsWith('.json')) {

--- a/client-web/config/playwright.config.nightly.ts
+++ b/client-web/config/playwright.config.nightly.ts
@@ -157,6 +157,15 @@ export default defineConfig({
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    /* Match the interactive config (playwright.config.ts): branded Chrome at
+     * 1920×1080. Without this the nightly ran bundled Chromium at the default
+     * 1280×720, where the sticky app header overlaps the calendar form's Save
+     * button and intercepts the click (whole-day-events-crud T1 failed on every
+     * nightly but passed at 1920×1080). Keep these in sync with the main config. */
+    ...devices['Desktop Chrome'],
+    channel: 'chrome',
+    viewport: { width: 1920, height: 1080 },
+
     headless: true,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/client-web/src/functional-e2e/fixtures/authenticated-session.fixture.ts
+++ b/client-web/src/functional-e2e/fixtures/authenticated-session.fixture.ts
@@ -1,4 +1,4 @@
-import { test as base, BrowserContext, Page } from '@playwright/test';
+import { test as base, Browser, BrowserContext, Page } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { LoginPage } from '@src/functional-e2e/space/pages';
@@ -15,10 +15,127 @@ let sharedContext: BrowserContext;
 let sharedPage: Page;
 
 /**
+ * Per-run cache of persona (email) → storage-state file.
+ *
+ * Login happens at most ONCE per persona per worker process: the first spec
+ * that needs a given user drives the login form; every later spec for the same
+ * user loads that persisted Kratos session from disk instead of logging in
+ * again. This removes the per-file login that made the shared login page the
+ * single point of failure for the whole suite — under load a slow login-form
+ * render used to time out in one spec's `beforeAll` and cascade into dozens of
+ * red rows across unrelated suites.
+ */
+const personaStatePaths = new Map<string, string>();
+
+function personaStatePath(email: string): string {
+  const slug = email.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+  return path.join(process.cwd(), '.auth', `persona.${slug}.json`);
+}
+
+/**
+ * Dismiss the one-time "A fresh new Alkemio is here" design dialog that can
+ * overlay the shell after sign-in / first authenticated navigation.
+ */
+async function dismissNewDesignDialog(page: Page): Promise<void> {
+  const switchToNewDesign = page.getByRole('button', {
+    name: /take me to the new design/i,
+  });
+  if (
+    await switchToNewDesign.isVisible({ timeout: 5000 }).catch(() => false)
+  ) {
+    await switchToNewDesign.click().catch(() => {});
+  }
+}
+
+/**
+ * Log a persona in once and persist its Kratos session to disk, returning the
+ * storage-state path. Cached in-process for the rest of the run. The login form
+ * is retried a few times so the single per-persona login is resilient to a slow
+ * SPA / login-form render — the exact failure mode that flaked the full-suite
+ * run when every spec logged in for itself.
+ */
+export async function ensurePersonaState(
+  browser: Browser,
+  email: string
+): Promise<string> {
+  const statePath = personaStatePath(email);
+
+  // Fast path: already logged in this worker process.
+  const cached = personaStatePaths.get(email);
+  if (cached && fs.existsSync(cached)) return cached;
+
+  // Survive worker restarts: Playwright recycles the worker process (e.g. after
+  // a failure), which wipes the in-memory cache above. A persona file on disk is
+  // from THIS run — global-setup deletes stale files at the start of every run —
+  // so a fresh worker adopts it instead of driving the login form again. Without
+  // this, a cold login runs inside the next spec's beforeAll and can blow its
+  // (often 30s) budget, timing out the hook and cascading the whole serial file.
+  if (fs.existsSync(statePath)) {
+    personaStatePaths.set(email, statePath);
+    return statePath;
+  }
+
+  await fs.promises.mkdir(path.dirname(statePath), { recursive: true });
+
+  console.info(`[auth] establishing session for ${email} (first use this run)`);
+  const maxAttempts = 3;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const context = await browser.newContext({ storageState: undefined });
+    try {
+      const page = await context.newPage();
+      const loginPage = new LoginPage(page, baseUrl);
+      await loginPage.login(email);
+      await dismissNewDesignDialog(page);
+      await context.storageState({ path: statePath });
+      await context.close();
+      personaStatePaths.set(email, statePath);
+      return statePath;
+    } catch (error) {
+      lastError = error;
+      await context.close().catch(() => {});
+      console.warn(
+        `[auth] login for ${email} failed (attempt ${attempt}/${maxAttempts}): ${
+          (error as Error)?.message ?? error
+        }`
+      );
+    }
+  }
+  throw new Error(
+    `[auth] could not establish a session for ${email} after ${maxAttempts} attempts: ${
+      (lastError as Error)?.message ?? lastError
+    }`
+  );
+}
+
+/**
+ * A Playwright `test` whose default `page` / `context` are already authenticated
+ * as the given persona, by overriding the built-in `storageState` option with
+ * the shared per-run session (logs in at most once per persona per run).
+ *
+ * Prefer this for simple specs that just need an authenticated page: Playwright
+ * manages the context/page lifecycle itself (a fresh context per test), so there
+ * are no shared-singleton hazards. `createAuthenticatedSessionFixture` remains
+ * for specs that deliberately reuse one context/page across a serial block.
+ *
+ * Usage:
+ * ```typescript
+ * const test = createPersonaTest(TestUserManager.users.globalAdmin.email);
+ * test('...', async ({ page }) => { await page.goto(...); }); // already logged in
+ * ```
+ */
+export function createPersonaTest(email: string) {
+  return base.extend({
+    storageState: async ({ browser }, use) => {
+      await use(await ensurePersonaState(browser, email));
+    },
+  });
+}
+
+/**
  * Creates a reusable authenticated session fixture that:
- * - Logs in once in beforeAll
- * - Persists the session to a storage state file
- * - Reuses the same browser context and page across all tests
+ * - Reuses a per-persona Kratos session (logging in at most once per user/run)
+ * - Exposes the same authenticated browser context and page across all tests
  *
  * Usage:
  * ```typescript
@@ -56,31 +173,27 @@ export function createAuthenticatedSessionFixture(
   return {
     test,
     /**
-     * Call this in your test.beforeAll to set up authentication
+     * Call this in your test.beforeAll to set up authentication. Logs the
+     * persona in only on the first spec that needs it; subsequent specs load
+     * the cached session.
      */
-    setupAuthentication: async (browser: any, email: string) => {
+    setupAuthentication: async (browser: Browser, email: string) => {
+      const statePath = await ensurePersonaState(browser, email);
+
+      // Preserve the previous behaviour of exposing a per-spec storage-state
+      // file (handy for debugging and honoured by cleanupAfterTests) by copying
+      // the shared persona session to this fixture's named file.
       await fs.promises.mkdir(path.dirname(storageStatePath), {
         recursive: true,
       });
-      sharedContext = await browser.newContext({ storageState: undefined });
+      await fs.promises.copyFile(statePath, storageStatePath);
+
+      sharedContext = await browser.newContext({ storageState: statePath });
       sharedPage = await sharedContext.newPage();
-      const loginPage = new LoginPage(sharedPage, baseUrl);
-      await loginPage.login(email);
-
-      // Accept cookies if the dialog appears (it may not always show)
-      const acceptCookiesButton = sharedPage.getByRole('button', {
-        name: 'Accept all cookies',
-      });
-      if (
-        await acceptCookiesButton
-          .isVisible({ timeout: 3000 })
-          .catch(() => false)
-      ) {
-        console.log('Accepting cookies...');
-        await acceptCookiesButton.click();
-      }
-
-      await sharedPage.context().storageState({ path: storageStatePath });
+      // Land on the authenticated home, matching the post-login state tests
+      // previously received (LoginPage.login ends on /home).
+      await sharedPage.goto(`${baseUrl}/home`);
+      await dismissNewDesignDialog(sharedPage);
     },
     /**
      * Call this in your test.afterAll to clean up
@@ -88,11 +201,12 @@ export function createAuthenticatedSessionFixture(
     teardownAuthentication: async () => {
       await sharedContext?.close();
 
-      // Clean up storage state file if requested
+      // Clean up the per-spec storage state file if requested. The shared
+      // persona cache file is intentionally left in place for reuse.
       if (options.cleanupAfterTests) {
         try {
           await fs.promises.unlink(storageStatePath);
-        } catch (error) {
+        } catch {
           // Ignore if file doesn't exist
         }
       }

--- a/client-web/src/functional-e2e/fixtures/authenticated-session.fixture.ts
+++ b/client-web/src/functional-e2e/fixtures/authenticated-session.fixture.ts
@@ -82,18 +82,28 @@ export async function ensurePersonaState(
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const context = await browser.newContext({ storageState: undefined });
+    // pid-unique temp path so two concurrent workers can't clobber each other's
+    // in-progress write.
+    const tmpPath = `${statePath}.${process.pid}.${attempt}.tmp`;
     try {
       const page = await context.newPage();
       const loginPage = new LoginPage(page, baseUrl);
       await loginPage.login(email);
       await dismissNewDesignDialog(page);
-      await context.storageState({ path: statePath });
+      // Write atomically: the fs.existsSync reuse check above must never observe
+      // a half-written persona file (a concurrent worker in the default
+      // multi-worker config would then load truncated JSON). Write a temp file,
+      // then rename it into place (atomic on the same filesystem). Last writer
+      // wins, which is fine — every persona session is equivalent.
+      await context.storageState({ path: tmpPath });
+      await fs.promises.rename(tmpPath, statePath);
       await context.close();
       personaStatePaths.set(email, statePath);
       return statePath;
     } catch (error) {
       lastError = error;
       await context.close().catch(() => {});
+      await fs.promises.unlink(tmpPath).catch(() => {});
       console.warn(
         `[auth] login for ${email} failed (attempt ${attempt}/${maxAttempts}): ${
           (error as Error)?.message ?? error

--- a/client-web/src/functional-e2e/space/organization-space-create.spec.ts
+++ b/client-web/src/functional-e2e/space/organization-space-create.spec.ts
@@ -32,6 +32,9 @@ const scenarioConfig: TestScenarioNoPreCreationConfig = {
 
 test.describe('CREATE Space Operations (Organization Account)', () => {
   test.beforeAll(async ({ browser }) => {
+    // Server-side scenario creation can approach the default 30s hook budget;
+    // give it headroom so a slow setup doesn't time out and cascade the file.
+    test.setTimeout(60_000);
     baseScenario =
       await TestScenarioFactory.createBaseScenarioOrganization(scenarioConfig);
     await setupAuthentication(

--- a/client-web/src/functional-e2e/space/space-create.spec.ts
+++ b/client-web/src/functional-e2e/space/space-create.spec.ts
@@ -30,6 +30,9 @@ const scenarioConfig: TestScenarioNoPreCreationConfig = {
 
 test.describe('CREATE Space Operations', () => {
   test.beforeAll(async ({ browser }) => {
+    // Server-side scenario creation can approach the default 30s hook budget;
+    // give it headroom so a slow setup doesn't time out and cascade the file.
+    test.setTimeout(60_000);
     await TestScenarioFactory.createBaseScenarioEmpty(scenarioConfig);
     await setupAuthentication(browser, TestUserManager.users.globalAdmin.email);
   });

--- a/client-web/src/functional-e2e/timeline/whole-day-events-crud.spec.ts
+++ b/client-web/src/functional-e2e/timeline/whole-day-events-crud.spec.ts
@@ -26,14 +26,14 @@ import { OrganizationWithSpaceModel } from '@alkemio/tests-lib/scenario/models/O
 import { TestScenarioFactory } from '@alkemio/tests-lib/scenario/TestScenarioFactory';
 import { TestUserManager } from '@alkemio/tests-lib';
 import { test as base, expect, BrowserContext, Page } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
-import { LoginPage } from '@src/functional-e2e/space/pages';
+import { ensurePersonaState } from '@src/functional-e2e/fixtures/authenticated-session.fixture';
 import { CalendarEventFormPage, dateLabelRe } from './pages/CalendarEventFormPage';
 
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
-const storageStatePath = path.join(process.cwd(), '.auth', 'whole-day-crud-admin.json');
 const VIEWER_TZ = 'Europe/Sofia';
+// Resolved in beforeAll to the shared per-persona session (login happens at
+// most once per user per run — see authenticated-session.fixture).
+let storageStatePath: string;
 
 // Dates live in NEXT year so they are always in the future regardless of when the
 // suite runs (a hardcoded year silently expires — and would strand the nightly).
@@ -82,14 +82,12 @@ test.beforeAll(async ({ browser }) => {
   baseScenario = await TestScenarioFactory.createBaseScenario(scenarioConfig);
   spaceNameId = baseScenario.space.nameId;
 
-  await fs.promises.mkdir(path.dirname(storageStatePath), { recursive: true });
-  const setupContext = await browser.newContext({ timezoneId: VIEWER_TZ });
-  const setupPage = await setupContext.newPage();
-  await new LoginPage(setupPage, baseUrl).login(TestUserManager.users.spaceAdmin.email);
-  const accept = setupPage.getByRole('button', { name: 'Accept all cookies' });
-  if (await accept.isVisible({ timeout: 3000 }).catch(() => false)) await accept.click();
-  await setupContext.storageState({ path: storageStatePath });
-  await setupContext.close();
+  // Reuse the shared spaceAdmin session (logs in once per run, cached to disk).
+  // The timezone pinning lives on the per-test context below, not the session.
+  storageStatePath = await ensurePersonaState(
+    browser,
+    TestUserManager.users.spaceAdmin.email
+  );
 });
 
 test.afterAll(async () => {

--- a/client-web/src/functional-e2e/timeline/whole-day-events-timezone.spec.ts
+++ b/client-web/src/functional-e2e/timeline/whole-day-events-timezone.spec.ts
@@ -32,13 +32,13 @@ import { TestScenarioFactory } from '@alkemio/tests-lib/scenario/TestScenarioFac
 import { TestUserManager, getGraphqlClient } from '@alkemio/tests-lib';
 import { CalendarEventType } from '@alkemio/tests-lib/core/generated/alkemio-schema';
 import { test, expect, Browser, BrowserContext } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
-import { LoginPage } from '@src/functional-e2e/space/pages';
+import { ensurePersonaState } from '@src/functional-e2e/fixtures/authenticated-session.fixture';
 import { CalendarEventFormPage, dateLabelRe } from './pages/CalendarEventFormPage';
 
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
-const storageStatePath = path.join(process.cwd(), '.auth', 'whole-day-tz-admin.json');
+// Resolved in beforeAll to the shared per-persona session (login happens at
+// most once per user per run — see authenticated-session.fixture).
+let storageStatePath: string;
 
 // Events live in NEXT year so the seeded dates and the grid month stay in the
 // future regardless of when the nightly runs (a hardcoded year silently expires).
@@ -147,18 +147,12 @@ test.beforeAll(async ({ browser }) => {
 
   calendarUrl = `${baseUrl}/${baseScenario.space.nameId}/calendar`;
 
-  // Log in once; every timezone context is built from this storage state.
-  await fs.promises.mkdir(path.dirname(storageStatePath), { recursive: true });
-  const setupContext = await browser.newContext();
-  const setupPage = await setupContext.newPage();
-  const loginPage = new LoginPage(setupPage, baseUrl);
-  await loginPage.login(TestUserManager.users.spaceAdmin.email);
-  const acceptCookies = setupPage.getByRole('button', { name: 'Accept all cookies' });
-  if (await acceptCookies.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await acceptCookies.click();
-  }
-  await setupContext.storageState({ path: storageStatePath });
-  await setupContext.close();
+  // Reuse the shared spaceAdmin session (logs in once per run, cached to disk);
+  // every timezone context below is built from this storage state.
+  storageStatePath = await ensurePersonaState(
+    browser,
+    TestUserManager.users.spaceAdmin.email
+  );
 });
 
 test.afterAll(async () => {

--- a/client-web/src/functional-e2e/user-profile/access-user-profile-from-dashboard.spec.ts
+++ b/client-web/src/functional-e2e/user-profile/access-user-profile-from-dashboard.spec.ts
@@ -1,54 +1,19 @@
 // spec: client-web/src/functional-e2e/user-profile-test-plan.md
 // Test: 1.1 Access User Profile from Dashboard
 
-import { delay } from '@alkemio/tests-lib';
-import { test, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { verifyMyDashboardWelcomeElement } from '../my-dashboard/my-dashboard-page-objects';
+import { createPersonaTest } from '../fixtures/authenticated-session.fixture';
 
-const password = process.env.AUTH_TEST_HARNESS_PASSWORD!;
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+
+const test = createPersonaTest('admin@alkem.io');
 
 test.describe('Navigation and Access', () => {
   test('1.1 Access User Profile from Dashboard', async ({ page }) => {
-    // Navigate to home page
+    // Already authenticated as admin via the shared persona session; land on the
+    // home dashboard.
     await page.goto(baseUrl);
-
-    // Accept cookies (CRD cookie banner may not always appear)
-    const cookieButton = page.getByRole('button', {
-      name: 'Accept All Cookies',
-    });
-    if (await cookieButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await cookieButton.click();
-    }
-
-    // 1. CRD header exposes a direct "Log in" link (replacing the MUI
-    // PersonIcon menu + "Log In | Sign Up" menu item).
-    const loginLink = page.getByRole('link', { name: 'Log in', exact: true });
-    await loginLink.waitFor({ state: 'visible', timeout: 30_000 });
-    await loginLink.click();
-
-    // Wait for login page
-    await page.waitForURL(/.*login.*/);
-
-    // Login
-    await page.getByRole('textbox', { name: 'E-Mail' }).fill('admin@alkem.io');
-    await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    // No explicit timeout: a click's timeout also covers the navigation it
-    // schedules, and 500ms is far too tight for a login submit round-trip.
-    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-
-    // Wait for dashboard
-    await page.waitForURL(/.*home.*/);
-
-    // Dismiss the one-time "A fresh new Alkemio is here" design dialog.
-    const switchToNewDesign = page.getByRole('button', {
-      name: /take me to the new design/i,
-    });
-    if (
-      await switchToNewDesign.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
-      await switchToNewDesign.click().catch(() => {});
-    }
 
     await verifyMyDashboardWelcomeElement(page);
 

--- a/client-web/src/functional-e2e/user-profile/direct-url-access-to-user-profile.spec.ts
+++ b/client-web/src/functional-e2e/user-profile/direct-url-access-to-user-profile.spec.ts
@@ -1,38 +1,18 @@
 // spec: client-web/src/functional-e2e/user-profile-test-plan.md
 // seed: seed-minimal.spec.js
 
-import { test, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { createPersonaTest } from '../fixtures/authenticated-session.fixture';
 
-const password = process.env.AUTH_TEST_HARNESS_PASSWORD!;
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+
+// admin@alkem.io is the globalAdmin persona (shares persona.admin-alkem-io.json
+// with the fixture-based specs, so it logs in at most once per run).
+const test = createPersonaTest('admin@alkem.io');
 
 test.describe('Navigation and Access', () => {
   test('Direct URL Access to User Profile', async ({ page }) => {
-    // Seed: Login (CRD header uses a direct "Log in" link)
-    await page.goto(baseUrl);
-    const cookieButton = page.getByRole('button', {
-      name: 'Accept All Cookies',
-    });
-    if (await cookieButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await cookieButton.click();
-    }
-    const loginLink = page.getByRole('link', { name: 'Log in', exact: true });
-    await loginLink.waitFor({ state: 'visible', timeout: 30_000 });
-    await loginLink.click();
-    await page.waitForURL(/.*login.*/);
-    await page.getByRole('textbox', { name: 'E-Mail' }).fill('admin@alkem.io');
-    await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-    await page.waitForURL(/.*home.*/);
-    const switchToNewDesign = page.getByRole('button', {
-      name: /take me to the new design/i,
-    });
-    if (
-      await switchToNewDesign.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
-      await switchToNewDesign.click().catch(() => {});
-    }
-
+    // Already authenticated as admin via the shared persona session.
     // 1. Navigate directly to /user/admin-alkemio/settings/profile
     await page.goto(`${baseUrl}/user/admin-alkemio/settings/profile`);
 

--- a/client-web/src/functional-e2e/user-profile/update-basic-information.spec.ts
+++ b/client-web/src/functional-e2e/user-profile/update-basic-information.spec.ts
@@ -1,11 +1,12 @@
 // spec: client-web/src/functional-e2e/user-profile-test-plan.md
 // seed: seed-minimal.spec.js
 
-import { delay } from '@alkemio/tests-lib/utils/delay';
-import { test, expect, Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
+import { createPersonaTest } from '../fixtures/authenticated-session.fixture';
 
-const password = process.env.AUTH_TEST_HARNESS_PASSWORD!;
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+
+const test = createPersonaTest('admin@alkem.io');
 
 // CRD profile identity fields are inline-edit buttons. Clicking the button
 // swaps the read-only button for an active textbox with the same accessible
@@ -48,32 +49,7 @@ test.describe('My Profile Tab - View and Edit', () => {
   let originalLastName: string;
 
   test('Update Basic Information', async ({ page }) => {
-    // Seed: Login
-    await page.goto(baseUrl);
-    const cookieButton = page.getByRole('button', {
-      name: 'Accept All Cookies',
-    });
-    if (await cookieButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await cookieButton.click();
-    }
-    await delay(1000); // inconsistency in passing locally
-    const loginLink = page.getByRole('link', { name: 'Log in', exact: true });
-    await loginLink.waitFor({ state: 'visible', timeout: 30_000 });
-    await loginLink.click();
-    await page.waitForURL(/.*login.*/);
-    await page.getByRole('textbox', { name: 'E-Mail' }).fill('admin@alkem.io');
-    await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-    await page.waitForURL(/.*home.*/);
-    const switchToNewDesign = page.getByRole('button', {
-      name: /take me to the new design/i,
-    });
-    if (
-      await switchToNewDesign.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
-      await switchToNewDesign.click().catch(() => {});
-    }
-
+    // Already authenticated as admin via the shared persona session.
     // Navigate to the Profile settings tab
     await page.goto(`${baseUrl}/user/admin-alkemio/settings/profile`);
 

--- a/client-web/src/functional-e2e/user-profile/view-profile-information.spec.ts
+++ b/client-web/src/functional-e2e/user-profile/view-profile-information.spec.ts
@@ -1,38 +1,16 @@
 // spec: client-web/src/functional-e2e/user-profile-test-plan.md
 // seed: seed-minimal.spec.js
 
-import { test, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { createPersonaTest } from '../fixtures/authenticated-session.fixture';
 
-const password = process.env.AUTH_TEST_HARNESS_PASSWORD!;
 const baseUrl = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+
+const test = createPersonaTest('admin@alkem.io');
 
 test.describe('My Profile Tab - View and Edit', () => {
   test('View Profile Information', async ({ page }) => {
-    // Seed: Login
-    await page.goto(baseUrl);
-    const cookieButton = page.getByRole('button', {
-      name: 'Accept All Cookies',
-    });
-    if (await cookieButton.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await cookieButton.click();
-    }
-    const loginLink = page.getByRole('link', { name: 'Log in', exact: true });
-    await loginLink.waitFor({ state: 'visible', timeout: 30_000 });
-    await loginLink.click();
-    await page.waitForURL(/.*login.*/);
-    await page.getByRole('textbox', { name: 'E-Mail' }).fill('admin@alkem.io');
-    await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-    await page.waitForURL(/.*home.*/);
-    const switchToNewDesign = page.getByRole('button', {
-      name: /take me to the new design/i,
-    });
-    if (
-      await switchToNewDesign.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
-      await switchToNewDesign.click().catch(() => {});
-    }
-
+    // Already authenticated as admin via the shared persona session.
     // Navigate to the Profile settings tab
     await page.goto(`${baseUrl}/user/admin-alkemio/settings/profile`);
 


### PR DESCRIPTION
## Problem

The client-web E2E suite passed **suite-by-suite** but failed non-deterministically when run **as a whole** (nightly). Two root causes:

1. **Login was the single point of failure.** Every authenticated spec logged in for itself in `beforeAll` (~60 live logins/run). Under load the CRD login-form render times out, and because almost every test logs in first, one slow render failed many tests. `describe.serial` blocks then cascaded a single flake into dozens of red rows / "did not run".
2. **The nightly config diverged from the interactive config.** It set no `viewport`/`channel`, so it ran bundled Chromium at 1280×720. At that height the sticky app header overlaps the calendar form **Save** button and intercepts the click — `whole-day-events-crud` T1 failed on every nightly (and stranded T2–T8), yet passed at 1920×1080.

## Changes

- **Shared per-persona session** (`fixtures/authenticated-session.fixture.ts`): `ensurePersonaState()` logs a persona in at most **once per run**, caches to `.auth/persona.*.json`, and **reuses it across Playwright worker restarts** (not just the in-memory cache — a worker restart otherwise forced a cold login inside the next spec's tight `beforeAll`). `config/global-setup.ts` clears stale persona files so reuse is strictly run-scoped.
- **`createPersonaTest()`** helper + converted the 4 `user-profile/` specs off their inline copy-pasted logins; the 2 `timeline/` specs now use the shared session too.
- **Heavier `beforeAll` budgets**: `space-create` / `organization-space-create` get `test.setTimeout(60_000)` so a slow `createBaseScenario` can't time out and cascade the file.
- **Nightly config aligned** with `playwright.config.ts`: branded Chrome at 1920×1080.

## Results — full nightly, local

| Metric | Before | After |
|---|---|---|
| Passed | 187 | **225** |
| Hard failures | 7 | **4** |
| Flaky | 13 | **0** |
| Did-not-run | 22 | **0** |
| Browser crashes | 5 | **0** |
| Logins/run | ~60 | **6** |
| Duration | 48.9m | 38.3m |

Timeline is now 14/14.

## Remaining 4 failures — not addressed here, by design

All 4 are in the `authentication/` suite, which exercises the **real** login flow (can't use cached sessions) and times out **waiting for the login page to render** (`E-Mail *` field / `Forgot password?` link, 30–120s). This is the honest canary for **login-page render latency under load** — arguably an app-perf signal to raise with the platform team rather than something to mask. Left intentionally logging in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by reusing authenticated sessions and clearing stale sessions before test runs.
  * Standardized nightly browser tests to Chrome at a 1920×1080 viewport, preventing layout-related interaction failures.
  * Increased time limits for space setup scenarios to reduce failures during slow initialization.

* **Refactor**
  * Simplified profile and calendar test authentication by using shared pre-authenticated sessions while preserving existing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->