### PR TITLE
fix(client-web): raise 'Add Post' timeout in callout access-control 7.1 (flaky on test env)

### DIFF
--- a/client-web/src/functional-e2e/callouts/0.2callout-access-control.spec.ts
+++ b/client-web/src/functional-e2e/callouts/0.2callout-access-control.spec.ts
@@ -76,8 +76,11 @@ adminFixture.test.describe.serial('Callout Access Control', () => {
 
     await collaborationPage.navigateToSpace(baseScenario.space.nameId);
 
+    // The "Add Post" create button appears after the space + collaboration tab
+    // finish rendering; on the slower test env that can take longer than the
+    // old 3s bound (7.1 flaked here, and 7.2 then can't find 7.1's callout).
     await expect(collaborationPage.addCalloutButton).toBeVisible({
-      timeout: 3000,
+      timeout: 15000,
     });
 
     await collaborationPage.createCallout(


### PR DESCRIPTION
## Problem

Nightly [run 30438542346](https://github.com/alkem-io/test-suites/actions/runs/30438542346) (develop `4d26afc3`, test env) failed 2 tests — both in `callouts/0.2callout-access-control.spec.ts` — on **the same commit that passed the day before**. Not a regression; a tight-timeout flake:

- **7.1 Space Admin – Full Access** asserts the **"Add Post"** create button visible within **3000ms** immediately after navigating to the space. On the slower test env the SPA occasionally needs longer to render it, so the assertion fails before 7.1 creates its callout.
- **7.2 Space Member – Limited Access** then times out waiting for `"Open Admin Full Access Test …"` — the callout 7.1 was supposed to create — so it fails as a **consequence** of 7.1.

## Fix

Raise that one bound 3s → 15s (it's a post-navigation page render, so generous headroom is appropriate). Fixing 7.1 fixes 7.2. Verified 2/2 locally.

The rest of the run was healthy (237 passed); the 1 other flaky (`applications … 2.5 Approve from Data Grid`) self-recovered on retry and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access-control test reliability by allowing more time for the Add Callout button to appear in slower environments.
  - Reduced intermittent failures in subsequent test steps caused by delayed rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->