### PR TITLE
Tests for the (feat)029 - lang persistence

### DIFF
--- a/client-web/.gitignore
+++ b/client-web/.gitignore
@@ -68,3 +68,6 @@ web_modules/
 
 # Authentication state files (contain session tokens)
 .auth/
+
+# 029 language-offer acceptance run report (throwaway)
+config/playwright-report-language-offer/

--- a/client-web/config/playwright.config.language-offer.ts
+++ b/client-web/config/playwright.config.language-offer.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Forge verifier config for feature 029-detect-signup-language.
+// Deliberately has NO globalSetup: the default global-setup calls
+// registerAllTestUsers() which requires the server's non-interactive-login
+// endpoint — DISABLED on this stack. These specs authenticate through the
+// Kratos browser UI instead, and the anonymous specs need no auth at all.
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+export default defineConfig({
+  testDir: path.resolve(__dirname, '..', 'src', 'functional-e2e', 'language-offer'),
+  fullyParallel: false,
+  forbidOnly: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report-language-offer' }]],
+  use: {
+    baseURL: process.env.ALKEMIO_BASE_URL || 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    headless: process.env.UI_HEADLESS !== 'false',
+  },
+  // Detection scenarios drive Config + session GraphQL through Traefik; give the
+  // SPA cold-load and Kratos redirects room to settle.
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  projects: [
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome', viewport: { width: 1440, height: 900 } },
+    },
+  ],
+});

--- a/client-web/src/functional-e2e/language-offer/helpers.ts
+++ b/client-web/src/functional-e2e/language-offer/helpers.ts
@@ -1,0 +1,122 @@
+// Shared helpers for the 029-detect-signup-language acceptance walks.
+//
+// ENVIRONMENT NOTE (verified 2026-07-23):
+//   The SPA under test is the feature worktree build served same-origin through
+//   Traefik at http://localhost:3000. Reaching it at the raw vite dev origin
+//   http://localhost:3001 fails CORS for every GraphQL + Kratos call
+//   (apollo-require-preflight header rejected; whoami wildcard-vs-credentials),
+//   so ConfigProvider never resolves and — by design (resolveOfferLanguage
+//   suspends until config loads, R-10) — no banner can ever appear there.
+//   All walks therefore target :3000. The spec.md/repos.yaml `:3001` URLs are
+//   the dev origin; :3000 is the running-app origin.
+//
+// DETECTION LEVER: browser language is driven per-file via
+//   test.use({ locale: 'nl-NL' })  -> sets navigator.languages, which is exactly
+//   what detectBrowserLanguage() (navigator.languages[0], primary-subtag) reads.
+
+import { Page, expect, Locator } from '@playwright/test';
+
+export const BASE_URL = process.env.ALKEMIO_BASE_URL || 'http://localhost:3000';
+export const GRAPHQL_URL = process.env.ALKEMIO_GRAPHQL || 'http://localhost:3000/graphql';
+
+// --- Selectors (from the real implementation) ---
+// LanguageOfferBanner.tsx: <header data-testid="language-offer-banner" data-language="nl">
+export const languageOfferBanner = (page: Page): Locator => page.getByTestId('language-offer-banner');
+
+// CookieConsentBanner.tsx (crd-layout keys) — button labels are the same across
+// locales for Accept-All (it is not re-translated in the nl file? verify), so we
+// anchor the landing wait on it. If localised, the settings/confirm still work by
+// role within the banner.
+export const cookieConsentAcceptAll = (page: Page): Locator =>
+  page.getByRole('button', { name: /Accept All Cookies|Alle cookies accepteren/i });
+// NOTE (2026-07-28): the `preference`/functional cookie category was removed. The
+// anonymous language choice is session-only (in-memory), never written to the
+// browser, so there is no per-category consent to grant. The cookie banner keeps
+// only technical + analysis; answering it (any way) is all the language offer waits
+// on (FR-013b-ii, UX ordering). See consentAcceptCookies() below.
+
+// The Dutch offer copy (crd-language nl namespace), rendered in the OFFERED language (FR-007).
+export const DUTCH_BANNER_TITLE = 'Alkemio is ook beschikbaar in het Nederlands.';
+export const DUTCH_ACCEPT_LABEL = 'Ja, gebruik Nederlands';
+export const DUTCH_DECLINE_LABEL = 'Nee bedankt, blijf in het Engels';
+
+export const dutchAcceptButton = (page: Page): Locator =>
+  page.getByRole('button', { name: DUTCH_ACCEPT_LABEL });
+export const dutchDeclineButton = (page: Page): Locator =>
+  page.getByRole('button', { name: DUTCH_DECLINE_LABEL });
+
+// localStorage keys the feature governs.
+export const LANGUAGE_OFFER_STORAGE_KEY = 'alkemio.languageOffer';
+export const LEGACY_I18N_KEY = 'i18nextLng';
+export const CONSENT_COOKIE_NAME = 'accepted_cookies';
+
+// The footer renders the ACTIVE display language as its endonym ("English" /
+// "Nederlands") in every locale file — this is the app's own ground truth for
+// which language the interface is currently displayed in.
+export const footerLanguageEnglish = (page: Page): Locator =>
+  page.getByRole('contentinfo').getByRole('button', { name: 'English' });
+export const footerLanguageDutch = (page: Page): Locator =>
+  page.getByRole('contentinfo').getByRole('button', { name: 'Nederlands' });
+
+// Either footer language endonym — used to auto-wait for the footer to render
+// before reading the active display language (the footer lazy-loads AFTER the
+// cookie-consent banner that landAnonymously anchors on; reading the language
+// with a bare isVisible() before it renders races to 'unknown' under load).
+export const footerLanguageAny = (page: Page): Locator =>
+  page.getByRole('contentinfo').getByRole('button', { name: /^(English|Nederlands)$/ });
+
+/**
+ * Returns 'en' | 'nl', read from the footer language button endonym. Auto-waits
+ * for the footer language control to render first (deterministic — no race), so
+ * callers get the app's own ground-truth display language rather than 'unknown'
+ * when the footer is still mounting. Throws (via expect) only if the footer never
+ * renders a language control within the timeout — a real failure, not a flake.
+ */
+export async function activeDisplayLanguage(page: Page, timeout = 20_000): Promise<string> {
+  await expect(footerLanguageAny(page)).toBeVisible({ timeout });
+  if (await footerLanguageDutch(page).isVisible().catch(() => false)) return 'nl';
+  if (await footerLanguageEnglish(page).isVisible().catch(() => false)) return 'en';
+  return 'unknown';
+}
+
+/**
+ * Land on a public page as a genuinely fresh anonymous visitor. The Playwright
+ * fixture already gives each test an isolated context (no cookies/storage), so
+ * this is just the navigation + settle. We land on /home; the SPA resolves
+ * anonymously (public Explore Spaces) and shows the cookie-consent banner.
+ * The landing wait is locale-independent (the consent Accept-All button).
+ */
+export async function landAnonymously(page: Page, pathAfterBase = '/home'): Promise<void> {
+  await page.goto(`${BASE_URL}${pathAfterBase}`);
+  await expect(cookieConsentAcceptAll(page)).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Answer (accept) the cookie-consent banner so the language offer can appear.
+ * With the `preference` category removed, there is a single "answer the cookie
+ * banner" action — Accept All resolves consent (technical + analysis). The
+ * anonymous language choice itself is session-only and never stored regardless.
+ */
+export async function consentAcceptCookies(page: Page): Promise<void> {
+  await cookieConsentAcceptAll(page).click();
+  await expect(cookieConsentAcceptAll(page)).toHaveCount(0, { timeout: 10_000 });
+}
+
+/** Read the two language-related localStorage keys + the consent cookie. Used to
+ *  assert the session-only invariant: an anonymous choice writes NOTHING (SC-001c). */
+export async function readLanguageStorage(page: Page): Promise<{
+  languageOffer: string | null;
+  legacyI18n: string | null;
+  consentCookie: string | undefined;
+}> {
+  const ls = await page.evaluate(
+    ({ offerKey, legacyKey }) => ({
+      languageOffer: window.localStorage.getItem(offerKey),
+      legacyI18n: window.localStorage.getItem(legacyKey),
+    }),
+    { offerKey: LANGUAGE_OFFER_STORAGE_KEY, legacyKey: LEGACY_I18N_KEY }
+  );
+  const cookies = await page.context().cookies();
+  const consent = cookies.find(c => c.name === CONSENT_COOKIE_NAME)?.value;
+  return { languageOffer: ls.languageOffer, legacyI18n: ls.legacyI18n, consentCookie: consent };
+}

--- a/client-web/src/functional-e2e/language-offer/loginHelper.ts
+++ b/client-web/src/functional-e2e/language-offer/loginHelper.ts
@@ -1,0 +1,73 @@
+// UI login helper for the 029 acceptance walks.
+//
+// The stack has non-interactive-login DISABLED, so we authenticate through the
+// Kratos browser UI exactly like the existing harness LoginPage does, but
+// against the running-app origin :3000. Seeded users log in with password
+// 'password' (e.g. non.space@alkem.io). admin@alkem.io also works on this stack.
+//
+// IMPORTANT: the anonymous header AND the Kratos-served login form are localised
+// to the browser locale under test (Log in/Anmelden/Inloggen; Password/Passwort;
+// Sign in/Anmelden). All control locators below therefore match every supported
+// label so the helper works under any test.use({ locale }).
+
+import { Page, expect } from '@playwright/test';
+import { BASE_URL } from './helpers';
+
+const PASSWORD = process.env.AUTH_TEST_HARNESS_PASSWORD || 'password';
+
+const LOGIN_LINK_RE = /^(Log in|Inloggen|Anmelden|Iniciar sesión|Se connecter|Вход)$/i;
+const LOGOUT_ITEM_RE = /^(Log out|Uitloggen|Abmelden|Cerrar sesión|Se déconnecter|Изход)$/i;
+// Kratos field labels carry a trailing " *"; match the stem across languages.
+const PASSWORD_FIELD_RE = /^(Password|Passwort|Wachtwoord|Contraseña|Mot de passe|Парола) \*$/i;
+const SIGNIN_BUTTON_RE = /^(Sign in|Anmelden|Inloggen|Iniciar sesión|Se connecter|Вход)$/i;
+
+/** Log in through the Kratos UI. Leaves the page on the authenticated shell. */
+export async function uiLogin(page: Page, email: string, password: string = PASSWORD): Promise<void> {
+  await page.goto(`${BASE_URL}/home`);
+
+  // Dismiss cookie consent if present so it doesn't overlay the header.
+  const acceptAll = page.getByRole('button', {
+    name: /Accept All Cookies|Alle cookies accepteren|Alle Cookies akzeptieren/i,
+  });
+  if (await acceptAll.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await acceptAll.click().catch(() => {});
+  }
+
+  // The in-SPA "Log in" link initialises the Kratos flow (a hard visit to /login
+  // does not render the form). Wait for it, click, then fill the Kratos form.
+  const loginLink = page.getByRole('link', { name: LOGIN_LINK_RE });
+  await loginLink.first().waitFor({ state: 'visible', timeout: 30_000 });
+  await loginLink.first().click();
+  await page.waitForURL(/.*login.*/, { timeout: 30_000 });
+
+  // Email label is "E-Mail *" in every locale; password label is localised.
+  const emailField = page.getByLabel('E-Mail *');
+  await emailField.waitFor({ state: 'visible', timeout: 30_000 });
+  await emailField.fill(email);
+  await page.getByLabel(PASSWORD_FIELD_RE).fill(password);
+  await page.getByRole('button', { name: SIGNIN_BUTTON_RE }).first().click();
+
+  // Land back on the authenticated app.
+  await page.waitForURL(/.*(home|user).*/, { timeout: 30_000 });
+
+  // One-time "A fresh new Alkemio is here" dialog — opt into the new design if shown.
+  const switchToNew = page.getByRole('button', { name: /take me to the new design/i });
+  if (await switchToNew.isVisible({ timeout: 4_000 }).catch(() => false)) {
+    await switchToNew.click().catch(() => {});
+  }
+}
+
+/** Log out via the user menu so a subsequent login can use a different account. */
+export async function uiLogout(page: Page): Promise<void> {
+  await page.goto(`${BASE_URL}/home`);
+  const avatar = page.getByRole('banner').getByRole('button').last();
+  await avatar.click();
+  const logout = page.getByRole('menuitem', { name: LOGOUT_ITEM_RE });
+  await logout.click().catch(() => {});
+  await page.waitForTimeout(1500);
+}
+
+/** Assert the authenticated shell is present (user avatar in the banner). */
+export async function expectAuthenticated(page: Page): Promise<void> {
+  await expect(page.getByRole('banner').getByRole('button').last()).toBeVisible({ timeout: 20_000 });
+}

--- a/client-web/src/functional-e2e/language-offer/us1-signup-offer.spec.ts
+++ b/client-web/src/functional-e2e/language-offer/us1-signup-offer.spec.ts
@@ -1,0 +1,59 @@
+// Feature 029-detect-signup-language — US1: new Dutch-speaking user offered Dutch.
+//
+// HEADLESS SIGNUP IS INFEASIBLE on this stack: the multi-step Kratos sign-up
+// (terms -> details -> password -> MailSlurper email verification) does not drive
+// reliably headless — the "Volgende/Next" transition stalls after the details
+// step. Recorded as infeasible-headless. US1's banner appears on FIRST
+// AUTHENTICATED LANDING via the very same detection + gate code exercised by US3
+// (detectBrowserLanguage + resolveOfferLanguage + useLanguageOffer), so the
+// detection-precedence half of US1 is covered here at the anonymous surface,
+// which runs the identical resolveOfferLanguage() decision:
+//   AS5 (de-DE -> no offer), AS6 (nl-BE -> Dutch offered), AS7 (en-first -> no
+//   offer). AS1/AS2/AS3 (accept/decline recording on a new account) and AS8
+//   (external-IdP) require completed signup and are recorded as infeasible /
+//   covered-by-US3 + client-web:T007 unit.
+//
+// NOTE: the anonymous offer banner was originally broken (it never rendered for an
+// unauthenticated visitor because useLegacyLanguageReconciliation never latched
+// reconcileComplete=true for !isAuthenticated — BUG-B). That is now FIXED, so the
+// nl-BE POSITIVE case (banner offered) is the regression guard for the fix, and the
+// de-DE / en-first NEGATIVE cases (no banner) continue to hold.
+//
+// spec source: specs/029-detect-signup-language/repos.yaml -> tracks (US1)
+
+import { test, expect } from '@playwright/test';
+import { landAnonymously, languageOfferBanner, consentAcceptCookies } from './helpers';
+
+test.describe('US1-AS5 de-DE — no Dutch offer (not eligible, SC-008)', () => {
+  test.use({ locale: 'de-DE' });
+  test('US1-AS5 — de-DE browser shows no offer banner', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+    await page.waitForTimeout(3000);
+    await expect(languageOfferBanner(page)).toHaveCount(0);
+    await page.screenshot({ path: 'us1-as5-de-no-offer.png', fullPage: false });
+  });
+});
+
+test.describe('US1-AS7 en-US — English top-ranked, no Dutch offer', () => {
+  test.use({ locale: 'en-US' });
+  test('US1-AS7 — English browser shows no offer banner', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+    await page.waitForTimeout(3000);
+    await expect(languageOfferBanner(page)).toHaveCount(0);
+    await page.screenshot({ path: 'us1-as7-en-no-offer.png', fullPage: false });
+  });
+});
+
+test.describe('US1-AS6 nl-BE — Belgian Dutch maps to nl, Dutch offered', () => {
+  test.use({ locale: 'nl-BE' });
+  test('US1-AS6 — nl-BE browser is offered Dutch', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(banner).toHaveAttribute('data-language', 'nl');
+    await page.screenshot({ path: 'us1-as6-nlbe-dutch-offered.png', fullPage: false });
+  });
+});

--- a/client-web/src/functional-e2e/language-offer/us2-cross-device-persistence.spec.ts
+++ b/client-web/src/functional-e2e/language-offer/us2-cross-device-persistence.spec.ts
@@ -1,0 +1,123 @@
+// Feature 029-detect-signup-language — US2: language preference follows the user
+// across browsers/devices (R-1 / FR-008 / FR-009 / FR-011). This is the
+// server-persistence half — the switcher/settings path, no detection needed.
+//
+// Uses seeded user non.space@alkem.io / password, authenticating through the
+// Kratos browser UI (non-interactive-login is disabled on this stack). Each test
+// performs multiple full UI logins across fresh contexts, so timeouts are raised.
+//
+// spec source: specs/029-detect-signup-language/repos.yaml -> tracks (US2)
+
+import { test, expect, Page } from '@playwright/test';
+import { BASE_URL, footerLanguageDutch, languageOfferBanner } from './helpers';
+import { uiLogin } from './loginHelper';
+
+const USER_EMAIL = 'non.space@alkem.io';
+
+// Settings language Select (UserSettingsTabView.tsx): SelectTrigger aria-label is
+// the localised "Interface language" (en) / "Interfacetaal" (nl) /
+// "Oberflächensprache" (de) — match all so the test is robust to whatever the
+// account's current display language is.
+const languageSelectTrigger = (page: Page) =>
+  page.getByRole('combobox', { name: /Interface language|Interfacetaal|Oberflächensprache/i });
+
+/** Derive the authenticated user's URL slug in a locale-independent way. The
+ *  dashboard renders an account link `/user/<slug>/settings/account` regardless
+ *  of the display language, so we wait for it and parse the slug from its href. */
+async function deriveUserSlug(page: Page): Promise<string> {
+  await page.goto(`${BASE_URL}/home`);
+  const accountLink = page.locator('a[href*="/settings/account"]').first();
+  await accountLink.waitFor({ state: 'attached', timeout: 25_000 });
+  const href = await accountLink.getAttribute('href');
+  const slug = href?.match(/\/user\/([^/?#]+)/)?.[1];
+  expect(slug, `could not derive user slug from account link href=${href}`).toBeTruthy();
+  return slug as string;
+}
+
+async function gotoLanguageSettings(page: Page): Promise<void> {
+  const slug = await deriveUserSlug(page);
+  await page.goto(`${BASE_URL}/user/${slug}/settings/settings`);
+  await expect(languageSelectTrigger(page)).toBeVisible({ timeout: 20_000 });
+}
+
+async function setLanguageViaSettings(page: Page, endonym: string): Promise<void> {
+  await languageSelectTrigger(page).click();
+  await page.getByRole('option', { name: endonym, exact: true }).click();
+  // Give the updateUserSettings mutation time to persist.
+  await page.waitForTimeout(2500);
+}
+
+test.describe('US2 — cross-device / cross-session persistence', () => {
+  // Reset the user back to English at the end of each test so runs are idempotent.
+  test.afterEach(async ({ browser }) => {
+    const ctx = await browser.newContext({ locale: 'en-US' });
+    const page = await ctx.newPage();
+    try {
+      await uiLogin(page, USER_EMAIL);
+      await gotoLanguageSettings(page);
+      const current = (await languageSelectTrigger(page).textContent())?.trim();
+      if (current && current !== 'English') {
+        await setLanguageViaSettings(page, 'English');
+      }
+    } catch {
+      /* best-effort reset */
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  // US2-AS5: change language in settings -> persists on a fresh re-login (a second
+  // "device" = a brand-new context with cleared storage). FR-008/FR-009/FR-011.
+  test('US2-AS5 — settings language change persists across a fresh-context re-login', async ({
+    browser,
+  }) => {
+    test.setTimeout(220_000);
+    // Device 1 (en-US browser): log in, switch to Dutch via settings.
+    const ctx1 = await browser.newContext({ locale: 'en-US' });
+    const page1 = await ctx1.newPage();
+    await uiLogin(page1, USER_EMAIL);
+    await gotoLanguageSettings(page1);
+    await setLanguageViaSettings(page1, 'Nederlands');
+    // Immediate effect on device 1.
+    await expect(footerLanguageDutch(page1)).toBeVisible({ timeout: 15_000 });
+    await page1.screenshot({ path: 'us2-as5-device1-dutch.png', fullPage: false });
+    await ctx1.close();
+
+    // Device 2 (fresh context, still en-US browser): log in again — Dutch persists
+    // with zero re-selection, proving it is a user-account setting not a browser one.
+    const ctx2 = await browser.newContext({ locale: 'en-US' });
+    const page2 = await ctx2.newPage();
+    await uiLogin(page2, USER_EMAIL);
+    await page2.goto(`${BASE_URL}/home`);
+    await expect(footerLanguageDutch(page2)).toBeVisible({ timeout: 20_000 });
+    // Stored preference wins => no new language offer banner.
+    await expect(languageOfferBanner(page2)).toHaveCount(0);
+    await page2.screenshot({ path: 'us2-as5-device2-dutch-persisted.png', fullPage: false });
+    await ctx2.close();
+  });
+
+  // US2-AS3: stored Dutch + a de-DE browser -> stored preference wins, no offer.
+  test('US2-AS3 — stored preference wins over a differing browser language; no offer', async ({
+    browser,
+  }) => {
+    test.setTimeout(220_000);
+    // Seed Dutch on the account (en-US device).
+    const ctx1 = await browser.newContext({ locale: 'en-US' });
+    const page1 = await ctx1.newPage();
+    await uiLogin(page1, USER_EMAIL);
+    await gotoLanguageSettings(page1);
+    await setLanguageViaSettings(page1, 'Nederlands');
+    await expect(footerLanguageDutch(page1)).toBeVisible({ timeout: 15_000 });
+    await ctx1.close();
+
+    // Sign in from a de-DE browser: account Dutch must win, and NO offer banner.
+    const ctx2 = await browser.newContext({ locale: 'de-DE' });
+    const page2 = await ctx2.newPage();
+    await uiLogin(page2, USER_EMAIL);
+    await page2.goto(`${BASE_URL}/home`);
+    await expect(footerLanguageDutch(page2)).toBeVisible({ timeout: 20_000 });
+    await expect(languageOfferBanner(page2)).toHaveCount(0);
+    await page2.screenshot({ path: 'us2-as3-stored-wins.png', fullPage: false });
+    await ctx2.close();
+  });
+});

--- a/client-web/src/functional-e2e/language-offer/us3-anonymous-offer.spec.ts
+++ b/client-web/src/functional-e2e/language-offer/us3-anonymous-offer.spec.ts
@@ -1,0 +1,166 @@
+// Feature 029-detect-signup-language — US3: anonymous Dutch-speaking visitors are
+// offered Dutch too. Highest-value story (widest funnel). Exercises: the banner-vs-
+// cookie-consent ordering, the cold-load display race, SC-001c (session-only — the
+// anonymous choice is in-memory and written NOWHERE in the browser), and the
+// FR-004/SC-005 "offer never silently switches display" invariant (anonymous
+// pre-answer display MUST be the platform default).
+//
+// NOTE (2026-07-28): the `preference` cookie category and the localStorage
+// persistence were removed — the anonymous choice is session-only, so it is never
+// remembered across sessions (a reload re-offers). These specs assert that.
+//
+// Target origin :3000 (running app, same-origin). Browser language driven by
+// test.use({ locale }) which sets navigator.languages — exactly what
+// detectBrowserLanguage() reads.
+//
+// spec source: specs/029-detect-signup-language/repos.yaml -> forge.verification.tracks (US3)
+
+import { test, expect } from '@playwright/test';
+import {
+  landAnonymously,
+  languageOfferBanner,
+  cookieConsentAcceptAll,
+  consentAcceptCookies,
+  dutchAcceptButton,
+  dutchDeclineButton,
+  readLanguageStorage,
+  activeDisplayLanguage,
+  footerLanguageDutch,
+  footerLanguageEnglish,
+  DUTCH_BANNER_TITLE,
+} from './helpers';
+
+// A Dutch (Netherlands) browser for every test in this file.
+test.use({ locale: 'nl-NL' });
+
+test.describe('US3 — anonymous Dutch offer', () => {
+  // DL-6 / FR-004 / SC-005 core invariant: a nl-NL anonymous visitor who has NOT
+  // yet answered the offer must see the platform DEFAULT (English) — tier #4
+  // (browser detection) feeds the OFFER only, never a silent display switch.
+  test('US3-SC005 — anonymous pre-answer display is the platform default (English), NOT auto-switched to Dutch', async ({
+    page,
+  }) => {
+    await landAnonymously(page);
+    // Cookie consent unanswered at this point; display must be the platform default.
+    const lang = await activeDisplayLanguage(page);
+    await page.screenshot({ path: 'us3-sc005-preanswer-display.png', fullPage: false });
+    expect(
+      lang,
+      'FR-004/SC-005/DL-6: an un-answered anonymous nl-NL visitor must be shown the platform default (en), not silently switched to Dutch by navigator detection'
+    ).toBe('en');
+  });
+
+  // US3-AS2b: on first visit, while the cookie-consent banner is unanswered, the
+  // language banner MUST NOT be shown (FR-013b-ii — consent resolved first).
+  test('US3-AS2b — language banner not shown until consent resolved', async ({ page }) => {
+    await landAnonymously(page);
+
+    // Consent banner is present (fresh context => no accepted_cookies cookie).
+    await expect(cookieConsentAcceptAll(page)).toBeVisible({ timeout: 15_000 });
+
+    // Language banner must NOT be present yet, even though the browser is nl-NL.
+    await expect(languageOfferBanner(page)).toHaveCount(0);
+
+    await page.screenshot({
+      path: 'us3-as2b-consent-unanswered-no-language-banner.png',
+      fullPage: false,
+    });
+  });
+
+  // US3-AS1: nl-NL context + the cookie banner answered -> the same non-blocking
+  // banner offers Dutch, written in Dutch (FR-007).
+  test('US3-AS1 — Dutch banner appears after consent, written in Dutch', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    // data-language must be the eligible Dutch language.
+    await expect(banner).toHaveAttribute('data-language', 'nl');
+    // Copy is in Dutch (FR-007): the title.
+    await expect(banner).toContainText(DUTCH_BANNER_TITLE);
+
+    await page.screenshot({ path: 'us3-as1-dutch-banner.png', fullPage: false });
+  });
+
+  // US3-AS2 (session-only): accept -> the interface renders Dutch for the CURRENT
+  // SESSION only. Nothing is written to the browser, and because the choice is
+  // in-memory, a reload (a fresh page session) is RE-OFFERED — it is not remembered.
+  test('US3-AS2 — accept renders Dutch for the session; nothing stored; reload re-offers', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await dutchAcceptButton(page).click();
+
+    // Banner dismisses; interface is Dutch for this session.
+    await expect(banner).toHaveCount(0, { timeout: 10_000 });
+    await expect(footerLanguageDutch(page)).toBeVisible({ timeout: 15_000 });
+
+    // Session-only: NOTHING language-related is written to the browser.
+    const storage = await readLanguageStorage(page);
+    expect(storage.languageOffer, 'session-only: alkemio.languageOffer is never written').toBeNull();
+    expect(storage.legacyI18n, 'session-only: legacy i18nextLng is never written').toBeNull();
+
+    // A reload starts a fresh page session -> the in-memory choice is gone. The
+    // cookie-consent cookie persists (consent already resolved), so the language
+    // banner returns directly, re-offering Dutch (not remembered across sessions).
+    await page.reload();
+    await expect(languageOfferBanner(page)).toBeVisible({ timeout: 15_000 });
+    const afterReload = await readLanguageStorage(page);
+    expect(afterReload.languageOffer, 'still nothing stored after reload').toBeNull();
+
+    await page.screenshot({ path: 'us3-as2-accept-session-only.png', fullPage: false });
+  });
+
+  // US3-AS2a (SC-001c hard negative): any anonymous accept renders Dutch for the
+  // session but writes ZERO language keys to browser storage (session-only by design).
+  test('US3-AS2a — accept writes zero language keys to browser storage (SC-001c)', async ({
+    page,
+  }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await dutchAcceptButton(page).click();
+
+    // Session renders Dutch (in-memory context) ...
+    await expect(footerLanguageDutch(page)).toBeVisible({ timeout: 15_000 });
+
+    // ... but NOTHING language-related is written to the browser at all.
+    const storage = await readLanguageStorage(page);
+    expect(storage.languageOffer, 'session-only: alkemio.languageOffer must never be written').toBeNull();
+    expect(storage.legacyI18n, 'session-only: legacy i18nextLng must never be written (retired ungated write)').toBeNull();
+
+    await page.screenshot({ path: 'us3-as2a-accept-zero-storage.png', fullPage: false });
+  });
+
+  // US3-AS3 (session-only): decline -> stays default (English) and the banner is
+  // gone for the rest of the session. Nothing is stored; a reload (fresh session)
+  // re-offers, since the answer is not remembered across sessions.
+  test('US3-AS3 — decline stays English; nothing stored; not re-shown this session', async ({ page }) => {
+    await landAnonymously(page);
+    await consentAcceptCookies(page);
+
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await dutchDeclineButton(page).click();
+
+    // Stays in the platform default (English footer label) and the banner is gone
+    // for the rest of this session.
+    await expect(banner).toHaveCount(0, { timeout: 10_000 });
+    await expect(footerLanguageEnglish(page)).toBeVisible({ timeout: 15_000 });
+
+    // Session-only: nothing is written to the browser.
+    const storage = await readLanguageStorage(page);
+    expect(storage.languageOffer, 'session-only: the decline is not persisted').toBeNull();
+
+    // Not re-shown within the same session (in-memory answered) — assert it stays gone.
+    await expect(footerLanguageEnglish(page)).toBeVisible();
+    await expect(languageOfferBanner(page)).toHaveCount(0);
+
+    await page.screenshot({ path: 'us3-as3-decline-session-only.png', fullPage: false });
+  });
+});

--- a/client-web/src/functional-e2e/language-offer/us3b-review-fixes.spec.ts
+++ b/client-web/src/functional-e2e/language-offer/us3b-review-fixes.spec.ts
@@ -1,0 +1,149 @@
+// Feature 029-detect-signup-language — Phase V' review-fix regression additions.
+//
+// These specs validate the review-phase client-web fixes committed after the
+// Phase-V acceptance run (HEAD 42269a630). They are additive to the persisted
+// US1/US2/US3/US5 walks and run with the same
+// config/playwright.config.language-offer.ts against the running app at :3000.
+//
+// corr-client-4 (LIVE, structural + best-effort behavioral) — LanguageOfferProvider
+//   was HOISTED to App.tsx, above all CrdLayoutWrapper route groups, so an
+//   anonymous visitor's in-memory `answered` choice survives a CLIENT-SIDE route
+//   change (SC-004 / FR-013b-i). See the extensive INFEASIBILITY NOTE on the test
+//   below: this build's ANONYMOUS surface exposes NO client-side (SPA-internal)
+//   cross-route-group link — every anonymous navigation (shell links, public
+//   space cards) is a full document load, which by design loses the un-persisted
+//   in-memory choice. The corr-client-4 precondition (a client-side transition)
+//   therefore cannot be produced through the anonymous UI as a black-box walk.
+//   The fix is instead verified structurally (provider hoisted above <Outlet/>;
+//   CrdLayoutWrapper no longer owns the provider) plus the observable invariant
+//   that a full reload without preference consent correctly re-offers.
+//
+// corr-client-2 (robustness) — a non-JSON / truncated `accepted_cookies` consent
+//   cookie must NEVER crash the app (FR-013e). (Since the 2026-07-28 session-only
+//   change the LanguageOfferProvider no longer reads the consent cookie at all — it
+//   is pure in-memory — so nothing JSON-parses the raw value; `consentResolved` is a
+//   plain presence check. This test remains a lasting regression guard that a
+//   malformed consent cookie does not blank the SPA.) Seeded via context.addCookies
+//   before first load; asserts the app renders and raises no uncaught error.
+//
+// Browser language driven by test.use({ locale: 'nl-NL' }) → navigator.languages,
+// exactly what detectBrowserLanguage() reads.
+
+import { test, expect } from '@playwright/test';
+import {
+  BASE_URL,
+  landAnonymously,
+  languageOfferBanner,
+  consentAcceptCookies,
+  dutchDeclineButton,
+  readLanguageStorage,
+  footerLanguageEnglish,
+  cookieConsentAcceptAll,
+} from './helpers';
+
+test.use({ locale: 'nl-NL' });
+
+test.describe("US3b — Phase V' review-fix regressions", () => {
+  // corr-client-4 — observable half: after DECLINE, a FULL page reload (the only
+  // navigation this build's anonymous surface offers between route groups) correctly
+  // RE-OFFERS, because the choice is session-only (in-memory) and never persisted.
+  // This is the contrapositive that proves the choice was NOT written to storage
+  // (session-only stores nothing; the in-memory choice survives client-side
+  // navigation only while the hoisted provider stays mounted, which a full reload
+  // deliberately tears down).
+  test('corr-client-4 — anon decline is session-only / in-memory (re-offered after a full reload)', async ({
+    page,
+  }) => {
+    await landAnonymously(page, '/home');
+    await consentAcceptCookies(page); // answer the cookie banner so the language offer can appear
+
+    const banner = languageOfferBanner(page);
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(banner).toHaveAttribute('data-language', 'nl');
+
+    await dutchDeclineButton(page).click();
+    await expect(banner).toHaveCount(0, { timeout: 10_000 });
+    await expect(footerLanguageEnglish(page)).toBeVisible({ timeout: 15_000 });
+
+    // Nothing persisted (session-only).
+    const afterDecline = await readLanguageStorage(page);
+    expect(
+      afterDecline.languageOffer,
+      'session-only → alkemio.languageOffer must NOT be written'
+    ).toBeNull();
+
+    // A full reload loses the in-memory choice → the visitor is re-offered. This is
+    // the documented, correct behaviour without consent AND confirms nothing was
+    // silently persisted that would suppress the re-offer.
+    await page.reload();
+    // consent cookie (technical) persists, so consent is already resolved → banner returns directly.
+    await expect(languageOfferBanner(page)).toBeVisible({ timeout: 15_000 });
+    const afterReload = await readLanguageStorage(page);
+    expect(afterReload.languageOffer, 'still nothing persisted after reload').toBeNull();
+
+    await page.screenshot({ path: 'us3b-corr-client-4-inmemory-only.png', fullPage: false });
+  });
+
+  // corr-client-4 — LIVE client-side-navigation form of the scenario.
+  // INFEASIBILITY NOTE (verified 2026-07-23): the anonymous surface of this build
+  // exposes no client-side (SPA-internal) cross-route-group link. Probed
+  // exhaustively: the shell links (logo→/home, Log in→/login, Sign Up→/sign_up)
+  // and every public space card (absolute-URL <a> e.g. /welcome-space) each
+  // trigger a FULL document load (a window sentinel planted before the click does
+  // not survive), which by design discards the un-persisted in-memory choice.
+  // React Router v7 is a data router: history.pushState + synthetic popstate does
+  // not drive a transition, and page.goBack() also reloads here. There is thus no
+  // anonymous UI path that performs a client-side route-group transition, so the
+  // corr-client-4 precondition cannot be reproduced as an anonymous black-box
+  // walk. The fix is verified structurally in App.tsx (provider hoisted above
+  // <Outlet/>) + CrdLayoutWrapper (provider removed) — see the verifier report.
+  // Kept as an explicit skip so the committed suite records WHY, rather than
+  // silently omitting the scenario.
+  test.skip('corr-client-4 LIVE — in-memory answered survives CLIENT-SIDE cross-route-group navigation', async () => {
+    // Intentionally empty: infeasible on the anonymous surface (see note above).
+  });
+
+  // corr-client-2 robustness: a non-JSON accepted_cookies cookie must NOT crash the
+  // app. Seed the raw cookie BEFORE load.
+  //
+  // NOTE on behavior: react-cookie returns the raw (unparseable) string, so App.tsx
+  // sees `cookies.accepted_cookies` as truthy and does NOT re-show the cookie-consent
+  // banner; useCrdLanguage's `consentResolved` is a plain presence check (=== undefined)
+  // and is therefore true. Nothing JSON-parses the raw value anymore (the anonymous
+  // choice is session-only, so LanguageOfferProvider no longer reads the cookie). The
+  // load-bearing assertion is only that nothing crashes on the unparseable value.
+  test('corr-client-2 — non-JSON consent cookie does not crash the app', async ({ page, context }) => {
+    const url = new URL(BASE_URL);
+    await context.addCookies([
+      {
+        name: 'accepted_cookies',
+        value: 'not-a-json-value{{{',
+        domain: url.hostname,
+        path: '/',
+      },
+    ]);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', err => pageErrors.push(String(err)));
+
+    await page.goto(`${BASE_URL}/home`);
+
+    // The app must render — a crash in an unguarded JSON.parse would blank the SPA.
+    await expect(page.getByRole('contentinfo')).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByRole('contentinfo').getByRole('button', { name: /English|Nederlands/ })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // No uncaught page error from the malformed cookie (the try/catch held).
+    expect(
+      pageErrors,
+      'corr-client-2: malformed accepted_cookies must not raise an uncaught error'
+    ).toEqual([]);
+
+    // Reference the imported helper so lint does not flag it unused; the malformed
+    // cookie is truthy so the consent Accept-All button is NOT expected to show.
+    await expect(cookieConsentAcceptAll(page)).toHaveCount(0);
+
+    await page.screenshot({ path: 'us3b-corr-client-2-bad-cookie-no-crash.png', fullPage: false });
+  });
+});

--- a/client-web/src/functional-e2e/language-offer/us5-invite-suggestion.spec.ts
+++ b/client-web/src/functional-e2e/language-offer/us5-invite-suggestion.spec.ts
@@ -1,0 +1,100 @@
+// Feature 029-detect-signup-language — US5: an inviter suggests Dutch for the
+// person they invite. This spec covers the COMPOSE-TIME half that is drivable on
+// this stack: as an admin, open the space-community invite dialog and exercise
+// the "Suggested language for invitee" control (FR-014/FR-014a/FR-015).
+//
+//   US5-AS1: mark the invitee as expecting Dutch -> invite sent carrying it.
+//   US5-AS6: send without touching the language control -> sends with no suggestion.
+//
+// The INVITEE-facing half (AS2/AS3/AS4: an emailed invitee signs up and lands in
+// Dutch) requires completing the Kratos email-invite -> signup flow, which does
+// not drive reliably headless on this stack (see us1-signup-offer.spec.ts) and is
+// recorded as infeasible-headless. AS7 (batch fan-out gql read-back onto both
+// Invitation and PlatformInvitation) is a server-contract check (gql-live probe 4)
+// and AS8 (invite email untouched) is a code assessment (FR-016a/DL-12).
+//
+// spec source: specs/029-detect-signup-language/repos.yaml -> tracks (US5)
+
+import { test, expect, Page } from '@playwright/test';
+import { BASE_URL } from './helpers';
+import { uiLogin } from './loginHelper';
+
+const ADMIN_EMAIL = 'admin@alkem.io';
+// A space the admin can administer + invite into (seeded).
+const SPACE_NAMEID = 'welcome-space';
+
+// The invite dialog's suggested-language control (InviteMembersDialog.tsx).
+const suggestedLanguageSelect = (page: Page) =>
+  page.getByRole('combobox', { name: /Suggested language for invitee|Verwachte taal/i });
+
+async function openInviteDialog(page: Page): Promise<void> {
+  // Community tab (client-side ?tab=2 on the seeded Welcome Space).
+  await page.goto(`${BASE_URL}/${SPACE_NAMEID}?tab=2`);
+  const inviteButton = page.getByRole('button', { name: /^Invite$/i });
+  await inviteButton.waitFor({ state: 'visible', timeout: 25_000 });
+  await inviteButton.click();
+  await expect(page.getByRole('dialog', { name: /Invite others to join/i })).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('US5 — inviter suggests Dutch (compose-time)', () => {
+  test.use({ locale: 'en-US' });
+
+  // US5-AS1: the suggested-language control is present, eligible-set-driven
+  // (Dutch is the only option), and an invite can be sent carrying the suggestion.
+  test('US5-AS1 — mark invitee as expecting Dutch and send', async ({ page }) => {
+    test.setTimeout(120_000);
+    await uiLogin(page, ADMIN_EMAIL);
+    await openInviteDialog(page);
+
+    // The control exists (FR-014) and offers exactly the eligible set (Dutch).
+    const select = suggestedLanguageSelect(page);
+    await expect(select).toBeVisible();
+    await select.click();
+    const dutchOption = page.getByRole('option', { name: 'Nederlands', exact: true });
+    await expect(dutchOption).toBeVisible({ timeout: 10_000 });
+    await dutchOption.click();
+    await expect(select).toContainText('Nederlands');
+
+    // Add a brand-new email invitee (PlatformInvitation path — R-5).
+    const email = `forge029-inv-${Date.now()}@alkemio.test`;
+    const search = page.getByRole('textbox', { name: /Search for users by name or email/i });
+    await search.fill(email);
+    await search.press('Enter');
+
+    // Send becomes enabled with a valid invitee; sending succeeds.
+    const send = page.getByRole('button', { name: /^Send$/i });
+    await expect(send).toBeEnabled({ timeout: 10_000 });
+    await send.click();
+
+    // A result row / success outcome appears (invitation sent).
+    await expect(page.getByText(/invitation.*sent|sent the invitation|Invitation sent/i).first()).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.screenshot({ path: 'us5-as1-invite-sent-dutch.png', fullPage: false });
+  });
+
+  // US5-AS6: the control is optional — sending without touching it still works
+  // and records no suggestion (FR-015). Default state is "No preference".
+  test('US5-AS6 — send without touching the language control', async ({ page }) => {
+    test.setTimeout(120_000);
+    await uiLogin(page, ADMIN_EMAIL);
+    await openInviteDialog(page);
+
+    // Control defaults to "No preference" — do NOT touch it.
+    await expect(suggestedLanguageSelect(page)).toContainText(/No preference|Geen voorkeur/i);
+
+    const email = `forge029-nolang-${Date.now()}@alkemio.test`;
+    const search = page.getByRole('textbox', { name: /Search for users by name or email/i });
+    await search.fill(email);
+    await search.press('Enter');
+
+    const send = page.getByRole('button', { name: /^Send$/i });
+    await expect(send).toBeEnabled({ timeout: 10_000 });
+    await send.click();
+
+    await expect(page.getByText(/invitation.*sent|sent the invitation|Invitation sent/i).first()).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.screenshot({ path: 'us5-as6-invite-sent-no-lang.png', fullPage: false });
+  });
+});


### PR DESCRIPTION
## What

Playwright **acceptance (functional-e2e) specs** for the *detect signup language & persist it as a user setting* feature — workspace `029-detect-signup-language`, story [alkem-io/alkemio#2017](https://github.com/alkem-io/alkemio/issues/2017).

They were grown during the feature's live verification and are the durable regression layer behind it. Product code already merged: **[alkem-io/server#6299](https://github.com/alkem-io/server/pull/6299)** + **[alkem-io/client-web#10079](https://github.com/alkem-io/client-web/pull/10079)**.

> **Aligned to the 2026-07-28 session-only decision:** the anonymous language choice is **in-memory, session-only, written nowhere in the browser** — the `preference`/functional cookie category was removed. These specs assert that (nothing stored; a reload re-offers). Signed-in users are unaffected (server-side account setting).

## Coverage

| Spec | Story | Covers |
|---|---|---|
| `us1-signup-offer.spec.ts` | US1 | Browser-detection precedence at the anonymous surface: `de-DE` → no offer, `en-US`-first → no offer, `nl-BE` → Dutch offered (regional map). Signup-driven cases are infeasible headless (see below). |
| `us2-cross-device-persistence.spec.ts` | US2 | Account-level (server-side) language persistence via the settings switcher; stored preference wins over a differing browser language, no re-offer. |
| `us3-anonymous-offer.spec.ts` | US3 | The anonymous offer + **the two regression guards** (below). AS2/AS2a/AS3 assert **session-only** — accept/decline renders for the session, writes **zero** language keys, and a reload re-offers. |
| `us3b-review-fixes.spec.ts` | US3 | Review-phase regressions: in-memory-only carry (re-offered after a full reload), and a malformed `accepted_cookies` cookie does not crash the SPA. |
| `us5-invite-suggestion.spec.ts` | US5 | Inviter suggested-language control (incl. the "No preference" clear option). |
| `helpers.ts`, `loginHelper.ts` | — | Shared selectors, the hardened `activeDisplayLanguage` (footer-endonym ground truth), `consentAcceptCookies`, storage inspection. |
| `config/playwright.config.language-offer.ts` | — | Runner config (Chrome, single worker, `globalSetup` disabled). |

## Why this matters — the walks caught two real bugs the unit tests missed

Both were boot-order / cross-hook orchestration defects invisible to the component unit tests, found live and fixed:

1. **Anonymous UI silently switched to Dutch *before* answering** (violated the "offer never silently switches display" invariant). Root cause: `navigator` was in the i18next detector order, setting `i18n.language` at boot. → Guarded by **`us3 US3-SC005`** (pre-answer display must be the platform default).
2. **The offer banner never rendered for *any* anonymous visitor** (killed US3 entirely). Root cause: reconciliation never latched `reconcileComplete` for unauthenticated visitors, so the banner gate never opened. → Guarded by **`us3 US3-AS1`** (banner renders after consent).

## How to run

Against a **running app on `http://localhost:3000`** (same-origin; not the `:3001` vite origin, which fails CORS so config never resolves and no banner appears):

```bash
cd client-web
ALKEMIO_BASE_URL=http://localhost:3000 \
  pnpm exec playwright test --config=config/playwright.config.language-offer.ts
```

Browser language per test is driven via `test.use({ locale: 'nl-NL' | 'nl-BE' | 'de-DE' | 'en-US' })` (sets `navigator.languages`, which the feature reads). Cookie consent is answered first (UX ordering), and the offer is one-time per session.

## Known limitations

- **Signup-driven scenarios are infeasible headless** on this stack (the Kratos + MailSlurper sign-up flow stalls): `US1-AS1/2/3`, `US5-AS2/3/4`, and `US4` are not walked here — they need a fuller harness or manual QA. The `us3b` client-side-navigation case is a documented `test.skip` (the anonymous surface has no SPA-internal cross-route-group link).
- These are e2e specs — they require the live stack above to run green (they typecheck clean standalone).
